### PR TITLE
Compile File and FileTest

### DIFF
--- a/jp2_pc/Source/Lib/File/FileTest.cpp
+++ b/jp2_pc/Source/Lib/File/FileTest.cpp
@@ -108,8 +108,10 @@ int main()
 	gsym = file_image->get_symbol("Geom_0001");
 	SGeom* pgeom = (SGeom*)file_image->get_data(gsym, true);
 #endif
+#ifdef _DEBUG
 	file_image->dump();
-
+#endif
+	
 	// Delete storage.
 
 	delete [] geom.vertices;

--- a/jp2_pc/Source/Lib/File/FileTest.cpp
+++ b/jp2_pc/Source/Lib/File/FileTest.cpp
@@ -55,7 +55,7 @@ CArea* write_geom(CFileImage* fi, CSection* section, SGeom* geom)
 	return g_area;
 }
 
-main()
+int main()
 {
 	// Let's construct a geom type to write and read.
 

--- a/jp2_pc/Source/Lib/File/Image.cpp
+++ b/jp2_pc/Source/Lib/File/Image.cpp
@@ -117,20 +117,20 @@ CFileImage::~CFileImage()
 	delete section_db;
 }
 
-inline void* CFileImage::get_data(TSymbol* symbol, bool resolve_to_symbols /* = true */)
+void* CFileImage::get_data(TSymbol* symbol, bool resolve_to_symbols /* = true */)
 {
 	assert(!writing);
 	assert(symbol);
 	return section_db->get_data(this, symbol->get_memref(), resolve_to_symbols);
 }
 
-inline CSection* CFileImage::create_section()
+CSection* CFileImage::create_section()
 {
 	assert(writing);
 	return section_db->create_section();
 }
 
-inline TSymbol* CFileImage::create_symbol(const char* name /* = 0 */)
+TSymbol* CFileImage::create_symbol(const char* name /* = 0 */)
 {
 	assert(writing);
 	return symbol_table->create_symbol(name);

--- a/jp2_pc/Source/Lib/File/Spec.hpp
+++ b/jp2_pc/Source/Lib/File/Spec.hpp
@@ -38,9 +38,6 @@
 #ifndef HEADER_LIB_FILE_FILE_SPEC_HPP
 #define HEADER_LIB_FILE_FILE_SPEC_HPP
 
-#pragma warning(disable: 4237)
-#include <bool.h>
-
 typedef unsigned int TSectionHandle;
 typedef unsigned int TSymbolHandle;
 


### PR DESCRIPTION
Trivial changes to make `File` and `FileTest` compile in all configurations.
`FileTest` cannot be executed yet, it requires a specific test file in a specific path.