### PR TITLE
Compile std math

### DIFF
--- a/jp2_pc/Source/Lib/Std/Hash.cpp
+++ b/jp2_pc/Source/Lib/Std/Hash.cpp
@@ -76,8 +76,8 @@
 // Includes.
 //
 
-#include <bstring.h>
-#include "Map.h"
+#include <string>
+#include <map>
 #include "Common.hpp"
 #include "Hash.hpp"
 #include "crc.hpp"
@@ -93,10 +93,10 @@
 //
 
 // Definition of a string to raster map.
-typedef map<string, uint32, less<string> > TMapHash;
+typedef std::map<std::string, uint32, std::less<std::string> > TMapHash;
 
 // Definition of a hash to a string map.
-typedef map<uint32, string, less<uint32> > TMapHashString;
+typedef std::map<uint32, std::string, std::less<uint32> > TMapHashString;
 //
 // Module variables.
 //
@@ -175,7 +175,7 @@ uint32 u4Hash(const void* pv, int i_size_bytes,	bool b_string)
 	#ifdef __MWERKS__
 		pair<TMapHashString::iterator, bool> pib = mapHashString.insert(pair<const uint32, string>(u4_hash,string(str)));
 	#else
-		pair<TMapHashString::iterator, bool> pib = mapHashString.insert(pair<uint32, string>(u4_hash,string(str)));
+		std::pair<TMapHashString::iterator, bool> pib = mapHashString.insert(std::pair<uint32, std::string>(u4_hash, std::string(str)));
 	#endif
 
 		// Did the insertion succeed?

--- a/jp2_pc/Source/Lib/Std/Ptr.cpp
+++ b/jp2_pc/Source/Lib/Std/Ptr.cpp
@@ -78,14 +78,14 @@
 #ifdef __MWERKS__
  #include <set.h>
 #else
- #include "Stl/Set.h"
+ #include <set>
 #endif
 
 //
 // Private variables.
 //
 
-typedef set<CRefObj*, less<CRefObj*> > TSetTracker;
+typedef std::set<CRefObj*, std::less<CRefObj*> > TSetTracker;
 
 //
 // Note: I would like to use ptr<TSetTracker> rather than TSetTracker*.  This does not work
@@ -141,7 +141,7 @@ static uint uRefs = 0;
 		// Insert the new member in the database, and ensure it wasn't there before.
 		Assert(uRefs == 0);
 		Assert(pSetTracker);
-		pair<TSetTracker::iterator, bool> pib = pSetTracker->insert(this);
+		std::pair<TSetTracker::iterator, bool> pib = pSetTracker->insert(this);
 		Assert(pib.second == true);
 #if bVER_SHOW_RPTR
 		dprintf("  rptr add %8X %s\n", this, strTypeName(*this));

--- a/jp2_pc/Source/Lib/Std/StringEx.cpp
+++ b/jp2_pc/Source/Lib/Std/StringEx.cpp
@@ -55,7 +55,7 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <typeinfo.h>
+#include <typeinfo>
 
 //
 // Constants.

--- a/jp2_pc/Source/Lib/Std/UTypes.hpp
+++ b/jp2_pc/Source/Lib/Std/UTypes.hpp
@@ -83,9 +83,6 @@
 #define HEADER_GBLINC_UTYPES_HPP
 
 
-// Get the STL definition of the bool type and the true and false constants.
-#include <bool.h>
-
 // Get limits of built-in types needed to define the user types.
 #include <limits.h>
 

--- a/jp2_pc/Source/Lib/Sys/DebugConsole.hpp
+++ b/jp2_pc/Source/Lib/Sys/DebugConsole.hpp
@@ -56,8 +56,8 @@
 
 // Declare the debug console interface.
 
-#include <iostream.h>
-#include <fstream.h>
+#include <iostream>
+#include <fstream>
 #include "crtdbg.h"
 
 #pragma warning(disable:4237)
@@ -83,7 +83,7 @@ extern void __cdecl dprintf(char* str,...);
 
 //**********************************************************************************************
 //
-class dbgstreambuf : public streambuf
+class dbgstreambuf : public std::streambuf
 {
 public:
 	//******************************************************************************************
@@ -111,7 +111,7 @@ public:
 	char					buf[1028];			// buffer to accumulate the text
 	uint32					u4Off;				// current offset in the above buffer
 	bool					bFile;
-	ofstream				dbgfile;			// ofstream for the debuglog if in joint mode
+	std::ofstream			dbgfile;			// ofstream for the debuglog if in joint mode
 #endif
 };
 
@@ -135,9 +135,9 @@ public:
 //**********************************************************************************************
 // global dout that is identical to cout but for the console debug window
 #if (DEBUG_OUT == DEBUG_OUTPUT_FILE)
-extern ofstream	dout;
+extern std::ofstream dout;
 #else
-extern ostream	dout;
+extern std::ostream	dout;
 #endif
 
 // #if VER_TEST


### PR DESCRIPTION
Trivial code adjustments are made to make the Std subproject compile in all three configurations (Debug, Release, Final). After fixing UTypes.hpp, the Math project is also compilable.

Both projects consist largely of header files which are not compiled directly as part of the static library. I expect that more adjustments in these projects are required in the future.