### PR TITLE
EntityDBase: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/EntityDBase/AnimationScript.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/AnimationScript.cpp
@@ -48,12 +48,12 @@
 #include "Lib/Renderer/Camera.hpp"
 #include "Lib/View/Grab.hpp"
 #include "Game/DesignDaemon/Player.hpp"
-#include <bstring.h>
-#include <set.h>
+#include <string>
+#include <set>
 #include <ctype.h>
-#include <fstream.h>
-#include <iomanip.h>
-#include <algo.h>
+#include <fstream>
+#include <iomanip>
+#include <algorithm>
 
 
 namespace
@@ -124,7 +124,7 @@ namespace
 	}
 
 	//******************************************************************************************
-	void ToLower(string& str)
+	void ToLower(std::string& str)
 	// Convert given string to lowercase.
 	{
 		for (int i = 0; i < str.length(); i++)
@@ -142,7 +142,7 @@ class NoCaseCmp
 //**************************************
 {
 public:
-	bool operator()(const string& s1, const string& s2) const;
+	bool operator()(const std::string& s1, const std::string& s2) const;
 };
 
 //**********************************************************************************************
@@ -155,9 +155,9 @@ class CScriptParser
 //
 //**************************************
 {
-	ifstream streamScript;
+	std::ifstream streamScript;
 
-	set<string, NoCaseCmp> setKeywords;
+	std::set<std::string, NoCaseCmp> setKeywords;
 
 	//******************************************************************************************
 	//
@@ -194,7 +194,7 @@ private:
 
 	//******************************************************************************************
 	//
-	bool bIsKeyword(const string& token) const;
+	bool bIsKeyword(const std::string& token) const;
 	//
 	// Returns:
 	//		'true' if token is a keyword.
@@ -203,7 +203,7 @@ private:
 
 	//******************************************************************************************
 	//
-	bool bReadKeyword(string& token, const char* token_match = 0);
+	bool bReadKeyword(std::string& token, const char* token_match = 0);
 	//
 	// Read next token or find next named token in stream. On return, stream will point after
 	// token. The token is converted to lowercase.
@@ -215,7 +215,7 @@ private:
 
 	//******************************************************************************************
 	//
-	bool bReadIdentifier(string& token);
+	bool bReadIdentifier(std::string& token);
 	//
 	// Read next identifier in stream. On return, stream will point after token.
 	//
@@ -237,7 +237,7 @@ private:
 
 	//******************************************************************************************
 	//
-	void OutputError(const char* str_text, const string* str_token = 0) const;
+	void OutputError(const char* str_text, const std::string* str_token = 0) const;
 	//
 	// Output script parse failure, in VER_TEST mode only.
 	//
@@ -299,13 +299,13 @@ private:
 	CAnimationScript::CAnimationScript(const char* str_name, const char* str_base_dir)
 		: fPlaybackRate(0), bDisableAutoGrab(false), bScriptHasMovedCamera(false)
 	{
-		string str_dir = str_base_dir;
+		std::string str_dir = str_base_dir;
 		str_dir += '/';
 	
 		// First, determine if a binary version of the requested animation script exists.
-		string str_bin_filename = str_dir + str_name + ".asb";
+		std::string str_bin_filename = str_dir + str_name + ".asb";
 
-		ifstream stream_file(str_bin_filename.c_str(), ios::in | ios::nocreate | ios::binary);
+		std::ifstream stream_file(str_bin_filename.c_str(), std::ios::in | std::ios::_Nocreate | std::ios::binary);
 
 		if (stream_file.good())
 		{
@@ -316,7 +316,7 @@ private:
 		else
 		{
 			// Load the ASCII version.
-			string str_asc_filename = str_dir + "anim/"+ str_name + ".asa";
+			std::string str_asc_filename = str_dir + "anim/"+ str_name + ".asa";
 
 			CScriptParser sp(str_asc_filename.c_str());
 			sp.Parse(*this);
@@ -333,8 +333,8 @@ private:
 	CAnimationScript::CAnimationScript(const char* str_filename, bool b_disable_autograb)
 		: fPlaybackRate(0), bDisableAutoGrab(b_disable_autograb), bScriptHasMovedCamera(false)
 	{
-		string str_file = str_filename;
-		string str_ext  = str_file.substr(str_file.find_last_of('.') + 1);
+		std::string str_file = str_filename;
+		std::string str_ext  = str_file.substr(str_file.find_last_of('.') + 1);
 
 		ToLower(str_ext);
 
@@ -545,7 +545,7 @@ private:
 	{
 		Assert(paiaiAnimation.uLen == 0 && paiapPlayback.uLen == 0);
 
-		ifstream stream_file(str_filename, ios::in | ios::nocreate | ios::binary);
+		std::ifstream stream_file(str_filename, std::ios::in | std::ios::_Nocreate | std::ios::binary);
 
 		// Make sure the file was successfully opened for loading.
 		AlwaysAssert(stream_file.good());
@@ -585,7 +585,7 @@ private:
 	//******************************************************************************************
 	void CAnimationScript::CPriv::Save(const char* str_filename)
 	{
-		ofstream stream_file(str_filename, ios::out | ios::trunc | ios::binary);
+		std::ofstream stream_file(str_filename, std::ios::out | std::ios::trunc | std::ios::binary);
 
 		// Make sure the file was successfully opened for saving.
 		AlwaysAssert(stream_file.good());
@@ -639,7 +639,7 @@ private:
 //
 
 	//******************************************************************************************
-	bool NoCaseCmp::operator()(const string& s1, const string& s2) const
+	bool NoCaseCmp::operator()(const std::string& s1, const std::string& s2) const
 	{
 		int i_index;
 		for (i_index = 0; i_index < Min(s1.length(), s2.length()); i_index++)
@@ -671,7 +671,7 @@ private:
 	//******************************************************************************************
 	namespace
 	{
-		string astrKeywords[] =
+		std::string astrKeywords[] =
 		{
 			"version",
 			"forced_rate",
@@ -686,8 +686,8 @@ private:
 
 	//******************************************************************************************
 	CScriptParser::CScriptParser(const char* str_file)
-		: streamScript(str_file, ios::in | ios::nocreate),
-		  setKeywords(astrKeywords, &astrKeywords[sizeof(astrKeywords) / sizeof(string)])
+		: streamScript(str_file, std::ios::in | std::ios::_Nocreate),
+		  setKeywords(astrKeywords, &astrKeywords[sizeof(astrKeywords) / sizeof(std::string)])
 	{
 		// Ensure the file was opened successfully.
 		AlwaysAssert(!streamScript.fail());
@@ -705,9 +705,9 @@ private:
 	//******************************************************************************************
 	void CScriptParser::Parse(CAnimationScript& ras_init)
 	{
-		vector<CAnimationScript_SInstanceAnimInfo> vciai_anim_ins;
+		std::vector<CAnimationScript_SInstanceAnimInfo> vciai_anim_ins;
 
-		string str_token;
+		std::string str_token;
 
 		// Read version info.
 		if (!bReadKeyword(str_token, "version"))
@@ -732,7 +732,7 @@ private:
 			}
 			else if (str_token == "object")
 			{
-				string str_obj_name;
+				std::string str_obj_name;
 				if (!bReadIdentifier(str_obj_name))
 					goto end;
 
@@ -744,7 +744,7 @@ private:
 					u4_hash_name = u4Hash(str_obj_name.c_str());
 
 				// Read all the animation frames.
-				vector<CAnimationScript_SAnimFrame> vcafr_frames;
+				std::vector<CAnimationScript_SAnimFrame> vcafr_frames;
 
 				while (bReadKeyword(str_token, "frame"))
 				{
@@ -808,7 +808,7 @@ private:
 				iai_new.paafrFrames = CPArray<CAnimationScript::SAnimFrame>(vcafr_frames.size());
 
 				int i_index = 0;
-				for (vector<CAnimationScript_SAnimFrame>::iterator it = vcafr_frames.begin(); it != vcafr_frames.end(); ++it, ++i_index)
+				for (std::vector<CAnimationScript_SAnimFrame>::iterator it = vcafr_frames.begin(); it != vcafr_frames.end(); ++it, ++i_index)
 					iai_new.paafrFrames[i_index] = *it;
 
 				// Add animation structure to list.
@@ -820,7 +820,7 @@ private:
 		CPArray<CAnimationScript::SInstanceAnimInfo> paiai_ret(vciai_anim_ins.size());
 
 		int i_index = 0;
-		for (vector<CAnimationScript_SInstanceAnimInfo>::iterator it = vciai_anim_ins.begin(); it != vciai_anim_ins.end(); ++it, ++i_index)
+		for (std::vector<CAnimationScript_SInstanceAnimInfo>::iterator it = vciai_anim_ins.begin(); it != vciai_anim_ins.end(); ++it, ++i_index)
 			paiai_ret[i_index] = *it;
 
 		ras_init.paiaiAnimation = paiai_ret;
@@ -844,13 +844,13 @@ private:
 	}
 
 	//******************************************************************************************
-	bool CScriptParser::bIsKeyword(const string& token) const
+	bool CScriptParser::bIsKeyword(const std::string& token) const
 	{
 		return setKeywords.find(token) != setKeywords.end();
 	}
 
 	//******************************************************************************************
-	bool CScriptParser::bReadKeyword(string& token, const char* token_match)
+	bool CScriptParser::bReadKeyword(std::string& token, const char* token_match)
 	{
 		if (streamScript.eof() || streamScript.fail())
 		{
@@ -871,7 +871,7 @@ private:
 	}
 
 	//******************************************************************************************
-	bool CScriptParser::bReadIdentifier(string& token)
+	bool CScriptParser::bReadIdentifier(std::string& token)
 	{
 		if (streamScript.eof() || streamScript.fail())
 		{
@@ -903,7 +903,7 @@ private:
 
 		if (!streamScript.good())
 		{
-			string token;
+			std::string token;
 			streamScript.clear();
 			streamScript >> token;
 
@@ -915,7 +915,7 @@ private:
 	}
 
 	//******************************************************************************************
-	void CScriptParser::OutputError(const char* str_text, const string* str_token) const
+	void CScriptParser::OutputError(const char* str_text, const std::string* str_token) const
 	{
 	#if VER_TEST
 		dout << "Animation script error: '" << str_text << "' ";
@@ -947,7 +947,7 @@ private:
 	{
 		CMessageStep::UnregisterRecipient(this);
 
-		for (list<CAnimationScript*>::iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
+		for (std::list<CAnimationScript*>::iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
 			delete *it;
 	}
 
@@ -973,7 +973,7 @@ private:
 	//******************************************************************************************
 	CAnimationScript* CAnimations::pansFind(const CAnimationScript* pans) const
 	{
-		for (list<CAnimationScript*>::const_iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
+		for (std::list<CAnimationScript*>::const_iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
 			if (pans == (*it))
 				return *it;
 
@@ -983,7 +983,7 @@ private:
 	//******************************************************************************************
 	void CAnimations::Process(const CMessageStep& msgstep)
 	{
-		for (list<CAnimationScript*>::iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
+		for (std::list<CAnimationScript*>::iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
 			if ((*it)->bIsPlaying())
 				(*it)->FrameAdvance(msgstep.sStep);
 	}
@@ -991,7 +991,7 @@ private:
 	//*****************************************************************************************
 	char * CAnimations::pcSave(char *  pc_buffer) const
 	{
-		for (list<CAnimationScript*>::const_iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
+		for (std::list<CAnimationScript*>::const_iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
 			pc_buffer = (*it)->pcSave(pc_buffer);
 
 		return pc_buffer;
@@ -1000,7 +1000,7 @@ private:
 	//*****************************************************************************************
 	const char * CAnimations::pcLoad(const char *  pc_buffer)
 	{
-		for (list<CAnimationScript*>::iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
+		for (std::list<CAnimationScript*>::iterator it = ltansAnims.begin(); it != ltansAnims.end(); ++it)
 			pc_buffer = (*it)->pcLoad(pc_buffer);
 
 		return pc_buffer;

--- a/jp2_pc/Source/Lib/EntityDBase/AnimationScript.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/AnimationScript.hpp
@@ -38,7 +38,7 @@
 #include "Lib/Sys/Timer.hpp"
 #include "Lib/Transform/Presence.hpp"
 #include "Lib/EntityDBase/Subsystem.hpp"
-#include <list.h>
+#include <list>
 
 class CInstance;
 class CScriptParser;
@@ -193,7 +193,7 @@ class CAnimations : public CSubsystem
 //
 //**************************************
 {
-	list<CAnimationScript*> ltansAnims;
+	std::list<CAnimationScript*> ltansAnims;
 
 	//******************************************************************************************
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/CameraPrime.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/CameraPrime.cpp
@@ -35,7 +35,7 @@
 
 #include "GblInc/Common.hpp"
 #include "CameraPrime.hpp"
-#include "set.h"
+#include <set>
 
 #include "Lib/GeomDBase/PartitionPriv.hpp"
 #include "Lib/W95/Direct3D.hpp"
@@ -153,7 +153,7 @@ namespace
 		// Iterate directly through the clut database and set the bump tables of any entries that
 		// have not already been set
 		//
-		for (set<CPalClut, CPalClutLess>::iterator it_palclut_db = pcdbMain.psetPalClut->begin(); it_palclut_db != pcdbMain.psetPalClut->end(); ++it_palclut_db)
+		for (std::set<CPalClut, CPalClutLess>::iterator it_palclut_db = pcdbMain.psetPalClut->begin(); it_palclut_db != pcdbMain.psetPalClut->end(); ++it_palclut_db)
 		{
 			// Does this clut entry have a bump table?
 			if ( (*it_palclut_db).pBumpTable )

--- a/jp2_pc/Source/Lib/EntityDBase/Container.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Container.hpp
@@ -133,7 +133,7 @@ public:
 #if _MSC_VER < 1100
 	iterator itContainer;		// Iterator for the container.
 #else
-	T::iterator itContainer;	// Iterator for the container.
+	typename T::iterator itContainer;	// Iterator for the container.
 #endif
 
 public:
@@ -214,7 +214,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	const T::value_type& tGet()
+	const typename T::value_type& tGet()
 	//
 	// Obtain a value from this container.
 	//
@@ -232,7 +232,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	T::value_type& rtGet()
+	typename T::value_type& rtGet()
 	//
 	// Obtain a value from this container.
 	//
@@ -266,7 +266,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	T::value_type& operator *()
+	typename T::value_type& operator *()
 	//
 	// Duplicate rtGet().
 	//
@@ -281,7 +281,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	T::value_type* operator ->()
+	typename T::value_type* operator ->()
 	//
 	// Return address of rtGet().
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/GameLoop.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/GameLoop.hpp
@@ -35,7 +35,7 @@
 #ifndef HEADER_ENTITYDBASE_GAMELOOP_HPP
 #define HEADER_ENTITYDBASE_GAMELOOP_HPP
 
-#include <list.h>
+#include <list>
 
 #include "Container.hpp"
 #include "Instance.hpp"
@@ -73,7 +73,7 @@ public:
 	EGameMode							egmGameMode;	// Game mode.
 	bool								bPauseGame;		// Pause flag.
 	bool								bPreload;		// Performs preloading.
-	CContainer<list <CInstance*> >		lpinsTrash;		// Trash list- instances that are to
+	CContainer<std::list <CInstance*> >		lpinsTrash;		// Trash list- instances that are to
 														// be discarded at end of frame.
 
 public:

--- a/jp2_pc/Source/Lib/EntityDBase/Instance.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Instance.cpp
@@ -253,7 +253,7 @@ namespace
 	}
 
 
-	typedef set<CInfo, less<CInfo> > TSI;
+	typedef std::set<CInfo, std::less<CInfo> > TSI;
 	// This guy is here instead of in the class header to cut down on compile times.
 	TSI tsiInfo;	// A set containing all shared infos, for instancing.
 	
@@ -303,7 +303,7 @@ namespace
 		}
 
 		// Insert or find, please.
-		pair<TSI::iterator, bool> p = tsiInfo.insert(*pinfo);
+		std::pair<TSI::iterator, bool> p = tsiInfo.insert(*pinfo);
 
 		// If we found a duplicate, it will do.
 		// If we inserted a new one, the new one will do.
@@ -1464,12 +1464,12 @@ namespace
 
 					AlwaysAssert(pestr);
 
-					string str_terrain_name = pestr_terrain_file->strData();
+					std::string str_terrain_name = pestr_terrain_file->strData();
 
 					// Attempt to open a matching file with a .wtd extension.
-					string str_transformed_filename = str_terrain_name + ".wtd";
+					std::string str_transformed_filename = str_terrain_name + ".wtd";
 
-					ifstream stream_transformed(str_transformed_filename.c_str(), ios::in | ios::nocreate | ios::binary);
+					std::ifstream stream_transformed(str_transformed_filename.c_str(), std::ios::in | std::ios::_Nocreate | std::ios::binary);
 
 					if (stream_transformed.fail())
 					{
@@ -2004,11 +2004,11 @@ namespace
 				pphiGetPhysicsInfo()->bFloats());
 
 			// Get attachment list.
-			list<CMagnetPair*> lspmp;
+			std::list<CMagnetPair*> lspmp;
 			NMagnetSystem::GetAttachedMagnets(this, &lspmp);
 
 			// List any magnets.
-			for (list<CMagnetPair*>::iterator itpmp = lspmp.begin(); itpmp != lspmp.end(); ++itpmp)
+			for (std::list<CMagnetPair*>::iterator itpmp = lspmp.begin(); itpmp != lspmp.end(); ++itpmp)
 			{
 				CMagnetPair& pmp = *(*itpmp);
 

--- a/jp2_pc/Source/Lib/EntityDBase/Instance.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Instance.hpp
@@ -145,8 +145,8 @@
 #ifndef HEADER_ENTITYDBASE_INTSTANCE_HPP
 #define HEADER_ENTITYDBASE_INTSTANCE_HPP
 
-#include <bstring.h>
-#include <map.h>
+#include <string>
+#include <map>
 #include "Lib/GeomDBase/Partition.hpp"
 #include "Lib/Loader/Fetchable.hpp"
 #include "Lib/Sys/FastHeap.hpp"
@@ -454,7 +454,7 @@ class	CValueTable;
 
 //*********************************************************************************************
 //
-typedef map<uint32, char*, less<uint32> >	TInstanceNameMap;
+typedef std::map<uint32, char*, std::less<uint32> >	TInstanceNameMap;
 
 #define u4INSTANCE_NAMES_VIRTUALSIZE	(8*1024*1024)		// 8Mb for the instance names
 
@@ -502,7 +502,7 @@ public:
 		rptr<CRenderType>	prdtRenderInfo;		// Rendering information.
 		CPhysicsInfo*		pphiPhysicsInfo;	// Physics information.
 		CAIInfo*			paiiAIInfo;			// AI information.
-		string				strName;			// Name of the instance.
+		std::string			strName;			// Name of the instance.
 
 		//*************************************************************************************
 		//
@@ -515,7 +515,7 @@ public:
 			rptr<CRenderType>	prdt = rptr0,		// Rendering information.
 			CPhysicsInfo*       pphi = 0,			// Physics information.
 			CAIInfo*            paii = 0,			// AI information.
-			string				str_name = "InitCon"	
+			std::string			str_name = "InitCon"
 		)
 			: prdtRenderInfo(prdt), pphiPhysicsInfo(pphi), paiiAIInfo(paii), strName(str_name)
 		{
@@ -528,7 +528,7 @@ public:
 			rptr<CRenderType>	prdt = rptr0,		// Rendering information.
 			CPhysicsInfo*		pphi = 0,			// Physics information.
 			CAIInfo*			paii = 0,			// AI information.
-			string				str_name = "InitCon"	
+			std::string			str_name = "InitCon"
 		)
 			: pr3Presence(pr3), prdtRenderInfo(prdt), pphiPhysicsInfo(pphi), paiiAIInfo(paii), strName(str_name)
 		{

--- a/jp2_pc/Source/Lib/EntityDBase/Instancer.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Instancer.hpp
@@ -26,7 +26,7 @@
 //
 // Includes.
 //
-#include "set.h"
+#include <set>
 #include "Container.hpp"
 
 
@@ -105,7 +105,7 @@ public:
 
 //*********************************************************************************************
 //
-class CInstanceCont : public CContainer < set<CInstancer, CInstancer> >
+class CInstanceCont : public CContainer < std::set<CInstancer, CInstancer> >
 //
 // Container class for CInstance.
 //
@@ -136,7 +136,7 @@ public:
 	//
 	//**************************
 	{
-		pair<iterator, bool> pair_inst = insert(inst);
+		std::pair<iterator, bool> pair_inst = insert(inst);
 		itContainer = pair_inst.first;
 
 		Assert(bIsNotEnd());

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/RegisteredMsg.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/RegisteredMsg.hpp
@@ -27,14 +27,14 @@
 #ifndef HEADER_LIB_ENTITYDBASE_MESSAGETYPES_REGISTEREDMSG_HPP
 #define HEADER_LIB_ENTITYDBASE_MESSAGETYPES_REGISTEREDMSG_HPP
 
-#include <list.h>
+#include <list>
 
 class CEntity;
 
 
 
 // Prefix: rc
-typedef list<CEntity*> TRecipientsContainer;
+typedef std::list<CEntity*> TRecipientsContainer;
 
 struct SRecipientsInfo
 // Prefix: ri

--- a/jp2_pc/Source/Lib/EntityDBase/ParticleGen.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/ParticleGen.cpp
@@ -37,8 +37,8 @@
 #include "Lib/Std/Random.hpp"
 #include "Lib/Audio/SoundDefs.hpp"
 
-#include <list.h>
-#include <map.h>
+#include <list>
+#include <map>
 
 //*********************************************************************************************
 //
@@ -171,9 +171,9 @@ namespace NParticleMap
 // 
 //**************************************
 {
-	list<CCreateParticles> lspcrtEffects;	// The list of effects.
+	std::list<CCreateParticles> lspcrtEffects;	// The list of effects.
 
-	typedef map< TSoundMaterial, CCreateParticles*, less<TSoundMaterial> > TParticleMap;
+	typedef std::map< TSoundMaterial, CCreateParticles*, std::less<TSoundMaterial> > TParticleMap;
 	// Prefix: prtm
 
 	TParticleMap	prtmEffectMap;			// The mapping to materials.
@@ -182,7 +182,7 @@ namespace NParticleMap
 	CCreateParticles* pcrtAddParticle(const CCreateParticles& crt)
 	{
 		// Just duplicate and add to list. Do not check for duplicates.
-		list<CCreateParticles>::iterator it = lspcrtEffects.insert(lspcrtEffects.end(), crt);
+		std::list<CCreateParticles>::iterator it = lspcrtEffects.insert(lspcrtEffects.end(), crt);
 		return &*it;
 	}
 

--- a/jp2_pc/Source/Lib/EntityDBase/Query.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query.cpp
@@ -330,12 +330,12 @@ template<class T> class CBuildList
 //
 //**************************************
 {
-	list<T*>& rlistBuild;
+	std::list<T*>& rlistBuild;
 
 public:
 
 	//******************************************************************************************
-	CBuildList(list<T*>& rlist)
+	CBuildList(std::list<T*>& rlist)
 		: rlistBuild(rlist)
 	{
 	}
@@ -655,7 +655,7 @@ public:
 	};
 */
 
-	list<CInstance*> CWDbQueryLights::lpinsActiveLights;	// The active light list, maintained by the world dbase.
+	std::list<CInstance*> CWDbQueryLights::lpinsActiveLights;	// The active light list, maintained by the world dbase.
 
 	//******************************************************************************************
 	CWDbQueryLights::CWDbQueryLights(const CPartition* ppart, const CWorld& w)
@@ -683,7 +683,7 @@ public:
 	public:
 
 		//******************************************************************************************
-		CBuildPhysics(list<CInstance*>& rlist)
+		CBuildPhysics(std::list<CInstance*>& rlist)
 			: CBuildList<CInstance>(rlist)
 		{
 		}
@@ -780,7 +780,7 @@ public:
 	public:
 
 		//******************************************************************************************
-		CBuildPhysicsMovable(list<CInstance*>& rlist)
+		CBuildPhysicsMovable(std::list<CInstance*>& rlist)
 			: CBuildPhysics(rlist)
 		{
 		}
@@ -829,7 +829,7 @@ public:
 	public:
 
 		//******************************************************************************************
-		CBuildPhysicsBoxFast(list<CInstance*>& rlist)
+		CBuildPhysicsBoxFast(std::list<CInstance*>& rlist)
 			: CBuildPhysics(rlist)
 		{
 		}
@@ -903,7 +903,7 @@ public:
 //
 
 	// The water object list, maintained by the world dbase.
-	list<CEntityWater*> CWDbQueryWater::lspetWater;
+	std::list<CEntityWater*> CWDbQueryWater::lspetWater;
 
 	//******************************************************************************************
 	CWDbQueryWater::CWDbQueryWater(const CBoundVol& bv, const CPresence3<>& pr3_boundvol, const CWorld& w)
@@ -927,14 +927,14 @@ public:
 //
 
 	//*****************************************************************************************
-	CWDbQueryWaterHeight::CWDbQueryWaterHeight(const CVector2<>& v2_world, const list<CEntityWater*>& lspetw)
+	CWDbQueryWaterHeight::CWDbQueryWaterHeight(const CVector2<>& v2_world, const std::list<CEntityWater*>& lspetw)
 	{
 		// Copy the querying vector.
 		v3Water = v2_world;
 		v3Water.tZ = rWATER_NONE;
 		petWater = 0;
 
-		forall_const (lspetw, list<CEntityWater*>, itpew)
+		forall_const (lspetw, std::list<CEntityWater*>, itpew)
 		{
 			// Ask the water its height.
 			v3Water.tZ = (*itpew)->rWaterHeight(v2_world);
@@ -978,7 +978,7 @@ public:
 	public:
 
 		//******************************************************************************************
-		CBuildAI(list<CInstance*>& rlist)
+		CBuildAI(std::list<CInstance*>& rlist)
 			: CBuildList<CInstance>(rlist)
 		{
 		}
@@ -1047,7 +1047,7 @@ public:
 //
 
 	bool CWDbQueryActiveEntities::bAlreadyExists = false;			// There can be only one of these instantiated at any one time.
-	list<CEntity*>	CWDbQueryActiveEntities::lpetActiveEntities;	// A list of active entities, maintained by the world database.
+	std::list<CEntity*>	CWDbQueryActiveEntities::lpetActiveEntities;	// A list of active entities, maintained by the world database.
 
 
 

--- a/jp2_pc/Source/Lib/EntityDBase/Query.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query.hpp
@@ -86,7 +86,7 @@
 #define HEADER_LIB_ENTITYDBASE_QUERY_HPP
 
 
-#include <list.h>
+#include <list>
 #include "Lib/EntityDBase/Container.hpp"
 #include "Lib/EntityDBase/WorldDBase.hpp"
 

--- a/jp2_pc/Source/Lib/EntityDBase/Query/QAI.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query/QAI.hpp
@@ -36,7 +36,7 @@
 
 //*********************************************************************************************
 //
-class CWDbQueryAnimal : public CWDbQuery< list<CAnimal*> >
+class CWDbQueryAnimal : public CWDbQuery< std::list<CAnimal*> >
 //
 // World database query container.
 //
@@ -61,7 +61,7 @@ public:
 
 //*********************************************************************************************
 //
-class CWDbQueryAI : public CWDbQuery< list<CInstance*> >
+class CWDbQueryAI : public CWDbQuery< std::list<CInstance*> >
 //
 // World database query container.
 //

--- a/jp2_pc/Source/Lib/EntityDBase/Query/QMessage.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query/QMessage.hpp
@@ -35,7 +35,7 @@ class CDaemon;
 
 //*********************************************************************************************
 //
-class CWDbQueryActiveEntities : public CWDbQuery< list<CEntity*> >
+class CWDbQueryActiveEntities : public CWDbQuery<std::list<CEntity*> >
 //
 // World database query container.
 //

--- a/jp2_pc/Source/Lib/EntityDBase/Query/QPhysics.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query/QPhysics.hpp
@@ -46,7 +46,7 @@
 
 //*********************************************************************************************
 //
-class CWDbQueryPhysics : public CWDbQuery< list<CInstance*> >
+class CWDbQueryPhysics : public CWDbQuery< std::list<CInstance*> >
 //
 // Prefix: wqph
 //
@@ -73,7 +73,7 @@ public:
 
 //*********************************************************************************************
 //
-class CWDbQueryPhysicsMovable : public CWDbQuery< list<CInstance*> >
+class CWDbQueryPhysicsMovable : public CWDbQuery< std::list<CInstance*> >
 //
 // Prefix: wqphm
 //
@@ -94,7 +94,7 @@ public:
 
 //*********************************************************************************************
 //
-class CWDbQueryPhysicsBoxFast : public CWDbQuery< list<CInstance*> >
+class CWDbQueryPhysicsBoxFast : public CWDbQuery< std::list<CInstance*> >
 //
 // Prefix: wqph
 //

--- a/jp2_pc/Source/Lib/EntityDBase/Query/QRenderer.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query/QRenderer.hpp
@@ -277,7 +277,7 @@ public:
 
 //*********************************************************************************************
 //
-class CWDbQueryLights : public CWDbQuery< list<CInstance*> >
+class CWDbQueryLights : public CWDbQuery< std::list<CInstance*> >
 //
 // World database query container.
 //

--- a/jp2_pc/Source/Lib/EntityDBase/Query/QSubsystem.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query/QSubsystem.hpp
@@ -32,7 +32,7 @@
 
 //*********************************************************************************************
 //
-class CWDbQuerySubsystem : public CWDbQuery< list<CSubsystem*> >
+class CWDbQuerySubsystem : public CWDbQuery< std::list<CSubsystem*> >
 //
 // World database query container.
 //

--- a/jp2_pc/Source/Lib/EntityDBase/Query/QTriggers.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query/QTriggers.hpp
@@ -31,7 +31,7 @@ class CLocationTrigger;
 
 //*********************************************************************************************
 //
-class CWDbQueryLocationTrigger : public CWDbQuery< list<CLocationTrigger*> >
+class CWDbQueryLocationTrigger : public CWDbQuery< std::list<CLocationTrigger*> >
 //
 // Prefix: wqlt
 //

--- a/jp2_pc/Source/Lib/EntityDBase/Query/QWater.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Query/QWater.hpp
@@ -31,7 +31,7 @@
 
 //*********************************************************************************************
 //
-class CWDbQueryWater: public CWDbQuery< list<CEntityWater*> >
+class CWDbQueryWater: public CWDbQuery< std::list<CEntityWater*> >
 //
 // Water object query.
 //
@@ -40,7 +40,7 @@ class CWDbQueryWater: public CWDbQuery< list<CEntityWater*> >
 //**************************************
 {
 public:
-	static list<CEntityWater*> lspetWater;	// List of all water objects in world.
+	static std::list<CEntityWater*> lspetWater;	// List of all water objects in world.
 
 public:
 
@@ -80,7 +80,7 @@ public:
 	CWDbQueryWaterHeight
 	(
 		const CVector2<>& v2_world,		// World point to test water height at.
-		const list<CEntityWater*>& lspetw = CWDbQueryWater::lspetWater		
+		const std::list<CEntityWater*>& lspetw = CWDbQueryWater::lspetWater
 										// Water list to use; default is world list.
 	);
 };

--- a/jp2_pc/Source/Lib/EntityDBase/QueueMessage.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/QueueMessage.cpp
@@ -74,8 +74,8 @@
 		pdqwmCurrentMessages = new queue< const CMessage*>();
 		pdqwmNextMessages    = new queue< const CMessage*>();
 	#else
-		pdqwmCurrentMessages = new queue< deque<const CMessage*> >();   //lint !e1732 !e1733
-		pdqwmNextMessages    = new queue< deque<const CMessage*> >();	//lint !e1732 !e1733
+		pdqwmCurrentMessages = new std::queue< std::deque<const CMessage*> >();   //lint !e1732 !e1733
+		pdqwmNextMessages    = new std::queue< std::deque<const CMessage*> >();	//lint !e1732 !e1733
 	#endif
 
 		Assert(pdqwmCurrentMessages);
@@ -103,8 +103,8 @@
 		pdqwmCurrentMessages = new queue< const CMessage*>();
 		pdqwmNextMessages    = new queue< const CMessage*>();
 	#else
-		pdqwmCurrentMessages = new queue< deque<const CMessage*> >();   //lint !e1732 !e1733
-		pdqwmNextMessages    = new queue< deque<const CMessage*> >();	//lint !e1732 !e1733
+		pdqwmCurrentMessages = new std::queue< std::deque<const CMessage*> >();   //lint !e1732 !e1733
+		pdqwmNextMessages    = new std::queue< std::deque<const CMessage*> >();	//lint !e1732 !e1733
 	#endif
 
 		frhFrameHeap.Reset();

--- a/jp2_pc/Source/Lib/EntityDBase/QueueMessage.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/QueueMessage.hpp
@@ -74,8 +74,8 @@
 #ifdef __MWERKS__
 #include <queue.h>
 #endif
-#include <deque.h>
-#include <stack.h>
+#include <deque>
+#include <queue>
 
 #include "FrameHeap.hpp"
 #include "Lib/Sys/Timer.hpp"
@@ -104,8 +104,8 @@ public:
 	queue< const CMessage* >* pdqwmCurrentMessages;			// Current frame's event message queue.
 	queue< const CMessage* >* pdqwmNextMessages;			// Next frame's event message queue.
 #else
-	queue< deque<const CMessage*> >* pdqwmCurrentMessages;	// Current frame's event message queue.
-	queue< deque<const CMessage*> >* pdqwmNextMessages;		// Next frame's event message queue.
+    std::queue< std::deque<const CMessage*> >* pdqwmCurrentMessages;	// Current frame's event message queue.
+    std::queue< std::deque<const CMessage*> >* pdqwmNextMessages;		// Next frame's event message queue.
 #endif
 
 public:

--- a/jp2_pc/Source/Lib/EntityDBase/RenderDB.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/RenderDB.cpp
@@ -203,7 +203,7 @@ static rptr<CLightAmbient>	pamb;
 			msgpaint.renContext.RenderScene
 			(
 				cam_backdrop,					// Special backdrop camera.
-				list<CInstance*>(1, &insFullAmbient),	// Special backdrop light list.
+				std::list<CInstance*>(1, &insFullAmbient),	// Special backdrop light list.
 				wDBase.ppartBackdropsList(),	// Special backdrop partition.
 				papoc,							// Use no occlusion objects.
 				esfINTERSECT,					// Assume intersection.
@@ -670,7 +670,7 @@ static rptr<CLightAmbient>	pamb;
 			if (iVersion >= 3)
 			{
 				// Load animating mesh data.
-				list<CMeshAnimating*>::iterator i = lpmaAnimatedMeshes.begin();
+				std::list<CMeshAnimating*>::iterator i = lpmaAnimatedMeshes.begin();
 				for ( ; i != lpmaAnimatedMeshes.end(); ++i)
 				{
 					pc = (*i)->pcLoad(pc);

--- a/jp2_pc/Source/Lib/EntityDBase/RenderDB.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/RenderDB.hpp
@@ -35,10 +35,11 @@
 
 #include "Lib/EntityDBase/Subsystem.hpp"
 #include "Lib/EntityDBase/WorldDBase.hpp"
-#include <list.h>
+#include <list>
+
 class CMeshAnimating;
 
-typedef list<CMeshAnimating*> LPMA;
+typedef std::list<CMeshAnimating*> LPMA;
 
 //**********************************************************************************************
 //

--- a/jp2_pc/Source/Lib/EntityDBase/Teleport.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Teleport.cpp
@@ -61,12 +61,12 @@
 #include "Lib/EntityDBase/WorldDBase.hpp"
 #include "Lib/Loader/SaveFile.hpp"
 
-#include <algo.h>
+#include <algorithm>
 
 
 //*****************************************************************************************
-list<CTeleport*> CTeleport::listTeleports;
-list<CTeleport*>::iterator CTeleport::itCurrent = CTeleport::listTeleports.end();
+std::list<CTeleport*> CTeleport::listTeleports;
+std::list<CTeleport*>::iterator CTeleport::itCurrent = CTeleport::listTeleports.end();
 
 
 //*****************************************************************************************
@@ -110,7 +110,7 @@ CTeleport::CTeleport
 CTeleport::~CTeleport()
 {
 	// Find ourselves in the teleport list.
-	list<CTeleport*>::iterator it_me = find(listTeleports.begin(), 
+	std::list<CTeleport*>::iterator it_me = find(listTeleports.begin(),
 											listTeleports.end(), this);
 
 	Assert(it_me != listTeleports.end());
@@ -129,7 +129,7 @@ char* CTeleport::pcSave(char* pc_buffer) const
 	// Save sequence number.
 	int i_seq_num = 0;
 
-	for (list<CTeleport*>::iterator it = listTeleports.begin(); it != listTeleports.end(); it++)
+	for (std::list<CTeleport*>::iterator it = listTeleports.begin(); it != listTeleports.end(); it++)
 	{
 		if (it == itCurrent)
 			break;

--- a/jp2_pc/Source/Lib/EntityDBase/Teleport.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Teleport.hpp
@@ -17,8 +17,8 @@
 class CTeleport : public CEntity
 {
 private:
-	static list<CTeleport*> listTeleports;
-	static list<CTeleport*>::iterator itCurrent;
+	static std::list<CTeleport*> listTeleports;
+	static std::list<CTeleport*>::iterator itCurrent;
 
 	CPresence3<> pr3_location;
 

--- a/jp2_pc/Source/Lib/EntityDBase/TextOverlay.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/TextOverlay.hpp
@@ -35,7 +35,7 @@
 #ifndef HEADER_ENTITYDBASE_OVERLAYTEXT_HPP
 #define HEADER_ENTITYDBASE_OVERLAYTEXT_HPP
 
-#include <list.h>
+#include <list>
 #include "Lib/EntityDBase/MessageTypes/MsgStep.hpp"
 #include "Lib/EntityDBase/Entity.hpp"
 #include "Lib/EntityDBase/Subsystem.hpp"
@@ -80,7 +80,7 @@ struct STextElement
 
 //**********************************************************************************************
 // prefix: ttl
-typedef list<STextElement>		TTextList;
+typedef std::list<STextElement>		TTextList;
 
 
 //*********************************************************************************************

--- a/jp2_pc/Source/Lib/EntityDBase/Water.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Water.cpp
@@ -77,7 +77,7 @@
  * 
  **********************************************************************************************/
 
-#include "list.h"
+#include <list>
 #include "Common.hpp"
 #include "Lib/W95/Direct3D.hpp"
 #include "Lib/View/RasterD3D.hpp"
@@ -130,7 +130,7 @@ extern CProfileStat		psWaterStep;
 //
 // Keep a list of currently active water.
 //
-typedef list<CEntityWater*> TWaterList;
+typedef std::list<CEntityWater*> TWaterList;
 TWaterList wlWaters;
 
 
@@ -195,7 +195,7 @@ namespace
 
 	//*********************************************************************************************
 	//
-	class CReflectTable: public CFloatTableRound<int, 512, -1.0, +1.0>
+	class CReflectTable: public CFloatTableRound<int, 512, -1, +1>
 	//
 	// Prefix: rfltab
 	//
@@ -241,7 +241,7 @@ namespace
 
 	//*********************************************************************************************
 	//
-	class CPixelReflectTable: public CFloatTableRound<uint16, 512, -1.0, +1.0>
+	class CPixelReflectTable: public CFloatTableRound<uint16, 512, -1, +1>
 	//
 	// Prefix: rfltaba
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
@@ -132,7 +132,7 @@ template<class X> class CMicrosoftsCompilerIsBuggyAndWeHateIt
 
 #include "Lib\Control\Control.hpp"
 
-#include <fstream.h>
+#include <fstream>
 
 
 #include "Lib\Sys\W95\Render.hpp"
@@ -153,7 +153,7 @@ template<class X> class CMicrosoftsCompilerIsBuggyAndWeHateIt
 #include "Lib/W95/Direct3D.hpp"
 #include "Lib/Renderer/RenderCache.hpp"
 
-#include <multimap.h>
+#include <map>
 
 #include "Shell\WinRenderTools.hpp"
 
@@ -170,7 +170,7 @@ extern bool bIsTrespasser;
 extern CConsoleBuffer conPreLoader;
 
 // Extern to allow proper clearing of world dbase.
-typedef multimap<CInstance*, CMagnetPair*, less<CInstance*> >   TMagnetTable;
+typedef std::multimap<CInstance*, CMagnetPair*, std::less<CInstance*> >   TMagnetTable;
 namespace NMagnetSystem
 {
 //	extern TMagnetTable	mtSlaveLookup;		// A table to find magnets pairs from the slave side.
@@ -183,7 +183,7 @@ namespace NMagnetSystem
 	// to be const, as specified by the STL standard.
 	typedef pair<const uint32, CPartition*> THandlePair;
 #else
-	typedef pair<uint32, CPartition*> THandlePair;
+	typedef std::pair<uint32, CPartition*> THandlePair;
 #endif
 
 
@@ -835,7 +835,7 @@ CRenderDB*  ps_renderDB = 0;
 		}
 
 		{
-			list<CInstance*>::iterator it_psub;
+			std::list<CInstance*>::iterator it_psub;
 
 			// Iterate through the subsystem object list.
 			con_out.Print("\n\nSubsystems...\n\n");\
@@ -1085,7 +1085,7 @@ CRenderDB*  ps_renderDB = 0;
 					bool b_already_have_it = false;
 
 					// Need this GROFF file.  Do we already have it?
-					list<const char*>::iterator i;
+					std::list<const char*>::iterator i;
 					for (i = plsstrGroffsLoaded->begin(); i != plsstrGroffsLoaded->end(); ++i)
 					{
 						// Is this the GROFF we are looking for?
@@ -1698,7 +1698,7 @@ CRenderDB*  ps_renderDB = 0;
 		Assert(ppartPartitions);
 		Assert(ppartPartitions->ppartChildren());
 
-		list<CPartition*> list_part;	// List of spatial partitions.
+		std::list<CPartition*> list_part;	// List of spatial partitions.
 		int i_count = 0;
 
 		// Construct a list of spatial partitions.
@@ -1734,7 +1734,7 @@ CRenderDB*  ps_renderDB = 0;
 		if (i_count == 2)
 		{
 			CPartitionVol<2> partvol;				// Partition set.
-			list<CPartition*>::iterator it_partlist;	// Partition list iterator.
+			std::list<CPartition*>::iterator it_partlist;	// Partition list iterator.
 
 			// Add partitions.
 			it_partlist = list_part.begin();
@@ -1883,7 +1883,7 @@ CRenderDB*  ps_renderDB = 0;
 #define ERASE(foo) foo.erase(foo.begin(), foo.end())
 
 		// tsaiAIInfo
- 		typedef set<CAIInfo, less<CAIInfo> > TSAI;
+ 		typedef std::set<CAIInfo, std::less<CAIInfo> > TSAI;
 		extern TSAI tsaiAIInfo;	// A set containing all shared AI infos, for instancing.
 		ERASE(tsaiAIInfo);
 
@@ -1896,23 +1896,23 @@ CRenderDB*  ps_renderDB = 0;
 		// Not necessary- setHandles is part of CSaveFile
 
 		// tsmMagnet
-		typedef set<CMagnet, less<CMagnet> > TSMagnet;
+		typedef std::set<CMagnet, std::less<CMagnet> > TSMagnet;
 		extern TSMagnet tsmMagnet;	// A set containing all shared magnets, for instancing.
 		ERASE(tsmMagnet);
 
 		// tsmMaterialInstances
-		typedef set<CMaterial, less<CMaterial> > TSM;
+		typedef std::set<CMaterial, std::less<CMaterial> > TSM;
 		extern TSM tsmMaterialInstances;
 		ERASE(tsmMaterialInstances);
 
 		// tspbPhysicsInfoBox
-		typedef set<CPhysicsInfoBox, less<CPhysicsInfoBox> > TSPB;
+		typedef std::set<CPhysicsInfoBox, std::less<CPhysicsInfoBox> > TSPB;
 		extern TSPB tspbPhysicsInfoBox;	// A set containing all shared box infos, for instancing.
 		ERASE(tspbPhysicsInfoBox);
 
 		// Track the skeletons for deletion.
-		extern list<CPhysicsInfoSkeleton*> lppisPhysicsSkeletons;
-		list<CPhysicsInfoSkeleton*>::iterator itskel;
+		extern std::list<CPhysicsInfoSkeleton*> lppisPhysicsSkeletons;
+		std::list<CPhysicsInfoSkeleton*>::iterator itskel;
 		for (itskel = lppisPhysicsSkeletons.begin(); itskel != lppisPhysicsSkeletons.end(); ++itskel)
 		{
 			delete *itskel;
@@ -1921,13 +1921,13 @@ CRenderDB*  ps_renderDB = 0;
 
 
 		// setinsprIgnore
-		typedef pair<CInstance*, CInstance*> TInstancePair;
-		typedef set<TInstancePair, CLessInstancePair> TSetInstancePair; 
+		typedef std::pair<CInstance*, CInstance*> TInstancePair;
+		typedef std::set<TInstancePair, CLessInstancePair> TSetInstancePair;
 		extern TSetInstancePair setinsprIgnore;
 		ERASE(setinsprIgnore);
 
 		// mapTextures
-		extern map< uint32, rptr<CTexture>, less<uint32> > mapTextures;
+		extern std::map< uint32, rptr<CTexture>, std::less<uint32> > mapTextures;
 		ERASE(mapTextures);
 
 		// mapTextureNames
@@ -1935,11 +1935,11 @@ CRenderDB*  ps_renderDB = 0;
 		//ERASE(mapTextureNames);
 
 		// mapMeshInstances
-		extern map<uint32, SMeshInstance, less<uint32> > mapMeshInstances;
+		extern std::map<uint32, SMeshInstance, std::less<uint32> > mapMeshInstances;
 		ERASE(mapMeshInstances);
 
 		// tmspPlatonicIdeal
-		typedef map<string, const CInstance*, less<string> >	TMapStrPins;
+		typedef std::map<std::string, const CInstance*, std::less<std::string> >	TMapStrPins;
 		extern TMapHashPins  tmPlatonicIdeal;
 		ERASE(tmPlatonicIdeal);
 
@@ -1967,7 +1967,7 @@ CRenderDB*  ps_renderDB = 0;
 		pinfoSphericalTrigger = 0;
 
 #if VER_TEST
-		extern set<uint32, less<uint32> > setSubmodels;
+		extern std::set<uint32, std::less<uint32> > setSubmodels;
 		ERASE(setSubmodels);
 #endif
 
@@ -2280,7 +2280,7 @@ CRenderDB*  ps_renderDB = 0;
 	//*****************************************************************************************
 	bool CWorld::bSaveAsText(const char *str_filename)
 	{
-		ofstream ofs(str_filename);
+		std::ofstream ofs(str_filename);
 
 		if (!ofs.is_open())
 			// Some sort of failure.
@@ -2306,7 +2306,7 @@ CRenderDB*  ps_renderDB = 0;
 
 				ofs << ' ' << pins->fGetScale();
 
-				ofs << endl;
+				ofs << std::endl;
 			}
 		}
 
@@ -2324,7 +2324,7 @@ CRenderDB*  ps_renderDB = 0;
 	{
 		Assert( (uint32)(plsstrGroffsLoaded->size())>u4_index );
 
-		list<const char*>::iterator i;
+		std::list<const char*>::iterator i;
 		uint32						u4_count = 0;
 
 		for (i = plsstrGroffsLoaded->begin(); i != plsstrGroffsLoaded->end(); ++i)
@@ -2522,7 +2522,7 @@ CRenderDB*  ps_renderDB = 0;
 
 	//*****************************************************************************************
 	//
-	const string& CWorld::strGetPendingLoad
+	const std::string& CWorld::strGetPendingLoad
 	(
 	)
 	//
@@ -2564,7 +2564,7 @@ CRenderDB*  ps_renderDB = 0;
 
 	//*****************************************************************************************
 	//
-	const string& CWorld::strGetPendingSave
+	const std::string& CWorld::strGetPendingSave
 	(
 	)
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/WorldDBase.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/WorldDBase.hpp
@@ -60,7 +60,7 @@
 // Required includes.
 //
 #include "Lib/Transform/Rotate.hpp"
-#include <bstring.h>
+#include <string>
 
 
 //
@@ -121,10 +121,10 @@ private:
 	TMapIntPPart*	 pmapHandlePointer;		// A map between handles and partition/instance pointers.
 
 	bool			 bLoadPending;			// We want to load a new level.
-	string			 strLoadName;			// Level to load before the next frame.
+	std::string		 strLoadName;			// Level to load before the next frame.
 
 	bool			 bSavePending;			// We want to save.
-	string			 strSaveName;			// Level to save before the next frame.
+	std::string		 strSaveName;			// Level to save before the next frame.
 
 	bool			 bGameOver;				// Game over man, game over.
 
@@ -813,7 +813,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	const string& strGetPendingLoad
+	const std::string& strGetPendingLoad
 	(
 	);
 	//
@@ -844,7 +844,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	const string& strGetPendingSave
+	const std::string& strGetPendingSave
 	(
 	);
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/WorldPriv.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/WorldPriv.hpp
@@ -24,19 +24,19 @@
 #define HEADER_LIB_ENTITYDBASE_WORLDDPRIV_HPP
 
 
-#include <list.h>
-#include <map.h>
+#include <list>
+#include <map>
 
 
-class TMapIntPPart : public map<uint32, CPartition*, less<uint32> >
+class TMapIntPPart : public std::map<uint32, CPartition*, std::less<uint32> >
 {
 };
 
-class TListConstChar : public list<const char*>
+class TListConstChar : public std::list<const char*>
 {
 };
 
-class TListInstance : public list<CInstance*>
+class TListInstance : public std::list<CInstance*>
 {
 };
 


### PR DESCRIPTION
In the `EntityDBase` project, the STL includes are modernized and the std:: namespace specifier is added where necessary.
This is _not_ sufficient to make `EntityDBase` compile.