### PR TITLE
GeomDBase: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/GeomDBase/Hull.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Hull.cpp
@@ -21,9 +21,9 @@
 #include "Lib/GeomDBase/Plane.hpp"
 #include "Lib/Sys/DebugConsole.hpp"
 
-#include <list.h>
-#include <vector.h>
-#include <algo.h>
+#include <list>
+#include <vector>
+#include <algorithm>
 #include <memory.h>
 
 #include <stdio.h>
@@ -55,7 +55,7 @@ public:
 	enum FacetFlags { Flipped = 1, Degenerate = 2 };
 
 	Vertex			verts[3];		// Vertices of the facet.
-	list<Vertex>	outside;		// Vertices outside the facet.
+	std::list<Vertex>	outside;		// Vertices outside the facet.
 	CPlane			plane;			// Plane equation for the facet.
 	int				flags;			// Flags for this facet.
 
@@ -98,7 +98,7 @@ class Edge
 {
 public:
 	Vertex vtx0, vtx1;
-	list<Facet>::iterator facet0, facet1;
+	std::list<Facet>::iterator facet0, facet1;
 
 	Edge()
 	{
@@ -120,12 +120,12 @@ public:
 		}
 	}
 
-	operator< (const Edge& edge)
+	bool operator< (const Edge& edge)
 	{
 		return (vtx0 < edge.vtx0 || (vtx0 == edge.vtx0 && vtx1 < edge.vtx1));
 	}
 
-	operator== (const Edge& edge)
+	bool operator== (const Edge& edge)
 	{
 		return (vtx0 == edge.vtx0 && vtx1 == edge.vtx1);
 	}
@@ -136,17 +136,17 @@ public:
 // A list of facets that keeps a list of edges so that adjacent facets can
 // be found quickly.
 //
-class FacetList : public list<Facet>
+class FacetList : public std::list<Facet>
 {
 private:
 	// A vector of edges.
-	vector<Edge> edges;
+	std::vector<Edge> edges;
 
 	// Return the iterator pointing to an edge.
-	vector<Edge>::iterator FindEdge(Vertex vtx0, Vertex vtx1)
+	std::vector<Edge>::iterator FindEdge(Vertex vtx0, Vertex vtx1)
 	{
 		// Binary search for edge.
-		vector<Edge>::iterator at = lower_bound(edges.begin(), edges.end(), Edge(vtx0, vtx1));
+		std::vector<Edge>::iterator at = lower_bound(edges.begin(), edges.end(), Edge(vtx0, vtx1));
 
 		Assert(*at == Edge(vtx0, vtx1));
 
@@ -157,7 +157,7 @@ private:
 	void AddEdge(Vertex vtx0, Vertex vtx1, iterator facet)
 	{
 		// Binary search for edge.
-		vector<Edge>::iterator at = lower_bound(edges.begin(), edges.end(), Edge(vtx0, vtx1));
+		std::vector<Edge>::iterator at = lower_bound(edges.begin(), edges.end(), Edge(vtx0, vtx1));
 
 		if (at != edges.end() && *at == Edge(vtx0, vtx1))
 		{
@@ -172,7 +172,7 @@ private:
 		else
 		{
 			// Insert edge (in sorted order).
-			vector<Edge>::iterator new_edge = edges.insert(at, Edge(vtx0, vtx1));
+			std::vector<Edge>::iterator new_edge = edges.insert(at, Edge(vtx0, vtx1));
 			new_edge->facet0 = facet;
 			new_edge->facet1 = end();
 		}
@@ -182,7 +182,7 @@ private:
 	void RemoveEdge(Vertex vtx0, Vertex vtx1, iterator facet)
 	{
 		// Binary search for edge.
-		vector<Edge>::iterator at = lower_bound(edges.begin(), edges.end(), Edge(vtx0, vtx1));
+		std::vector<Edge>::iterator at = lower_bound(edges.begin(), edges.end(), Edge(vtx0, vtx1));
 
 		Assert(*at == Edge(vtx0, vtx1));
 
@@ -216,7 +216,7 @@ public:
 		Assert(index1 != index2);
 
 		// Lookup edge based on index.
-		vector<Edge>::iterator edge = FindEdge((*facet).verts[index1], (*facet).verts[index2]);
+		std::vector<Edge>::iterator edge = FindEdge((*facet).verts[index1], (*facet).verts[index2]);
 
 		// Return the facet that is opposite this facet.
 		if (edge->facet0 == facet)
@@ -263,7 +263,7 @@ class Extreme
 {
 public:
 	float			fv;
-	list<Vertex>	verts;
+	std::list<Vertex>	verts;
 
 	Extreme()
 	{
@@ -324,7 +324,7 @@ bool find_visble_neighbors
 	const FacetList::iterator &facet, 
 	FacetList &facets, 
 	Vertex vtx_p, 
-	list<FacetList::iterator> &visible
+	std::list<FacetList::iterator> &visible
 )
 {
 	bool bIsVisible = 0;
@@ -334,7 +334,7 @@ bool find_visble_neighbors
 	{
 		// Degenerate facet is visisble if either of it's neighors are.
 		FacetList::iterator it_adj;
-		list<FacetList::iterator>::iterator itit_this;
+		std::list<FacetList::iterator>::iterator itit_this;
 
 		// Add facet iterator to visible list.
 		visible.push_front(facet);
@@ -601,12 +601,12 @@ int iQuickHull
 	// Create a four point simplex out of the six points with min/max co-ordinates.
 	//
 	Vertex vtx_simplex[4];
-	list<Vertex> lvtx_dont_use;
+	std::list<Vertex> lvtx_dont_use;
 
 	// Choose four different vertices.
 	int i_use_extreme = 0;
 	int i_simplex_cnt = 0;
-	list<Vertex>::iterator it_vtx_ext = extremes[i_use_extreme].verts.begin();
+	std::list<Vertex>::iterator it_vtx_ext = extremes[i_use_extreme].verts.begin();
 
 	// Find vertices to use for the simplex.
 	while (i_simplex_cnt < 4 && i_use_extreme < 6)
@@ -803,7 +803,7 @@ int iQuickHull
 						(*F).verts[0] - av3_pts, (*F).verts[1] - av3_pts, (*F).verts[2] - av3_pts));
 				
 				// initialize the visible set V to F
-				list<FacetList::iterator> V;
+				std::list<FacetList::iterator> V;
 	
 				// Find all the neighbors of F that P is visible from.
 				find_visble_neighbors(F, facets, vtx_p, V);
@@ -811,8 +811,8 @@ int iQuickHull
 				Assert(!V.empty())
 
 				// the boundary of V is the set of horizon ridges H
-				list<FacetList::iterator>::iterator itit_fac;
-				list<Edge> H;
+				std::list<FacetList::iterator>::iterator itit_fac;
+				std::list<Edge> H;
 
 				for (itit_fac = V.begin(); itit_fac != V.end(); itit_fac++)
 				{
@@ -878,7 +878,7 @@ int iQuickHull
 				// delete the facets in V  
 				// get all the points outside facets in V
 				// do it now so that new faces get proper edges
-				list<Vertex> outside;
+				std::list<Vertex> outside;
 
 				for (itit_fac = V.begin(); itit_fac != V.end(); itit_fac++)
 				{
@@ -892,7 +892,7 @@ int iQuickHull
 				V.erase(V.begin(), V.end());
 
 				// Compute pseudo centroid of polygon formed by horizon ridges H.
-				list<Edge>::iterator R = H.begin();
+				std::list<Edge>::iterator R = H.begin();
 				i = 1;
 
 				CVector3<> v3_avg = *(*R).vtx0;
@@ -969,11 +969,11 @@ int iQuickHull
 				// for each new facet F'
 				for (itit_fac = V.begin(); itit_fac != V.end(); itit_fac++)
 				{
-					list<Vertex>::iterator it_vtx_next;
+					std::list<Vertex>::iterator it_vtx_next;
 					float f_max_dist = 0.0f;
 
 					// for each unassigned point q in an outside set of a facet V
-					for (list<Vertex>::iterator it_vtx = outside.begin(); it_vtx != outside.end(); it_vtx = it_vtx_next)
+					for (std::list<Vertex>::iterator it_vtx = outside.begin(); it_vtx != outside.end(); it_vtx = it_vtx_next)
 					{
 						it_vtx_next = it_vtx;
 						it_vtx_next++;

--- a/jp2_pc/Source/Lib/GeomDBase/Mesh.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Mesh.cpp
@@ -167,7 +167,7 @@
 
 #include <memory.h>
 #include <malloc.h>
-#include <list.h>
+#include <list>
 
 
 //**********************************************************************************************
@@ -1231,7 +1231,7 @@ CFastHeap	CMesh::fhGlobalMesh(1 << 25);		// 32Mb
 
 
 		// Point to face mapping array of lists.
-		CAArray< list<SFaceVert> > paPointToFaces(mh.mav3Points.uLen);
+		CAArray< std::list<SFaceVert> > paPointToFaces(mh.mav3Points.uLen);
 
 		// Create a point to face mapping.
 		for (int i_face = 0; i_face < mh.mampPolygons.uLen; i_face++)
@@ -1268,7 +1268,7 @@ CFastHeap	CMesh::fhGlobalMesh(1 << 25);		// 32Mb
 				uint u_index = pmv->pv3Point - mh.mav3Points;
 
 				// Look at polygons that share this point.
-				for (list<SFaceVert>::iterator it = paPointToFaces[u_index].begin(); it != paPointToFaces[u_index].end(); it++)
+				for (std::list<SFaceVert>::iterator it = paPointToFaces[u_index].begin(); it != paPointToFaces[u_index].end(); it++)
 				{
 					SPolygon& mp = mh.mampPolygons[(*it).i_face];
 

--- a/jp2_pc/Source/Lib/GeomDBase/Partition.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Partition.cpp
@@ -39,8 +39,8 @@
 
 // Note: reording done to insure Windows.h is included before
 // io.h "disables" a subsequent include of same.
-#include "multiset.h"
-#include "map.h"
+#include <set>
+#include <map>
 #include "Common.hpp"
 #include "Lib/W95/WinInclude.hpp"
 
@@ -85,7 +85,7 @@ CConsoleBuffer conPreLoader;
 //
 // Map for finding duplicate spatial partitions.
 //
-typedef map< uint32, CPartition*, less<uint32> > TPartDuplicate;
+typedef std::map< uint32, CPartition*, std::less<uint32> > TPartDuplicate;
 TPartDuplicate partdupMap;
 
 //
@@ -1151,8 +1151,8 @@ static void PrintPos(CConsoleBuffer& con, const CPartition* ppart)
 	//*****************************************************************************************
 	CInstance* CPartition::pinsFindNamedInstance
 	(
-		string str_name,
-		string str_class
+		std::string str_name,
+		std::string str_class
 	) const
 	{
 		uint32 u4_handle = u4Hash(str_name.c_str());
@@ -1233,7 +1233,7 @@ static void PrintPos(CConsoleBuffer& con, const CPartition* ppart)
 	//
 	CInstance* CPartition::pinsFindInstance
 	(
-		string str_name					// Name of instance
+		std::string str_name					// Name of instance
 	) const	
 	{
 		uint32 u4_handle = u4Hash(str_name.c_str());
@@ -1284,8 +1284,8 @@ static void PrintPos(CConsoleBuffer& con, const CPartition* ppart)
 	//*****************************************************************************************
 	void CPartition::SortChildrenByVolume()
 	{
-		multiset<CPartVol, CPartVol>           mset_pvol;	// Multiset.
-		multiset<CPartVol, CPartVol>::iterator itmset;		// Multiset iterator.
+		std::multiset<CPartVol, CPartVol>           mset_pvol;	// Multiset.
+		std::multiset<CPartVol, CPartVol>::iterator itmset;		// Multiset iterator.
 
 		// Get a pointer to the child list.
 		CPartition* ppartc = (CPartition*)ppartChildren();

--- a/jp2_pc/Source/Lib/GeomDBase/Partition.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Partition.hpp
@@ -65,7 +65,7 @@
 #include "Lib/Transform/Presence.hpp"
 #include "Lib/GeomDBase/Plane.hpp"
 #include "Lib/Std/Set.hpp"
-#include <bstring.h>
+#include <string>
 #include "Lib/Math/FloatShort.hpp"
 
 
@@ -1613,8 +1613,8 @@ public:
 	//
 	CInstance* pinsFindNamedInstance
 	(
-		string str_name,				// Name of instance.
-		string str_class = ""			// Optional name of C++ class, for further disambiguation.
+		std::string str_name,				// Name of instance.
+		std::string str_class = ""			// Optional name of C++ class, for further disambiguation.
 	) const;
 	//
 	// Returns the first instance found in the partition with matching name and class.
@@ -1640,7 +1640,7 @@ public:
 	//
 	CInstance* pinsFindInstance
 	(
-		string str_name					// Name of instance
+		std::string str_name					// Name of instance
 	) const;
 	//
 	// Returns the first instance found in the partition with matching name

--- a/jp2_pc/Source/Lib/GeomDBase/PartitionBuild.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/PartitionBuild.cpp
@@ -31,7 +31,7 @@
  * 
  **********************************************************************************************/
 
-#include "Algo.h"
+#include <algorithm>
 #include "Lib/Sys/RegInit.hpp"
 #include "Common.hpp"
 #include "Lib/Renderer/GeomTypes.hpp"
@@ -504,11 +504,11 @@ void SubdividePartition(CPartition& rpart)
 	// Divide on the X or Y axis.
 	if (Abs(v3_dim.tX) > Abs(v3_dim.tY))
 	{
-		sort(appart_main, appart_main + i_num_children, CPartitionSortX());
+		std::sort(appart_main, appart_main + i_num_children, CPartitionSortX());
 	}
 	else
 	{
-		sort(appart_main, appart_main + i_num_children, CPartitionSortY());
+		std::sort(appart_main, appart_main + i_num_children, CPartitionSortY());
 	}
 	int i_num_a = i_num_children / 2;
 	int i_num_b = i_num_children - i_num_a;

--- a/jp2_pc/Source/Lib/GeomDBase/PartitionPriv.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/PartitionPriv.hpp
@@ -51,7 +51,7 @@
 //
 // Required includes for this object.
 //
-#include "List.h"
+#include <list>
 #include "Lib/EntityDBase/Container.hpp"
 #include "Partition.hpp"
 #include "Lib/EntityDBase/Instance.hpp"
@@ -331,13 +331,13 @@ void SetPrioritySetting
 //
 
 // Type describing a container of CPartition pointers.
-class TPartitionList : public CContainer< list<SPartitionListElement> >
+class TPartitionList : public CContainer< std::list<SPartitionListElement> >
 // Prefix: partlist
 {
 };
 
 // Type describing a container of CPartition pointers.
-class TPartitionListChild : public CContainer< list<CPartition*> >
+class TPartitionListChild : public CContainer< std::list<CPartition*> >
 // Prefix: partlist
 {
 };

--- a/jp2_pc/Source/Lib/GeomDBase/PartitionSpace.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/PartitionSpace.hpp
@@ -58,7 +58,7 @@
 #include "Partition.hpp"
 #include "Lib/Renderer/GeomTypes.hpp"
 
-#include "map.h"
+#include <map>
 
 
 //
@@ -66,7 +66,7 @@
 //
 
 // Type representing an associative container between a spatial partition and a value.
-typedef map< uint, CPartition*, less<uint> > TPartSpaceMap;
+typedef std::map< uint, CPartition*, std::less<uint> > TPartSpaceMap;
 
 
 //

--- a/jp2_pc/Source/Lib/GeomDBase/RayCast.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/RayCast.cpp
@@ -94,7 +94,7 @@
 #include "Lib/View/LineDraw.hpp"
 #include "Lib/Sys/DebugConsole.hpp"
 
-#include <set.h>
+#include <set>
 
 //*********************************************************************************************
 //
@@ -137,7 +137,7 @@
 	{
 	public:
 		// The result list.
-		CContainer< set<SObjectLoc, less<SObjectLoc> > >	setoblResults;
+		CContainer< std::set<SObjectLoc, std::less<SObjectLoc> > >	setoblResults;
 	};
 
 	//*****************************************************************************************

--- a/jp2_pc/Source/Lib/GeomDBase/Skeleton.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Skeleton.cpp
@@ -329,7 +329,7 @@
 	CSubBioMesh::~CSubBioMesh()
 	{
 		// Delete all of the substitutes.
-		list<CSubstitute*>::iterator i;
+		std::list<CSubstitute*>::iterator i;
 		for (i = lpsubSubstitutes.begin(); i != lpsubSubstitutes.end(); ++i)
 		{
 			delete *i;
@@ -340,7 +340,7 @@
 	void CSubBioMesh::Substitute(const CSubstitute* psub)
 	{
 		// Apply the substitution.
-		list<CVertexReplacement>::const_iterator i = psub->lvrVertexReplacements.begin();
+		std::list<CVertexReplacement>::const_iterator i = psub->lvrVertexReplacements.begin();
 
 		for (; i != psub->lvrVertexReplacements.end(); ++i)
 		{
@@ -353,7 +353,7 @@
 	void CSubBioMesh::Substitute(int i_index)
 	{
 		// Find the correct CSubstitute, and apply it.
-		list<CSubstitute*>::iterator i = lpsubSubstitutes.begin();
+		std::list<CSubstitute*>::iterator i = lpsubSubstitutes.begin();
 
 		for (; i != lpsubSubstitutes.end(); ++i)
 		{
@@ -374,7 +374,7 @@
 	void CSubBioMesh::MakeRelative(CSubstitute* psub, CPArray< CTransform3<> > patf3_joints)
 	{
 		// Calculate the relative attributes of the substitution.
-		list<CVertexReplacement>::iterator i = psub->lvrVertexReplacements.begin();
+		std::list<CVertexReplacement>::iterator i = psub->lvrVertexReplacements.begin();
 
 		for (; i != psub->lvrVertexReplacements.end(); ++i)
 		{

--- a/jp2_pc/Source/Lib/GeomDBase/Skeleton.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Skeleton.hpp
@@ -63,7 +63,7 @@
 
 #include "Mesh.hpp"
 
-#include <list.h>
+#include <list>
 
 class CInstance;
 class CShapePresence;
@@ -250,7 +250,7 @@ class CSubstitute
 //**************************************
 {
 public:
-	list<CVertexReplacement> lvrVertexReplacements;		// The substitute vertex positions.
+	std::list<CVertexReplacement> lvrVertexReplacements;		// The substitute vertex positions.
 															// index, vector
 };
 
@@ -270,7 +270,7 @@ class CSubBioMesh : public CBioMesh
 	//
 public:
 
-	list<CSubstitute*> lpsubSubstitutes;		// The substitute vertex positions.
+	std::list<CSubstitute*> lpsubSubstitutes;		// The substitute vertex positions.
 
 public:
 	//******************************************************************************************

--- a/jp2_pc/Source/Lib/GeomDBase/TerrainLoad.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/TerrainLoad.cpp
@@ -31,7 +31,7 @@
 #include "Common.hpp"
 #include "TerrainLoad.hpp"
 
-#include <iomanip.h>
+#include <iomanip>
 #include "Lib/Sys/TextOut.hpp"
 #include "Lib/GeomDBase/WaveletQuadTreeTForm.hpp"
 #include "Lib/GeomDBase/WaveletQuadTreeQuery.hpp"
@@ -45,15 +45,15 @@
 #endif
 
 //**********************************************************************************************
-NMultiResolution::CTransformedDataHeader* ptdhLoadTerrainData(const string& str_terrain_name)
+NMultiResolution::CTransformedDataHeader* ptdhLoadTerrainData(const std::string& str_terrain_name)
 {
 	using NMultiResolution::CTransformedDataHeader;
 	using NMultiResolution::CQuadRootTForm;
 
 	// Attempt to open a matching file with a .wtd extension.
-	string str_transformed_filename = str_terrain_name + ".wtd";
+	std::string str_transformed_filename = str_terrain_name + ".wtd";
 
-	ifstream stream_transformed(str_transformed_filename.c_str(), ios::in | ios::nocreate | ios::binary);
+	std::ifstream stream_transformed(str_transformed_filename.c_str(), std::ios::in | std::ios::_Nocreate | std::ios::binary);
 
 	if (stream_transformed.fail())
 	{
@@ -73,7 +73,7 @@ NMultiResolution::CTransformedDataHeader* ptdhLoadTerrainData(const string& str_
 
 
 //**********************************************************************************************
-void ConvertTerrainData(const string& str_terrain_name, int i_quant_bits, CConsoleBuffer& rcon_text_out)
+void ConvertTerrainData(const std::string& str_terrain_name, int i_quant_bits, CConsoleBuffer& rcon_text_out)
 {
 	using NMultiResolution::CTransformedDataHeader;
 	using NMultiResolution::CQuadRootTForm;
@@ -114,7 +114,7 @@ void ConvertTerrainData(const string& str_terrain_name, int i_quant_bits, CConso
 	//
 	// Save data.
 	//
-	string str_transformed_filename = str_terrain_name + ".wtd";
+	std::string str_transformed_filename = str_terrain_name + ".wtd";
 
 	rcon_text_out.Print("\nFinal data size: %4.1fKB\n", ptdh_transformed->uDataBitSize() / (1024.0 * 8.0));
 	rcon_text_out.Print("Output file    : %s\n", str_transformed_filename.c_str());
@@ -158,7 +158,7 @@ namespace
 }
 
 //**********************************************************************************************
-void SaveTerrainTriangulation(const string& str_terrain_name, TReal r_freq_highpass, bool b_freq_as_ratio, bool b_conform, CConsoleBuffer& rcon_text_out)
+void SaveTerrainTriangulation(const std::string& str_terrain_name, TReal r_freq_highpass, bool b_freq_as_ratio, bool b_conform, CConsoleBuffer& rcon_text_out)
 {
 	rcon_text_out.SetActive(true);
 
@@ -221,9 +221,9 @@ void SaveTerrainTriangulation(const string& str_terrain_name, TReal r_freq_highp
 		// Write the triangulation to a file.
 		//
 
-		string str_triangles_filename = str_terrain_name + ".tri";
+		std::string str_triangles_filename = str_terrain_name + ".tri";
 
-		ofstream stream_tri(str_triangles_filename.c_str(), ios::out | ios::trunc);
+		std::ofstream stream_tri(str_triangles_filename.c_str(), std::ios::out | std::ios::trunc);
 
 		if (stream_tri.fail())
 		{
@@ -249,7 +249,7 @@ void SaveTerrainTriangulation(const string& str_terrain_name, TReal r_freq_highp
 		rcon_text_out.Print("Writing %d triangles\n", u_num_tri);
 		rcon_text_out.Show();
 
-		stream_tri << u_num_tri << endl;
+		stream_tri << u_num_tri << std::endl;
 
 		for (it.Reset(); it; ++it)
 		{
@@ -272,7 +272,7 @@ void SaveTerrainTriangulation(const string& str_terrain_name, TReal r_freq_highp
 
 			stream_tri << au_vert_indices[0] << ' ';
 			stream_tri << au_vert_indices[1] << ' ';
-			stream_tri << au_vert_indices[2] << endl;
+			stream_tri << au_vert_indices[2] << std::endl;
 		}
 
 
@@ -280,8 +280,8 @@ void SaveTerrainTriangulation(const string& str_terrain_name, TReal r_freq_highp
 		rcon_text_out.Print("Writing %d vertices\n", dapqvtq_used_verts.uLen);
 		rcon_text_out.Show();
 
-		stream_tri << dapqvtq_used_verts.uLen << endl;
-		stream_tri << setprecision(12);
+		stream_tri << dapqvtq_used_verts.uLen << std::endl;
+		stream_tri << std::setprecision(12);
 
 		for (uint u_vt = 0; u_vt < dapqvtq_used_verts.uLen; u_vt++)
 		{
@@ -289,7 +289,7 @@ void SaveTerrainTriangulation(const string& str_terrain_name, TReal r_freq_highp
 
 			stream_tri << pqvt_curr->v3World(qnq_root.mpConversions).tX << ' ';
 			stream_tri << pqvt_curr->v3World(qnq_root.mpConversions).tY << ' ';
-			stream_tri << pqvt_curr->v3World(qnq_root.mpConversions).tZ << endl;
+			stream_tri << pqvt_curr->v3World(qnq_root.mpConversions).tZ << std::endl;
 		}
 	}
 
@@ -341,7 +341,7 @@ void SaveTerrainTriangulation(const string& str_terrain_name, TReal r_freq_highp
 		rcon_text_out.Print("Input file: %s\n\n", str_filename);
 		rcon_text_out.Show();
 
-		streamFile.open(str_filename, ios::in | ios::nocreate);
+		streamFile.open(str_filename, std::ios::in | std::ios::_Nocreate);
 
 		if (!streamFile)
 		{

--- a/jp2_pc/Source/Lib/GeomDBase/TerrainLoad.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/TerrainLoad.hpp
@@ -33,9 +33,9 @@
 #define HEADER_LIB_GEOMDBASE_TERRAINLOAD_HPP
 
 
-#include <fstream.h>
+#include <fstream>
 #include <float.h>
-#include <bstring.h>
+#include <string>
 
 #include "Lib/Transform/TransLinear.hpp"
 #include "Lib/Transform/Vector.hpp"
@@ -53,7 +53,7 @@ namespace NMultiResolution
 //
 NMultiResolution::CTransformedDataHeader* ptdhLoadTerrainData
 (
-	const string& str_terrain_name	// Filename of terrain data file, without extension.
+	const std::string& str_terrain_name	// Filename of terrain data file, without extension.
 );
 //
 // Load a terrain data file.
@@ -70,7 +70,7 @@ NMultiResolution::CTransformedDataHeader* ptdhLoadTerrainData
 //
 void ConvertTerrainData
 (
-	const string& str_terrain_name,	// Filename of terrain data file, without extension.
+	const std::string& str_terrain_name,	// Filename of terrain data file, without extension.
 	int i_quant_bits,				// Number of bits to use to quantise terrain height values.
 	CConsoleBuffer& rcon_text_out
 );
@@ -97,7 +97,7 @@ void ConvertTerrainData
 //
 void SaveTerrainTriangulation
 (
-	const string& str_terrain_name,	// Filename of terrain data file, without extension.
+	const std::string& str_terrain_name,	// Filename of terrain data file, without extension.
 	TReal r_freq_highpass,			// High pass wavelet coeficient filter, in meters or as ratio.
 	bool b_freq_as_ratio,			// Whether cutoff is represented as a ratio of a node's size.
 	bool b_conform,
@@ -199,7 +199,7 @@ class CTerrainExportedData
 
 	bool abErrorDialogDone[eerrEND];		// Flags indicating dialog has been raised for specific error.
 
-	ifstream streamFile;
+	std::ifstream streamFile;
 
 	SExportDataInfo ediInfo;
 

--- a/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.cpp
@@ -55,7 +55,7 @@
 #include "Lib/Std/PrivSelf.hpp"
 #include "Lib/Std/MemLimits.hpp"
 
-#include <list.h>
+#include <list>
 
 //
 // Static constants.
@@ -269,7 +269,7 @@ namespace NMultiResolution
 		static rptr<CRaster> prasBaseTexture;
 		static CTexturePageManager::CRegionHandle rhBaseTexture;
 
-		typedef list< ptr<NMultiResolution::CTextureNode> > TList;
+		typedef std::list< ptr<NMultiResolution::CTextureNode> > TList;
 		static TList lptxnTextures;
 
 		static CClut* pclutCurrent;
@@ -395,7 +395,7 @@ namespace NMultiResolution
 		//
 		static void MergeInList
 		(
-			list< CRectangle<int> >& lrc_merged,
+			std::list< CRectangle<int> >& lrc_merged,
 			CRectangle<int> rc_new
 		);
 		//
@@ -525,7 +525,7 @@ namespace NMultiResolution
 		// Copy the ancestor's moving shadows' dirty rects if they intersect this descendant.
 		if (!rtxn_ancestor.ltrcDirtyRects.empty())
 		{
-			list< CRectangle<> >::const_iterator it;
+			std::list< CRectangle<> >::const_iterator it;
 			for (it = rtxn_ancestor.ltrcDirtyRects.begin(); it != rtxn_ancestor.ltrcDirtyRects.end(); ++it)
 				if ((*it).bIntersects(pqnt_owner->rcGetRectangle()))
 					ltrcDirtyRects.push_back(*it);
@@ -1157,7 +1157,7 @@ namespace NMultiResolution
 	{
 		if (pqntin_node->ptxnGetTextureNode() != 0)
 		{
-			list< CRectangle<> >::const_iterator it;
+			std::list< CRectangle<> >::const_iterator it;
 			for (it = pqntin_node->ptxnGetTextureNode()->ltrcDirtyRects.begin(); it != pqntin_node->ptxnGetTextureNode()->ltrcDirtyRects.end(); ++it)
 				ptxn_ancestor->ltrcDirtyRects.push_back(*it);
 		}
@@ -1793,10 +1793,10 @@ namespace NMultiResolution
 		// This list must include the dirty rectangles of the previous update and the dirty rectangles
 		// of the current frame.
 		//
-		list< CRectangle<int> > lrc_this_frame;
+		std::list< CRectangle<int> > lrc_this_frame;
 
 		// Add the dirty rects from the previous update.
-		list< CRectangle<int> >::iterator it_prev;
+		std::list< CRectangle<int> >::iterator it_prev;
 		for (it_prev = ltrcPrevDirtyRects.begin(); it_prev != ltrcPrevDirtyRects.end(); ++it_prev)
 			lrc_this_frame.push_back(*it_prev);
 
@@ -1813,9 +1813,9 @@ namespace NMultiResolution
 		{
 			CTransLinear2<> tlr2_quad_inv_raster(pqntOwner->rcGetRectangle(), CRectangle<>(0, 0, v2_size.tX, v2_size.tY));
 
-			list< CRectangle<int> > lrc_next_frame;
+			std::list< CRectangle<int> > lrc_next_frame;
 
-			list< CRectangle<> >::iterator it_curr;
+			std::list< CRectangle<> >::iterator it_curr;
 			for (it_curr = ltrcDirtyRects.begin(); it_curr != ltrcDirtyRects.end(); ++it_curr)
 			{
 				// Convert the dirty rect from quad space to texture raster coords. Add an extra few pixels in all
@@ -1837,7 +1837,7 @@ namespace NMultiResolution
 				}
 			}
 
-			for (list< CRectangle<int> >::iterator it_next = lrc_next_frame.begin(); it_next != lrc_next_frame.end(); ++it_next)
+			for (std::list< CRectangle<int> >::iterator it_next = lrc_next_frame.begin(); it_next != lrc_next_frame.end(); ++it_next)
 				ltrcPrevDirtyRects.push_back(*it_next);
 		}
 
@@ -1856,7 +1856,7 @@ namespace NMultiResolution
 		));
 
 		// Copy regions from the buffer containing the non-clut converted texture and static shadows.
-		list< CRectangle<int> >::iterator it_this = lrc_this_frame.begin();
+		std::list< CRectangle<int> >::iterator it_this = lrc_this_frame.begin();
 		for (; it_this != lrc_this_frame.end(); ++it_this)
 			CPriv::CopyRaster(pras_region, pras_shadow, &(*it_this));
 
@@ -1868,7 +1868,7 @@ namespace NMultiResolution
 		}
 		else
 		{
-			list< CRectangle<int> >::iterator it_new;
+			std::list< CRectangle<int> >::iterator it_new;
 			for (it_new = ltrcPrevDirtyRects.begin(); it_new != ltrcPrevDirtyRects.end(); ++it_new)
 			{
 				#if VER_TEST
@@ -1967,11 +1967,11 @@ namespace NMultiResolution
 
 
 	//******************************************************************************************
-	void CTextureNode::CPriv::MergeInList(list< CRectangle<int> >& lrc_merged, CRectangle<int> rc_new)
+	void CTextureNode::CPriv::MergeInList(std::list< CRectangle<int> >& lrc_merged, CRectangle<int> rc_new)
 	{
 		for (;;)
 		{
-			list< CRectangle<int> >::iterator it_merge;
+			std::list< CRectangle<int> >::iterator it_merge;
 			for (it_merge = lrc_merged.begin(); it_merge != lrc_merged.end(); ++it_merge)
 				if (rc_new.bIntersects(*it_merge))
 					break;

--- a/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.hpp
@@ -40,7 +40,7 @@
 #ifndef HEADER_LIB_GEOMDBASE_TERRAINTEXTURE_HPP
 #define HEADER_LIB_GEOMDBASE_TERRAINTEXTURE_HPP
 
-#include <list.h>
+#include <list>
 #include "Lib/Std/BlockAllocator.hpp"
 #include "Lib/Transform/TransLinear.hpp"
 #include "Lib/GeomDBase/Shape.hpp"
@@ -119,8 +119,8 @@ namespace NMultiResolution
 		CTexturePageManager::CRegionHandle rhAllocShadow;
 											// Allocation handle for the texture and static shadows.
 
-		list< CRectangle<> >    ltrcDirtyRects;
-		list< CRectangle<int> > ltrcPrevDirtyRects;
+		std::list< CRectangle<> >    ltrcDirtyRects;
+		std::list< CRectangle<int> > ltrcPrevDirtyRects;
 
 		//******************************************************************************************
 		//

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletCoef.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletCoef.hpp
@@ -51,7 +51,7 @@
 #include "Lib/Math/FloatDef.hpp"
 #include "Lib/Transform/Vector.hpp"
 
-#include <function.h>
+#include <functional>
 
 #ifdef __MWERKS__
  // for <= if only given < and ==

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTree.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTree.cpp
@@ -264,7 +264,7 @@ namespace NMultiResolution
 
 		//******************************************************************************************
 		//
-		pair<CCoef, CCoef> prcfCheckCoefLimitsBranch() const;
+		std::pair<CCoef, CCoef> prcfCheckCoefLimitsBranch() const;
 		//
 		// Checks the coeficient 'Z' limits for this branch of the quad tree, in debug builds only.
 		//
@@ -1411,9 +1411,9 @@ namespace NMultiResolution
 
 
 	//******************************************************************************************
-	pair<CCoef, CCoef> CQuadNodeTIN::CPriv::prcfCheckCoefLimitsBranch() const
+	std::pair<CCoef, CCoef> CQuadNodeTIN::CPriv::prcfCheckCoefLimitsBranch() const
 	{
-		pair<CCoef, CCoef> prcf_lim(cfMAX, -cfMAX);
+		std::pair<CCoef, CCoef> prcf_lim(cfMAX, -cfMAX);
 
 		#if VER_DEBUG
 			if (bHasDescendants())
@@ -1422,7 +1422,7 @@ namespace NMultiResolution
 
 				for (int i_dsc = 0; i_dsc < 4; i_dsc++)
 				{
-					pair<CCoef, CCoef> prcf_ret = static_cast<CPriv*>(pqntin_dsc)->prcfCheckCoefLimitsBranch();
+					std::pair<CCoef, CCoef> prcf_ret = static_cast<CPriv*>(pqntin_dsc)->prcfCheckCoefLimitsBranch();
 
 					prcf_lim.first  = Min(prcf_ret.first,  prcf_lim.first);
 					prcf_lim.second = Max(prcf_ret.second, prcf_lim.second);

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeBaseTri.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeBaseTri.hpp
@@ -51,7 +51,7 @@
 #ifndef HEADER_LIB_GEOMDBASE_WAVELETQUADTREEBASETRI_HPP
 #define HEADER_LIB_GEOMDBASE_WAVELETQUADTREEBASETRI_HPP
 
-#include <pair.h>
+#include <utility>
 #include "Lib/Std/BlockAllocator.hpp"
 #include "Lib/Renderer/ClipRegion2D.hpp"
 #include "Lib/GeomDBase/Plane.hpp"

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeQuery.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeQuery.cpp
@@ -124,7 +124,7 @@ namespace NMultiResolution
 
 
 	//******************************************************************************************
-	pair<TReal, TReal> CQuadNodeQuery::prrGetWorldZLimits(const CQuadRootQuery* pqnq_root)
+	std::pair<TReal, TReal> CQuadNodeQuery::prrGetWorldZLimits(const CQuadRootQuery* pqnq_root)
 	{
 		CTriNodeInfoQuery* ptinf = ptinfGetTriangleInfo();
 
@@ -177,7 +177,7 @@ namespace NMultiResolution
 			ptinf->rMaxZ = cf_max.rGet(pqnq_root->mpConversions.rCoefToWorld);
 		}
 
-		return pair<TReal, TReal>(ptinf->rMinZ, ptinf->rMaxZ);
+		return std::pair<TReal, TReal>(ptinf->rMinZ, ptinf->rMaxZ);
 	}
 
 	//******************************************************************************************
@@ -757,7 +757,7 @@ namespace NMultiResolution
 
 		if (bDecimateTree())
 		{
-			for (list<CQueryRect*>::iterator it = ltpqrQueries.begin(); it != ltpqrQueries.end(); ++it)
+			for (std::list<CQueryRect*>::iterator it = ltpqrQueries.begin(); it != ltpqrQueries.end(); ++it)
 				(*it)->SetEvaluateReq();
 		}
 

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeQuery.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeQuery.hpp
@@ -72,7 +72,7 @@
 #ifndef HEADER_LIB_GEOMDBASE_WAVELETQUADTREEQUERY_HPP
 #define HEADER_LIB_GEOMDBASE_WAVELETQUADTREEQUERY_HPP
 
-#include <list.h>
+#include <list>
 #include "Lib/Std/BlockAllocator.hpp"
 #include "Lib/Sys/Profile.hpp"
 #include "Lib/GeomDBase/Plane.hpp"
@@ -389,7 +389,7 @@ namespace NMultiResolution
 
 		//******************************************************************************************
 		//
-		pair<TReal, TReal> prrGetWorldZLimits
+		std::pair<TReal, TReal> prrGetWorldZLimits
 		(
 			const CQuadRootQuery* pqnq_root
 		);
@@ -546,7 +546,7 @@ namespace NMultiResolution
 		static CProfileStat psRayRefine;
 		static CProfileStat psRayIntersect;
 
-		list<CQueryRect*> ltpqrQueries;
+		std::list<CQueryRect*> ltpqrQueries;
 
 	public:
 		SMapping mpConversions;					// Conversions between quad - world space.


### PR DESCRIPTION
In the `GeomDBase` project, the STL includes are modernized and the std:: namespace specifier is added where necessary.
This is _not_ sufficient to make `GeomDBase` compile.