### PR TITLE
Loader: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/Groff/EasyString.cpp
+++ b/jp2_pc/Source/Lib/Groff/EasyString.cpp
@@ -42,7 +42,7 @@
 
 // Standard includes.
 #include <assert.h>
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -420,7 +420,7 @@ CEasyString& CEasyString::operator+=
 
 //**********************************************************************************************
 //
-CEasyString::operator[]
+char CEasyString::operator[]
 (
 	uint u_index
 ) const
@@ -441,7 +441,7 @@ CEasyString::operator[]
 
 //**********************************************************************************************
 //
-CEasyString::operator[]
+char CEasyString::operator[]
 (
 	int i_index
 ) const
@@ -651,9 +651,9 @@ void CEasyString::Puts
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&			os_stream, 
+	std::ostream&			os_stream,
 	const CEasyString&	estr_string
 )
 {
@@ -664,16 +664,16 @@ ostream& operator<<
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&	 is_stream,
+	std::istream&	 is_stream,
 	CEasyString& estr_string
 )
 {
 	char strBuffer[__ESTR_INPUT_BUFFER_SIZE__];
 
 	// Read in the string.
-	cin.getline(strBuffer, __ESTR_INPUT_BUFFER_SIZE__, '\n');
+	std::cin.getline(strBuffer, __ESTR_INPUT_BUFFER_SIZE__, '\n');
 
 	// Assign the string to the string.
 	estr_string = strBuffer;
@@ -1003,5 +1003,5 @@ void CEasyString::Dump
 )
 {
 	// Display the string information in a dump format.
-	cout << "CEasyString :" << strString << ":, Length = " << uStringLength << endl;
+	std::cout << "CEasyString :" << strString << ":, Length = " << uStringLength << std::endl;
 }

--- a/jp2_pc/Source/Lib/Groff/EasyString.hpp
+++ b/jp2_pc/Source/Lib/Groff/EasyString.hpp
@@ -44,7 +44,7 @@
 #ifndef HEADER_LIB_GROFF_EASYSTRING_HPP
 #define HEADER_LIB_GROFF_EASYSTRING_HPP
 
-#include <iostream.h>
+#include <iostream>
 #include <stdio.h>
 #include <stdarg.h>
 #include <string.h>
@@ -196,7 +196,7 @@ public:
 
 	//**********************************************************************************************
 	//
-	operator[]
+	char operator[]
 	(
 		uint u_index
 	) const;
@@ -204,7 +204,7 @@ public:
 
 	//**********************************************************************************************
 	//
-	operator[]
+	char operator[]
 	(
 		int i_index
 	) const;
@@ -324,18 +324,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&			os_stream, 
+		std::ostream&		os_stream,
 		const CEasyString&	estr_string
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&	 is_stream,
+		std::istream&	 is_stream,
 		CEasyString& estr_string
 	);
 

--- a/jp2_pc/Source/Lib/Groff/FileIO.cpp
+++ b/jp2_pc/Source/Lib/Groff/FileIO.cpp
@@ -374,7 +374,7 @@ TSymbolHandle CFileIO::syhInsert(const char* str_name)
 	else
 	{
 		// Check if this symbol is in the list.
-		set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.find(str_name);
+		std::set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.find(str_name);
 		if (it == fsFile.pstSymbols.setName.end())
 		{
 			// Add to list.
@@ -399,7 +399,7 @@ TSymbolHandle CFileIO::syhInsert(const char* str_name)
 bool CFileIO::bDelete(const char* str_name)
 {
 	// Lookup the symbol by name.
-	set<SSymbolEntry*, SSymbolNameLess>::iterator it_name = fsFile.pstSymbols.find(str_name);
+	std::set<SSymbolEntry*, SSymbolNameLess>::iterator it_name = fsFile.pstSymbols.find(str_name);
 
 	// Was the symbol found?
 	if (it_name != fsFile.pstSymbols.setName.end())
@@ -413,7 +413,7 @@ bool CFileIO::bDelete(const char* str_name)
 			fsFile.pstSymbols.setName.erase(it_name);
 
 			// Remove it from the handle set as well.
-			set<SSymbolEntry*, SSymbolHandleLess>::iterator it_handle = fsFile.pstSymbols.find(pse_symbol->syhHandle);
+			std::set<SSymbolEntry*, SSymbolHandleLess>::iterator it_handle = fsFile.pstSymbols.find(pse_symbol->syhHandle);
 			Assert(it_handle != fsFile.pstSymbols.setHandle.end());
 			fsFile.pstSymbols.setHandle.erase(it_handle);
 
@@ -453,7 +453,7 @@ bool CFileIO::bDelete(const char* str_name)
 bool CFileIO::bDelete(TSymbolHandle syh_handle)
 {
 	// Lookup the symbol by handle.
-	set<SSymbolEntry*, SSymbolHandleLess>::iterator it_handle = fsFile.pstSymbols.find(syh_handle);
+	std::set<SSymbolEntry*, SSymbolHandleLess>::iterator it_handle = fsFile.pstSymbols.find(syh_handle);
 
 	// Was the symbol found?
 	if (it_handle != fsFile.pstSymbols.setHandle.end())
@@ -467,7 +467,7 @@ bool CFileIO::bDelete(TSymbolHandle syh_handle)
 			fsFile.pstSymbols.setHandle.erase(it_handle);
 
 			// Remove it from the name set as well.
-			set<SSymbolEntry*, SSymbolNameLess>::iterator it_name = fsFile.pstSymbols.find(pse_symbol->strName);
+			std::set<SSymbolEntry*, SSymbolNameLess>::iterator it_name = fsFile.pstSymbols.find(pse_symbol->strName);
 			Assert(it_name != fsFile.pstSymbols.setName.end());
 			fsFile.pstSymbols.setName.erase(it_name);
 
@@ -507,7 +507,7 @@ bool CFileIO::bDelete(TSymbolHandle syh_handle)
 TSymbolHandle CFileIO::syhLookup(const char* str_name)
 {
 	// Lookup the symbol by name.
-	set<SSymbolEntry*, SSymbolNameLess>::iterator it_name = fsFile.pstSymbols.find(str_name);
+	std::set<SSymbolEntry*, SSymbolNameLess>::iterator it_name = fsFile.pstSymbols.find(str_name);
 
 	// Was the symbol found?
 	if (it_name != fsFile.pstSymbols.setName.end())
@@ -569,7 +569,7 @@ TSectionHandle CFileIO::sehLookup(const char* str_name)
 const char* CFileIO::strLookup(TSymbolHandle syh_handle)
 {
 	// Lookup the symbol by handle.
-	set<SSymbolEntry*, SSymbolHandleLess>::iterator it_handle = fsFile.pstSymbols.find(syh_handle);
+	std::set<SSymbolEntry*, SSymbolHandleLess>::iterator it_handle = fsFile.pstSymbols.find(syh_handle);
 
 	// Was the symbol found?
 	if (it_handle != fsFile.pstSymbols.setHandle.end())
@@ -814,7 +814,7 @@ bool CFileIO::bWriteImage()
 	if (!fsFile.pstSymbols.empty())
 	{
 		// Calculate the size of the symbol table.
-		set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
+		std::set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
 		while (it != fsFile.pstSymbols.setName.end())
 		{
 			// Count the amount of information.
@@ -882,7 +882,7 @@ bool CFileIO::bWriteImage()
 	if (!fsFile.pstSymbols.empty())
 	{
 		// Calculate the size of the symbol table.
-		set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
+		std::set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
 		while (it != fsFile.pstSymbols.setName.end())
 		{
 			// Write out the symbol entry information.
@@ -1114,7 +1114,7 @@ bool CFileIO::bDeleteImage()
 	}
 
 	// Loop through the symbol table an delete all the symbol entries.
-	set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
+	std::set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
 	while (it != fsFile.pstSymbols.setName.end())
 	{
 		// Delete the symbol name and symbol entry.
@@ -1895,7 +1895,7 @@ void CFileIO::Dump()
 	else
 	{
 		// Begin dumping the symbol table.
-		set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
+		std::set<SSymbolEntry*, SSymbolNameLess>::iterator it = fsFile.pstSymbols.setName.begin();
 		while (it != fsFile.pstSymbols.setName.end())
 		{
 			// Dump the symbol information to the logfile.

--- a/jp2_pc/Source/Lib/Groff/FileIO.hpp
+++ b/jp2_pc/Source/Lib/Groff/FileIO.hpp
@@ -52,8 +52,8 @@
 #undef min
 #undef max
 
-#include <vector.h>
-#include <set.h>
+#include <vector>
+#include <set>
 
 #ifndef PFNWORLDLOADNOTIFY
 typedef uint32 (__stdcall * PFNWORLDLOADNOTIFY)(uint32 dwContext, uint32 dwParam1, uint32 dwParam2, uint32 dwParam3);
@@ -249,8 +249,8 @@ public:
 struct SSymbolTable
 // Prefix: st
 {
-	set<SSymbolEntry*, SSymbolHandleLess>	setHandle;		// Set sorted by handle.
-	set<SSymbolEntry*, SSymbolNameLess>		setName;		// Set sorted by name.
+	std::set<SSymbolEntry*, SSymbolHandleLess>	setHandle;		// Set sorted by handle.
+	std::set<SSymbolEntry*, SSymbolNameLess>		setName;		// Set sorted by name.
 
 	// Insert symbol.
 	void insert(SSymbolEntry* pse_symbol)
@@ -266,7 +266,7 @@ struct SSymbolTable
 	}
 
 	// Find string.
-	set<SSymbolEntry*, SSymbolNameLess>::iterator find(const char* str_name)
+	std::set<SSymbolEntry*, SSymbolNameLess>::iterator find(const char* str_name)
 	{
 		SSymbolEntry se_temp;
 
@@ -279,7 +279,7 @@ struct SSymbolTable
 	}
 
 	// Find handle.
-	set<SSymbolEntry*, SSymbolHandleLess>::iterator find(TSymbolHandle syh_handle)
+	std::set<SSymbolEntry*, SSymbolHandleLess>::iterator find(TSymbolHandle syh_handle)
 	{
 		SSymbolEntry se_temp;
 
@@ -320,7 +320,7 @@ struct SFileStructure
 // Prefix: fs
 {
 	SFileHeader			 fhHeader;		// The file header.
-	vector<SSectionList> slSections;	// A list of all the sections.
+	std::vector<SSectionList> slSections;	// A list of all the sections.
 	SSymbolTable		 pstSymbols;	// A list of all the symbols.
 	int					 fdFile;		// Define a handle to the file using streams.
 	EOpenModes			 omOpenMode;	// In what mode was the file opened?

--- a/jp2_pc/Source/Lib/Groff/ObjectHandle.cpp
+++ b/jp2_pc/Source/Lib/Groff/ObjectHandle.cpp
@@ -59,7 +59,7 @@ uint			 	 CHandleManager::uClassCount = 0;
 uint				 CHandleManager::uHandleBase = 0;
 
 // Setup the STL list for tracking the object handle records for each registered handle class.
-deque<CObjectHandle> CHandleManager::aobjhObjectHandle;
+std::deque<CObjectHandle> CHandleManager::aobjhObjectHandle;
 
 
 //******************************************************************************************
@@ -238,18 +238,18 @@ CHandle& CHandle::operator-=
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&		os_stream, 
+	std::ostream&		os_stream,
 	const CHandle&	h_handle
 )
 {
 	// Display the string.
-	os_stream.setf(ios::uppercase|ios::hex);
+	os_stream.setf(std::ios::uppercase| std::ios::hex);
 
 #if 1
-	os_stream << "h<" << h_handle.uHandleID << "#" << dec
-		<< h_handle.uReferenceCount << ">" << flush;
+	os_stream << "h<" << h_handle.uHandleID << "#" << std::dec
+		<< h_handle.uReferenceCount << ">" << std::flush;
 #else
 	cout << "CHandle(0x" << h_handle.uHandleID << ", " << dec << flush;
 	cout << h_handle.uReferenceCount << ")" << flush;
@@ -262,17 +262,17 @@ ostream& operator<<
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream& is_stream,
+	std::istream& is_stream,
 	CHandle& h_handle
 )
 {
 	// Display the string.
-	cout << "CHandle...\nHandle: " << flush;
-	cin >> hex >> h_handle.uHandleID;
-	cout << "Ref Count: " << flush;
-	cin >> dec >> h_handle.uReferenceCount;
+	std::cout << "CHandle...\nHandle: " << std::flush;
+	std::cin >> std::hex >> h_handle.uHandleID;
+	std::cout << "Ref Count: " << std::flush;
+	std::cin >> std::dec >> h_handle.uReferenceCount;
 
 	return is_stream;
 }
@@ -409,26 +409,26 @@ CObjectHandle& CObjectHandle::operator=
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&			 os_stream, 
+	std::ostream&			 os_stream,
 	const CObjectHandle& objh_handle
 )
 {
 	// Display the string.
-	os_stream.setf(ios::uppercase|ios::hex);
-	os_stream << "CObjectHandle(\"" << objh_handle.estrClassName << "\", Base:" << hex
+	os_stream.setf(std::ios::uppercase| std::ios::hex);
+	os_stream << "CObjectHandle(\"" << objh_handle.estrClassName << "\", Base:" << std::hex
 		<< objh_handle.uHandleBase << ", Next:" << objh_handle.uNextHandle << ", #" 
-		<< dec << objh_handle.uHandleCount;
+		<< std::dec << objh_handle.uHandleCount;
 
 	// Is this handle in use?
 	if (objh_handle.bInUse)
 	{
-		cout << ", Busy)";
+		std::cout << ", Busy)";
 	}
 	else
 	{
-		cout << ", Free)";
+		std::cout << ", Free)";
 	}
 
 	// Return the stream.
@@ -438,24 +438,24 @@ ostream& operator<<
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&		is_stream,
+	std::istream&		is_stream,
 	CObjectHandle&	objh_handle
 )
 {
 	// Display the string.
-	cout << "CObjectHandle...\n" << flush;
-	cin >> objh_handle.estrClassName;
+	std::cout << "CObjectHandle...\n" << std::flush;
+	std::cin >> objh_handle.estrClassName;
 
-	cout << "Base: 0x" << flush;
-	cin >> hex >> objh_handle.uHandleBase;
+	std::cout << "Base: 0x" << std::flush;
+	std::cin >> std::hex >> objh_handle.uHandleBase;
 
-	cout << "Next: 0x" << flush;
-	cin >> objh_handle.uNextHandle;
+	std::cout << "Next: 0x" << std::flush;
+	std::cin >> objh_handle.uNextHandle;
 
-	cout << "Count: " << flush;
-	cin >> dec >> objh_handle.uHandleCount;
+	std::cout << "Count: " << std::flush;
+	std::cin >> std::dec >> objh_handle.uHandleCount;
 
 	return is_stream;
 }
@@ -620,15 +620,15 @@ uint CObjectHandle::uRead
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&			  os_stream, 
+	std::ostream&			  os_stream,
 	const CHandleManager& hmgr_handle
 )
 {
 	// Display the string.
-	return os_stream << "CHandleManager(Count: " << hmgr_handle.uClassCount << hex << ", Base: 0x" 
-		<< hmgr_handle.uHandleBase << ")" << dec;
+	return os_stream << "CHandleManager(Count: " << hmgr_handle.uClassCount << std::hex << ", Base: 0x"
+		<< hmgr_handle.uHandleBase << ")" << std::dec;
 }
 
 
@@ -702,7 +702,7 @@ bool CHandleManager::bDelete
 	const CEasyString& estr_classname
 )
 {
-	deque<CObjectHandle>::iterator i = aobjhObjectHandle.begin();
+	std::deque<CObjectHandle>::iterator i = aobjhObjectHandle.begin();
 
 	// Look through the list to make sure the Search the list to see if the class is active.
 	for (; i != aobjhObjectHandle.end(); i++)
@@ -825,15 +825,15 @@ void CHandleManager::Dump
 )
 {
 	// Display the banner.
-	cout << *this << endl;
+	std::cout << *this << std::endl;
 
 	// Loop through each of the entries.
 	for (uint u_index = 0; u_index < aobjhObjectHandle.size(); u_index++)
 	{
 		// Dump the handle entry records.
-		cout << "Object Handle(" << dec << u_index << "), " << aobjhObjectHandle[u_index] << endl;
+		std::cout << "Object Handle(" << std::dec << u_index << "), " << aobjhObjectHandle[u_index] << std::endl;
 	}
 
 	// Add a carriage return and spill the output to the console.
-	cout << endl;
+	std::cout << std::endl;
 }

--- a/jp2_pc/Source/Lib/Groff/ObjectHandle.hpp
+++ b/jp2_pc/Source/Lib/Groff/ObjectHandle.hpp
@@ -46,7 +46,7 @@
 #ifndef HEADER_LIB_GROFF_OBJECTHANDLE_HPP
 #define HEADER_LIB_GROFF_OBJECTHANDLE_HPP
 
-#include <iostream.h>
+#include <iostream>
 
 //
 // Disable a number of annoying warning messages about symbol truncation, and unsigned
@@ -57,8 +57,8 @@
 #pragma warning(disable: 4146)
 #pragma warning(disable: 4786)
 
-#include <map.h>
-#include <deque.h>
+#include <map>
+#include <deque>
 
 //
 // Determine which set of standard types to use based upon the environment.  This is done to
@@ -220,18 +220,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&		os_stream, 
+		std::ostream&	os_stream,
 		const CHandle&	h_handle
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream& is_stream,
+		std::istream& is_stream,
 		CHandle& h_handle
 	);
 
@@ -324,18 +324,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&			 os_stream, 
+		std::ostream&		 os_stream,
 		const CObjectHandle& objh_handle
 	);
 
 
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&		is_stream,
+		std::istream&	is_stream,
 		CObjectHandle&	objh_handle
 	);
 
@@ -420,15 +420,15 @@ class CHandleManager
 {
 	static uint					uClassCount;
 	static uint					uHandleBase;
-	static deque<CObjectHandle>	aobjhObjectHandle;
+	static std::deque<CObjectHandle>	aobjhObjectHandle;
 
 public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&			  os_stream, 
+		std::ostream&		  os_stream,
 		const CHandleManager& hmgr_handle
 	);
 

--- a/jp2_pc/Source/Lib/Groff/SymbolTable.cpp
+++ b/jp2_pc/Source/Lib/Groff/SymbolTable.cpp
@@ -30,8 +30,8 @@
  *
  **********************************************************************************************/
 
-#include <iostream.h>
-#include <iomanip.h>
+#include <iostream>
+#include <iomanip>
 
 //
 // Disable a number of annoying warning messages about symbol truncation, and unsigned
@@ -42,8 +42,8 @@
 #pragma warning(disable: 4146)
 #pragma warning(disable: 4786)
 
-#include <map.h>
-#include <deque.h>
+#include <map>
+#include <deque>
 
 //
 // Determine which set of standard types to use based upon the environment.  This is done to
@@ -101,9 +101,9 @@ CSymbolEntry& CSymbolEntry::operator=
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&			os_stream, 
+	std::ostream&		os_stream,
 	const CSymbolEntry&	se_symbol
 )
 {
@@ -114,17 +114,17 @@ ostream& operator<<
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&	  is_stream,
+	std::istream& is_stream,
 	CSymbolEntry& se_symbol
 )
 {
 	// Display the string.
-	cout << "CSymbolEntry...\nCEasyString: " << flush; 
-	cin >> se_symbol.estrSymbolName;
-	cin >> hex >> se_symbol.hSymbolHandle;
-	cin.setf(ios::dec);
+	std::cout << "CSymbolEntry...\nCEasyString: " << std::flush;
+	std::cin >> se_symbol.estrSymbolName;
+	std::cin >> std::hex >> se_symbol.hSymbolHandle;
+	std::cin.setf(std::ios::dec);
 
 	return is_stream;
 }
@@ -313,7 +313,7 @@ void CSymbolEntry::Dump
 )
 {
 	// Dump the CHandle to stdout.
-	cout << *this << endl;
+	std::cout << *this << std::endl;
 }
 
 
@@ -587,7 +587,7 @@ uint CNewSymbolTable::uRead
 			else
 			{
 				// No! Assertion!  Report a big error.
-				cout << "Unable to add symbol to list.  Aborting.";
+				std::cout << "Unable to add symbol to list.  Aborting.";
 
 				// Halt the program in a user break point.
 				_asm
@@ -609,14 +609,14 @@ uint CNewSymbolTable::uRead
 void CNewSymbolTable::Dump()
 {
 	// Print out a banner.
-	cout << "\nCNewSymbolTable(Name: \"" << estrTableName << "\", Count: " << (int) aseSymbolTable.size() << ")\n{";
+	std::cout << "\nCNewSymbolTable(Name: \"" << estrTableName << "\", Count: " << (int) aseSymbolTable.size() << ")\n{";
 
 	// Dump the table.
 	for (uint u_index = 0; u_index < aseSymbolTable.size(); u_index++)
 	{
 		// Get a local copy of the symbol entry.
-		cout << endl << setw(4) << u_index << ": " << aseSymbolTable[u_index];
+		std::cout << std::endl << std::setw(4) << u_index << ": " << aseSymbolTable[u_index];
 	}
 
-	cout << "\n}" << endl;
+	std::cout << "\n}" << std::endl;
 }

--- a/jp2_pc/Source/Lib/Groff/SymbolTable.hpp
+++ b/jp2_pc/Source/Lib/Groff/SymbolTable.hpp
@@ -37,8 +37,8 @@
 #ifndef HEADER_LIB_GROFF_SYMBOLTABLE_HPP
 #define HEADER_LIB_GROFF_SYMBOLTABLE_HPP
 
-#include <iostream.h>
-#include <iomanip.h>
+#include <iostream>
+#include <iomanip>
 
 //
 // Disable a number of annoying warning messages about symbol truncation, and unsigned
@@ -49,8 +49,8 @@
 #pragma warning(disable: 4146)
 #pragma warning(disable: 4786)
 
-#include <map.h>
-#include <deque.h>
+#include <map>
+#include <deque>
 
 //
 // Determine which set of standard types to use based upon the environment.  This is done to
@@ -108,18 +108,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&			os_stream, 
+		std::ostream&		os_stream,
 		const CSymbolEntry&	se_symbol
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&	  is_stream,
+		std::istream& is_stream,
 		CSymbolEntry& se_symbol
 	);
 
@@ -239,14 +239,14 @@ class CNewSymbolTable
 	CEasyString												estrTableName;
 
 	// Fast associative access to the symbol entry information.
-	map< CEasyString, CSymbolEntry*, less<CEasyString> >	asiSymbolIndex;
+	std::map< CEasyString, CSymbolEntry*, std::less<CEasyString> >	asiSymbolIndex;
 
 	// Fast associative access to the element through this type. 
-	map< CHandle, CSymbolEntry*, less<CHandle> >			asiHandleIndex;
+	std::map< CHandle, CSymbolEntry*, std::less<CHandle> >			asiHandleIndex;
 
 public:   // Need access to verify validity of loaded value table.
 	// Storage container for the element type.
-	deque<CSymbolEntry>										aseSymbolTable; 
+	std::deque<CSymbolEntry>										aseSymbolTable;
 
 public:
 

--- a/jp2_pc/Source/Lib/Groff/ValueTable.cpp
+++ b/jp2_pc/Source/Lib/Groff/ValueTable.cpp
@@ -57,10 +57,10 @@
 #pragma warning(disable: 4146)
 #pragma warning(disable: 4786)
 
-#include <iostream.h>
-#include <iomanip.h>
-#include <map.h>
-#include <deque.h>
+#include <iostream>
+#include <iomanip>
+#include <map>
+#include <deque>
 
 //
 // Determine which set of standard types to use based upon the environment.  This is done to
@@ -286,19 +286,19 @@ const EVarScope CBaseValue::evsScope
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&			os_stream, 
+	std::ostream&			os_stream,
 	const CBaseValue&	basev_value
 )
 {
 	// Display the string.
-	os_stream.setf(ios::uppercase|ios::hex);
+	os_stream.setf(std::ios::uppercase| std::ios::hex);
 
 	os_stream << "basev(val" << basev_value.hValueHandle << ", sym" 
 		<< basev_value.hSymbolHandle << ", " << strVarType[basev_value.evtVarType] << ", " 
 		<< strVarScope[basev_value.evsVarScope] << ", target" << basev_value.hTargetHandle
-		<< ", " << strVarReference[basev_value.ersRefStatus] << ")" << dec << flush;
+		<< ", " << strVarReference[basev_value.ersRefStatus] << ")" << std::dec << std::flush;
 
 	// Return the stream.
 	return os_stream;
@@ -478,29 +478,29 @@ void CBoolValue::Value
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&		  os_stream, 
+	std::ostream&		  os_stream,
 	const CBoolValue& bval_value
 )
 {
 	// Display the string.
-	return os_stream << dec << strBoolValue[bval_value.bBoolValue] << " -> " << (CBaseValue) bval_value;
+	return os_stream << std::dec << strBoolValue[bval_value.bBoolValue] << " -> " << (CBaseValue) bval_value;
 }
 
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&	is_stream,
+	std::istream&	is_stream,
 	CBoolValue&	bval_value
 )
 {
 	int i_temp;
 
 	// Read in the string.
-	is_stream >> dec >> i_temp;
+	is_stream >> std::dec >> i_temp;
 
 	bval_value.bBoolValue = i_temp;
 
@@ -668,27 +668,27 @@ void CCharValue::Value
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&		  os_stream, 
+	std::ostream&	  os_stream,
 	const CCharValue& cval_value
 )
 {
 	// Display the string.
-	return os_stream << dec << cval_value.cCharValue << " -> " << (CBaseValue) cval_value;
+	return os_stream << std::dec << cval_value.cCharValue << " -> " << (CBaseValue) cval_value;
 }
 
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&	is_stream,
+	std::istream&	is_stream,
 	CCharValue&	cval_value
 )
 {
 	// Read in the string.
-	is_stream >> dec >> cval_value.cCharValue;
+	is_stream >> std::dec >> cval_value.cCharValue;
 
 	// Pass the input stream along.
 	return is_stream;
@@ -854,27 +854,27 @@ void CIntValue::Value
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&		 os_stream, 
+	std::ostream&	 os_stream,
 	const CIntValue& ival_value
 )
 {
 	// Display the string.
-	return os_stream << dec << ival_value.iIntValue << " -> " << (CBaseValue) ival_value;
+	return os_stream << std::dec << ival_value.iIntValue << " -> " << (CBaseValue) ival_value;
 }
 
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&	is_stream,
+	std::istream&	is_stream,
 	CIntValue&	ival_value
 )
 {
 	// Read in the string.
-	is_stream >> dec >> ival_value.iIntValue;
+	is_stream >> std::dec >> ival_value.iIntValue;
 
 	// Pass the input stream along.
 	return is_stream;
@@ -1040,9 +1040,9 @@ void CFloatValue::Value
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&			os_stream, 
+	std::ostream&			os_stream,
 	const CFloatValue&	fval_value
 )
 {
@@ -1053,9 +1053,9 @@ ostream& operator<<
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&		is_stream,
+	std::istream&	is_stream,
 	CFloatValue&	fval_value
 )
 {
@@ -1224,9 +1224,9 @@ void CStringValue::Value
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&		    os_stream, 
+	std::ostream&		os_stream,
 	const CStringValue& sval_value
 )
 {
@@ -1237,9 +1237,9 @@ ostream& operator<<
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&	  is_stream,
+	std::istream& is_stream,
 	CStringValue& sval_value
 )
 {
@@ -1415,9 +1415,9 @@ CObjectValue& CObjectValue::operator=
 
 //**********************************************************************************************
 //
-ostream& operator<<
+std::ostream& operator<<
 (
-	ostream&		os_stream, 
+	std::ostream&		os_stream,
 	CObjectValue&	oval_value
 )
 {
@@ -1437,9 +1437,9 @@ ostream& operator<<
 
 //**********************************************************************************************
 //
-istream& operator>>
+std::istream& operator>>
 (
-	istream&	 is_stream,
+	std::istream&	 is_stream,
 	CObjectValue& estr_string
 )
 {
@@ -1563,7 +1563,7 @@ CValueTable::~CValueTable
 	}
 
 	// Clean up all those value table values.
-	map< CHandle, CBaseValue*, less<CHandle> >::iterator i = aviValueIndex.begin();
+	std::map< CHandle, CBaseValue*, std::less<CHandle> >::iterator i = aviValueIndex.begin();
 	for ( ; i != aviValueIndex.end(); i++)
 	{
 		delete (*i).second;
@@ -1651,7 +1651,7 @@ uint CValueTable::uWriteCount
 	u_count += sizeof(uint);
 
 	// Loop through all the value records and records their amounts.
-	map< CHandle, CBaseValue*, less<CHandle> >::iterator i;
+	std::map< CHandle, CBaseValue*, std::less<CHandle> >::iterator i;
 	for (i = aviValueIndex.begin(); i != aviValueIndex.end(); i++)
 	{
 		//
@@ -1701,7 +1701,7 @@ uint CValueTable::uWrite
 
 	// Loop through all the value records and remove any degenerate records.
 	uint u_record_count = 0;
-	map< CHandle, CBaseValue*, less<CHandle> >::iterator i;
+	std::map< CHandle, CBaseValue*, std::less<CHandle> >::iterator i;
 	for (i = aviValueIndex.begin(); i != aviValueIndex.end(); i++)
 	{
 		//
@@ -1867,18 +1867,18 @@ void CValueTable::Dump
 )
 {
 	// Print out a banner.
-	cout << "CValueTable(\"" << estrValueName << "\", hobj:" << objhHandle << endl;
+	std::cout << "CValueTable(\"" << estrValueName << "\", hobj:" << objhHandle << std::endl;
 
 	// Dump the symbol table.
 	CNewSymbolTable::Dump();
 
 	// Are there any entries in the value table?
 
-	cout << "\nValue table entries: " << aviValueIndex.size() << endl;
+	std::cout << "\nValue table entries: " << aviValueIndex.size() << std::endl;
 
 	// Dump the value table.
 	uint u_index;
-	map< CHandle, CBaseValue*, less<CHandle> >::iterator i;
+	std::map< CHandle, CBaseValue*, std::less<CHandle> >::iterator i;
 	for (u_index = 0, i = aviValueIndex.begin(); i != aviValueIndex.end(); i++, u_index++)
 	{
 		// Get a local copy of the symbol entry.
@@ -1892,38 +1892,38 @@ void CValueTable::Dump
 			{
 				case evtBOOL:
 					// Allocate and integer value record.
-					cout << setw(4) << u_index << ": " << *((CBoolValue *) pbasev_value) << endl;
+					std::cout << std::setw(4) << u_index << ": " << *((CBoolValue *) pbasev_value) << std::endl;
 
 					break;
 
 				case evtCHAR:
 					// Allocate and integer value record.
-					cout << setw(4) << u_index << ": " << *((CCharValue *) pbasev_value) << endl;
+					std::cout << std::setw(4) << u_index << ": " << *((CCharValue *) pbasev_value) << std::endl;
 
 					break;
 
 				case evtINT:
 					
 					// Allocate and integer value record.
-					cout << setw(4) << u_index << ": " << *((CIntValue *) pbasev_value) << endl;
+					std::cout << std::setw(4) << u_index << ": " << *((CIntValue *) pbasev_value) << std::endl;
 
 					break;
 
 				case evtFLOAT:
 					// Allocate and integer value record.
-					cout << setw(4) << u_index << ": " << *((CFloatValue *) pbasev_value) << endl;
+					std::cout << std::setw(4) << u_index << ": " << *((CFloatValue *) pbasev_value) << std::endl;
 
 					break;
 
 				case evtSTRING:
 					// Allocate and integer value record.
-					cout << setw(4) << u_index << ": " << *((CStringValue *) pbasev_value) << endl;
+					std::cout << std::setw(4) << u_index << ": " << *((CStringValue *) pbasev_value) << std::endl;
 
 					break;
 
 				case evtOBJECT:
 					// Allocate and integer value record.
-					cout << setw(4) << u_index << ": " << *((CObjectValue *) pbasev_value) << endl;
+					std::cout << std::setw(4) << u_index << ": " << *((CObjectValue *) pbasev_value) << std::endl;
 
 					break;
 
@@ -1934,5 +1934,5 @@ void CValueTable::Dump
 	}
 
 	// Close off the opening banner.
-	cout << ")\n" << endl;
+	std::cout << ")\n" << std::endl;
 }

--- a/jp2_pc/Source/Lib/Groff/ValueTable.hpp
+++ b/jp2_pc/Source/Lib/Groff/ValueTable.hpp
@@ -66,10 +66,10 @@
 #pragma warning(disable: 4146)
 #pragma warning(disable: 4786)
 
-#include <iostream.h>
-#include <iomanip.h>
-#include <map.h>
-#include <deque.h>
+#include <iostream>
+#include <iomanip>
+#include <map>
+#include <deque>
 
 //
 // Determine which set of standard types to use based upon the environment.  This is done to
@@ -280,9 +280,9 @@ public:
 	
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&			os_stream, 
+		std::ostream&		os_stream,
 		const CBaseValue&	basev_value
 	);
 
@@ -388,18 +388,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&		  os_stream, 
+		std::ostream&	  os_stream,
 		const CBoolValue& bval_value
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&	is_stream,
+		std::istream&	is_stream,
 		CBoolValue&	bval_value
 	);
 
@@ -503,18 +503,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&		  os_stream, 
+		std::ostream&	  os_stream,
 		const CCharValue& cval_value
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&	is_stream,
+		std::istream&	is_stream,
 		CCharValue&	cval_value
 	);
 
@@ -617,18 +617,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&		 os_stream, 
+		std::ostream&	 os_stream,
 		const CIntValue& ival_value
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&	is_stream,
+		std::istream&	is_stream,
 		CIntValue&	ival_value
 	);
 
@@ -731,18 +731,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&			os_stream, 
+		std::ostream&		os_stream,
 		const CFloatValue&	fval_value
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&		is_stream,
+		std::istream&	is_stream,
 		CFloatValue&	fval_value
 	);
 
@@ -845,18 +845,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&		    os_stream, 
+		std::ostream&		os_stream,
 		const CStringValue& sval_value
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&	  is_stream,
+		std::istream& is_stream,
 		CStringValue& sval_value
 	);
 
@@ -1069,18 +1069,18 @@ public:
 
 	//**********************************************************************************************
 	//
-	friend ostream& operator<<
+	friend std::ostream& operator<<
 	(
-		ostream&		os_stream, 
+		std::ostream&	os_stream,
 		CObjectValue&	oval_value
 	);
 
 	
 	//**********************************************************************************************
 	//
-	friend istream& operator>>
+	friend std::istream& operator>>
 	(
-		istream&	 is_stream,
+		std::istream& is_stream,
 		CObjectValue& estr_string
 	);
 
@@ -1121,7 +1121,7 @@ class CValueTable : public CNewSymbolTable
 	CHandleManager								hmgrManager;
 
 	// Provide fast access to the value record through it's handle. 
-	map< CHandle, CBaseValue*, less<CHandle> >	aviValueIndex;
+	std::map< CHandle, CBaseValue*, std::less<CHandle> >	aviValueIndex;
 
 public:
 

--- a/jp2_pc/Source/Lib/Loader/ImageLoader.cpp
+++ b/jp2_pc/Source/Lib/Loader/ImageLoader.cpp
@@ -395,7 +395,7 @@ CLoadImageDirectory::~CLoadImageDirectory
 	// raster should reference one of these palettes. All rasters should have created their
 	// own palettes.
 
-	for (vector<CPal*>::iterator i = appal.begin(); i<appal.end(); ++i)
+	for (std::vector<CPal*>::iterator i = appal.begin(); i<appal.end(); ++i)
 	{
 		delete (*i);
 	}
@@ -573,7 +573,7 @@ bool CLoadImageDirectory::bProcessLocalSwapFile
 	// Before we copy local ensure that we have not reached our quota for used disk space
 	char					str_wildcard[MAX_PATH];
 	_finddata_t				fnd;
-	vector<SDiskSwapFile>	vdsf;
+	std::vector<SDiskSwapFile>	vdsf;
 
 	strcpy(str_wildcard,str_local_swap_dir);
 	strcat(str_wildcard,"\\*.swp");

--- a/jp2_pc/Source/Lib/Loader/ImageLoader.hpp
+++ b/jp2_pc/Source/Lib/Loader/ImageLoader.hpp
@@ -73,9 +73,9 @@
 #include "Lib/Sys/MemoryLog.hpp"
 #include "Lib/View/Colour.hpp"
 #include "Lib/View/Palette.hpp"
-#include "vector.h"
-#include "map.h"
-#include "set.h"
+#include <vector>
+#include <map>
+#include <set>
 
 
 //**********************************************************************************************
@@ -176,8 +176,8 @@ public:
 	static bool							bCompressed;
 	static bool							bNewCompression;
 
-	map<uint64,SDirectoryFileChunk*,less<uint64> >	mapChunk;
-	vector<CPal*>									appal;
+	std::map<uint64,SDirectoryFileChunk*, std::less<uint64> >	mapChunk;
+	std::vector<CPal*>									appal;
 	char											strLocalImage[264];
 	char											strSourceImage[264];
 	uint64											u8SourceImageTime;

--- a/jp2_pc/Source/Lib/Loader/LoadTexture.cpp
+++ b/jp2_pc/Source/Lib/Loader/LoadTexture.cpp
@@ -127,8 +127,8 @@
 #include "Lib/Sys/DebugConsole.hpp"
 #include "Lib/Std/stringex.hpp"
 #include "Lib/Std/hash.hpp"
-#include "map.h"
-#include <bstring.h>
+#include <map>
+#include <string>
 
 #include "Lib/Sys/Profile.hpp"
 
@@ -155,7 +155,7 @@ const char* strTEXTURE_OCCLUDE   = "Soccludet2.bmp";
 // String to bitmap instancer map.
 // Since this is a map of rptrs, all objects will be deleted properly upon the map's destruction.
 //
-typedef map< uint32, rptr<CTexture>, less<uint32> > TMapTexture;
+typedef std::map< uint32, rptr<CTexture>, std::less<uint32> > TMapTexture;
 TMapTexture mapTextures;
 
 
@@ -189,7 +189,7 @@ static rptr<CRaster> prasGetBitmap
 	if (!pras)
 	{
 		// Try ignoring leading path components.
-		char* str_new;
+		const char* str_new;
 
 		while (str_new = strpbrk(str_filename, ":/\\"))
 		{

--- a/jp2_pc/Source/Lib/Loader/Loader.cpp
+++ b/jp2_pc/Source/Lib/Loader/Loader.cpp
@@ -135,7 +135,7 @@
 #include "Game/AI/ActivityEnum.hpp"
 #include "Lib/EntityDBase/MessageTypes/MsgSystem.hpp"
 
-#include "map.h"
+#include <map>
 
 #include <string.h>
 #include <direct.h>
@@ -165,7 +165,7 @@ THREE:	All magnets and triggers
 // Module variables.
 //
 
-map<uint32, SMeshInstance, less<uint32> > mapMeshInstances;
+std::map<uint32, SMeshInstance, std::less<uint32> > mapMeshInstances;
 float fDefaultBumpiness = 0.025f;
 
 
@@ -710,7 +710,7 @@ CProfileStat psBumpPack("Bumpmap pack", &psLoader);
 
 		dout << "Total unique meshes: " << mapMeshInstances.size() << "\n";
 
-		map<uint32, SMeshInstance, less<uint32> >::iterator i;
+		std::map<uint32, SMeshInstance, std::less<uint32> >::iterator i;
 
 		while(!b_done)
 		{
@@ -732,7 +732,7 @@ CProfileStat psBumpPack("Bumpmap pack", &psLoader);
 
 		dout << "Discarded Meshes: " << i_discarded_meshes << "\n";
 
-		extern map< uint32, rptr<CTexture>, less<uint32> > mapTextures;
+		extern std::map< uint32, rptr<CTexture>, std::less<uint32> > mapTextures;
 		dout << "Total unique textures: " << mapTextures.size() << "\n";
 		
 		// Write the names of the loaded textures.
@@ -740,7 +740,7 @@ CProfileStat psBumpPack("Bumpmap pack", &psLoader);
 		
 		int i_discarded_textures = 0;
 
-		map< uint32, rptr<CTexture>, less<uint32> >::iterator i_tex;
+		std::map< uint32, rptr<CTexture>, std::less<uint32> >::iterator i_tex;
 		b_done = false;
 		
 		while(!b_done)

--- a/jp2_pc/Source/Lib/Loader/PlatonicInstance.cpp
+++ b/jp2_pc/Source/Lib/Loader/PlatonicInstance.cpp
@@ -118,7 +118,7 @@ void AddToIdealList
 #ifdef __MWERKS__
 	tmPlatonicIdeal.insert(pair<const uint32, const CInstance*>(u4_hash, pins));
 #else
-	tmPlatonicIdeal.insert(pair<uint32, const CInstance*>(u4_hash, pins));
+	tmPlatonicIdeal.insert(std::pair<uint32, const CInstance*>(u4_hash, pins));
 #endif
 	MEMLOG_SET_COUNTER(emlUniqueInstances, tmPlatonicIdeal.size() );
 }

--- a/jp2_pc/Source/Lib/Loader/PlatonicInstance.hpp
+++ b/jp2_pc/Source/Lib/Loader/PlatonicInstance.hpp
@@ -46,8 +46,8 @@
 #define HEADER_GUIAPP_LOADER_PLATONICINSTANCE_HPP
 
 
-#include <map.h>
-#include <bstring.h>
+#include <map>
+#include <string>
 
 class CInstance;
 
@@ -102,7 +102,7 @@ void RemoveFromIdealList
 //
 //**************************************
 
-typedef map<uint32, const CInstance*, less<uint32> >	TMapHashPins;
+typedef std::map<uint32, const CInstance*, std::less<uint32> >	TMapHashPins;
 
 
 //

--- a/jp2_pc/Source/Lib/Loader/SaveFile.cpp
+++ b/jp2_pc/Source/Lib/Loader/SaveFile.cpp
@@ -176,7 +176,7 @@ int iAnimalVersion = -1;
 
 		if (shHeader.iVersion < iLATEST_SAVE_VERSION)
 			dout <<"Warning: Scene file is version " <<shHeader.iVersion
-				 <<", latest version is " <<iLATEST_SAVE_VERSION <<endl;
+				 <<", latest version is " <<iLATEST_SAVE_VERSION << std::endl;
 
 		// Put the animal version somewhere that animals can find it.
 		iAnimalVersion = shHeader.iAnimalVersion;
@@ -295,7 +295,7 @@ int iAnimalVersion = -1;
 		Assert(!bRead);
 
 		// Make sure that we don't already have one of these!  Assert that the insertion is successful.
-		pair < set <uint32, less<uint32> >::iterator, bool > p = setHandles.insert(pins->u4GetUniqueHandle());
+		std::pair < std::set <uint32, std::less<uint32> >::iterator, bool > p = setHandles.insert(pins->u4GetUniqueHandle());
 		Assert(p.second);
 
 

--- a/jp2_pc/Source/Lib/Loader/SaveFile.hpp
+++ b/jp2_pc/Source/Lib/Loader/SaveFile.hpp
@@ -82,7 +82,7 @@
 #include "SaveBuffer.hpp"
 #include "Lib/GROFF/FileIO.hpp"
 #include "Lib/Sys/Timer.hpp"
-#include <set.h>
+#include <set>
 
 class CInstance;
 
@@ -134,7 +134,7 @@ public:
 	CFileIO			fioFile;	// The file for saving/loading.
 	bool			bValidFile;	// True if the file is valid.
 
-	set<uint32, less<uint32> > setHandles;	// The handles of instances that have been saved or loaded.
+	std::set<uint32, std::less<uint32> > setHandles;	// The handles of instances that have been saved or loaded.
 
 
 	static bool		bBrief;		// True if we are to conserve space.

--- a/jp2_pc/Source/Lib/Loader/TextureManager.hpp
+++ b/jp2_pc/Source/Lib/Loader/TextureManager.hpp
@@ -79,9 +79,9 @@
 #include "Lib/Renderer/Texture.hpp"
 #include "Lib/View/Colour.hpp"
 #include "Lib/Groff/EasyString.hpp"
-#include "vector.h"
-#include "map.h"
-#include "set.h"
+#include <vector>
+#include <map>
+#include <set>
 
 
 #define MAX_TEXTURE_PAGES			1024			//64 megs of source textures for the time being..
@@ -183,15 +183,15 @@ public:
 
 //**********************************************************************************************
 //
-typedef vector<SBumpMapListElement>		TBumpList;
+typedef std::vector<SBumpMapListElement>		TBumpList;
 
 //**********************************************************************************************
 //
-typedef vector<SVirtualImageElement>	TVirtualImageList;
+typedef std::vector<SVirtualImageElement>	TVirtualImageList;
 
 //**********************************************************************************************
 //
-typedef set<SCurvedParentElement, test_curved_parent >	TCurvedParentList;
+typedef std::set<SCurvedParentElement, test_curved_parent >	TCurvedParentList;
 
 
 //**********************************************************************************************

--- a/jp2_pc/Source/Lib/Sys/SmartBuffer.hpp
+++ b/jp2_pc/Source/Lib/Sys/SmartBuffer.hpp
@@ -34,7 +34,7 @@
 #undef min
 #undef max
 
-#include <vector.h>
+#include <vector>
 
 #ifdef USE_MAX_TYPES
 #include "StandardTypes.hpp"
@@ -73,7 +73,7 @@ class CSmartBuffer
 //*********************************************************************************************
 {
 	CSysLog			slLogfile;
-	vector<SBuffer>	bfBuffer;
+	std::vector<SBuffer>	bfBuffer;
 
 	TBufferHandle	bhToHandle(uint u_index)		  { return (0x40000000 + u_index); };
 	uint			uToIndex(TBufferHandle bh_handle) { return (bh_handle - 0x40000000); };


### PR DESCRIPTION
In the `Loader` project, the STL includes are modernized and the `std::` namespace specifier is added where necessary. 
There is also a small type adjustment in `LoadTexture.cpp`.
This is _not_ sufficient to make `Loader` compile.