### PR TITLE
Nullstream std::endl support

### DIFF
--- a/jp2_pc/Source/Lib/Sys/DebugConsole.hpp
+++ b/jp2_pc/Source/Lib/Sys/DebugConsole.hpp
@@ -143,6 +143,8 @@ extern std::ostream	dout;
 // #if VER_TEST
 #else
 
+#include <iostream>
+
 // Make null versions of the print functions.
 
 inline void dprint(const char*)
@@ -169,6 +171,12 @@ class nullstream
 template<class T> inline nullstream& operator<<(nullstream& ns, const T&)
 {
 	return ns;
+}
+
+//This overload makes it possible to use std::endl with nullstream
+inline nullstream& operator<<(nullstream& ns, decltype(std::endl<char, std::char_traits<char>>))
+{
+    return ns;
 }
 
 // The dummy debug stream.


### PR DESCRIPTION
`nullstream` is a NOP output stream, used only in the `Final` configuration for the `dout` output stream, which is otherwise used for debug information.
`dout` is often used with `std::endl`, but using `std::endl` with `nullstream` causes compiler errors.
Adding an overload to the `<<` operator resolves that problem.