### PR TITLE
CCoef comparison operators

### DIFF
--- a/jp2_pc/Source/Lib/GeomDBase/WaveletCoef.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletCoef.hpp
@@ -308,9 +308,33 @@ namespace NMultiResolution
 		}
 
 
+		forceinline bool operator !=(CCoef cf) const
+		{
+			return iCoefVal != cf.iCoefVal;
+		}
+
+
 		forceinline bool operator <(CCoef cf) const
 		{
 			return iCoefVal < cf.iCoefVal;
+		}
+
+
+		forceinline bool operator <=(CCoef cf) const
+		{
+			return iCoefVal <= cf.iCoefVal;
+		}
+
+
+		forceinline bool operator >(CCoef cf) const
+		{
+			return iCoefVal > cf.iCoefVal;
+		}
+
+
+		forceinline bool operator >=(CCoef cf) const
+		{
+			return iCoefVal >= cf.iCoefVal;
 		}
 
 


### PR DESCRIPTION
Comparison operators are used very often with `CCoef` objects, but only two of them are defined. The missing operators are _not_ implicitly generated in C++17, which causes compiler errors.
The missing operator definitions are added.