### PR TITLE
CFastHeap: missing type-conversion operator

### DIFF
--- a/jp2_pc/Source/Lib/Sys/FastHeap.hpp
+++ b/jp2_pc/Source/Lib/Sys/FastHeap.hpp
@@ -769,6 +769,13 @@ public:
 		Grow(u_len_curr - uLen);
 	};
 
+	//Hides the operator from the base class
+	//but CFastHeap has private inheritance from that class
+	//and the operator is needed often
+	operator char* () const
+	{
+		return CDArray<char>::operator char*();
+	}
 
 	friend void* operator new(uint u_size_type, CFastHeap& fh_heap);
 	friend void* operator new(uint u_size_type, CFastHeap& fh_heap, uint u_alignment);


### PR DESCRIPTION
`CFastHeap` is often implicitly converted to a pointer, but the corresponding type-conversion operator is missing, causing compiler errors. 
There is an operator definition further up in the inheritance hierarchy. But `CFastHeap` uses `private` inheritance, so users of `CFastHeap` cannot access it.
A definition of the needed type-casting operator is added.