### PR TITLE
View: STL includes, DirectX includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/View/AGPTextureMemManager.cpp
+++ b/jp2_pc/Source/Lib/View/AGPTextureMemManager.cpp
@@ -112,7 +112,7 @@
  * 
  **********************************************************************************************/
 
-#include <list.h>
+#include <list>
 #include "Common.hpp"
 #include "Lib/View/AGPTextureMemManager.hpp"
 
@@ -289,7 +289,7 @@ public:
 //
 
 // Type for maintaining a list of currently active textures.
-typedef list<CRasterWrap> TRasD3DList;
+typedef std::list<CRasterWrap> TRasD3DList;
 
 
 //

--- a/jp2_pc/Source/Lib/View/ColourBase.cpp
+++ b/jp2_pc/Source/Lib/View/ColourBase.cpp
@@ -81,7 +81,7 @@
 #include "Lib/Sys/DebugConsole.hpp"
 #include "Lib/Loader/Loader.hpp"
 
-#include <set.h>
+#include <set>
 
 extern bool bIsTrespasser;
 
@@ -225,15 +225,15 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 	CPalClutDatabase::CPalClutDatabase()
 		: pceMainPalClut(0), ppalMain(0)
 	{
-		psetPalClut = new set<class CPalClut,class CPalClutLess>;
-		psetOwnedPals = new set<class CPal*,class CPalPtrLess>;
+		psetPalClut = new std::set<class CPalClut,class CPalClutLess>;
+		psetOwnedPals = new std::set<class CPal*,class CPalPtrLess>;
 	}
 
 	//*****************************************************************************************
 	CPalClutDatabase::~CPalClutDatabase()
 	{
 		// Delete the palettes we own.
-		set<class CPal*,class CPalPtrLess>::iterator it_palptr;
+		std::set<class CPal*,class CPalPtrLess>::iterator it_palptr;
 		for (it_palptr = psetOwnedPals->begin(); it_palptr != psetOwnedPals->end(); it_palptr++)
 			delete *it_palptr;
 	
@@ -263,7 +263,7 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 		Assert(ppal);
 		Assert(pmat);
 
-		set<CPalClut, CPalClutLess>::iterator it_palclut_db;
+		std::set<CPalClut, CPalClutLess>::iterator it_palclut_db;
 
 		//
 		// Search for CPalClut in the set.
@@ -364,7 +364,7 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 		// Reset the clut count for stats.
 		psCluts.Reset();
 
-		set<CPalClut, CPalClutLess>::iterator it_palclut_db;
+		std::set<CPalClut, CPalClutLess>::iterator it_palclut_db;
 
 		// Iterate through list of palette-clut objects.
 		for (it_palclut_db = psetPalClut->begin(); it_palclut_db != psetPalClut->end(); it_palclut_db++)
@@ -393,7 +393,7 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 		// Reset the clut count for stats.
 		psCluts.Reset();
 
-		set<CPalClut, CPalClutLess>::iterator it_palclut_db;
+		std::set<CPalClut, CPalClutLess>::iterator it_palclut_db;
 
 		// Iterate through list of palette-clut objects.
 		for (it_palclut_db = psetPalClut->begin(); it_palclut_db != psetPalClut->end(); it_palclut_db++)
@@ -414,7 +414,7 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 	//*****************************************************************************************
 	CPalClut* CPalClutDatabase::ppceFindColourMatch(CColour clr, int& i_index) const
 	{
-		set<CPalClut, CPalClutLess>::iterator it_palclut_db;
+		std::set<CPalClut, CPalClutLess>::iterator it_palclut_db;
 		CPalClut* ppce_current;
 		CPalClut* ppce_best;
 		int       i_current_difference;
@@ -480,7 +480,7 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 		if (i_index < 0 || i_index >= psetPalClut->size())
 			return 0;
 
-		set<CPalClut, CPalClutLess>::iterator it_palclut_db;
+		std::set<CPalClut, CPalClutLess>::iterator it_palclut_db;
 		it_palclut_db = psetPalClut->begin();
 
 		while (i_index > 0)
@@ -498,7 +498,7 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 		AlwaysAssert(ppalMain);
 
 		// Delete the palettes we own.
-		set<class CPal*,class CPalPtrLess>::iterator it_palptr;
+		std::set<class CPal*,class CPalPtrLess>::iterator it_palptr;
 		for (it_palptr = psetOwnedPals->begin(); it_palptr != psetOwnedPals->end(); it_palptr++)
 			delete *it_palptr;
 
@@ -508,8 +508,8 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 		pceMainPalClut = 0;
 		delete psetPalClut;
 		delete psetOwnedPals;
-		psetPalClut = new set<class CPalClut,class CPalClutLess>;
-		psetOwnedPals = new set<class CPal*,class CPalPtrLess>;
+		psetPalClut = new std::set<class CPalClut,class CPalClutLess>;
+		psetOwnedPals = new std::set<class CPal*,class CPalPtrLess>;
 		CreateMainClut();
 	}
 
@@ -537,7 +537,7 @@ CProfileStat	psCluts/*("Cluts", &proProfile.psMain)*/;
 		int i_num_prelit_clut_entries   = 0;
 
 		// Iterate through list of palette-clut objects.
-		for (set<CPalClut, CPalClutLess>::iterator it_palclut_db = psetPalClut->begin(); it_palclut_db != psetPalClut->end(); ++it_palclut_db)
+		for (std::set<CPalClut, CPalClutLess>::iterator it_palclut_db = psetPalClut->begin(); it_palclut_db != psetPalClut->end(); ++it_palclut_db)
 		{
 			uint32 u4_size = (*it_palclut_db).pclutClut->u4GetMemSize();
 

--- a/jp2_pc/Source/Lib/View/ColourBase.hpp
+++ b/jp2_pc/Source/Lib/View/ColourBase.hpp
@@ -57,8 +57,7 @@
 #ifdef __MWERKS__
 #include <set.h>
 #else
-// Note that this declares ::set (not std::set).
-template <class ITEM, class COMPARE> class set;
+#include <set>
 #endif
 
 class CBumpTable;
@@ -200,9 +199,9 @@ public:
 	CPalClut* pceMainPalClut;					// Pointer to the CPalClut object for the main screen.
 	CPal*     ppalMain;							// Main palette.
 
-	set<CPalClut, CPalClutLess>* psetPalClut;	// STL Associate Container for CPalClut.
+	std::set<CPalClut, CPalClutLess>* psetPalClut;	// STL Associate Container for CPalClut.
 										
-	set<CPal*, CPalPtrLess>*	 psetOwnedPals;	// Palettes we own (and need to delete).
+	std::set<CPal*, CPalPtrLess>*	 psetOwnedPals;	// Palettes we own (and need to delete).
 
 	CPixelFormat pxfDest;						// The current pixel format that cluts convert to.
 

--- a/jp2_pc/Source/Lib/View/Direct3DRenderState.hpp
+++ b/jp2_pc/Source/Lib/View/Direct3DRenderState.hpp
@@ -60,7 +60,7 @@
 #include "Lib/W95/WinInclude.hpp"
 #include "Lib/W95/DD.hpp"
 #define D3D_OVERLOADS
-#include <DirectX/d3d.h>
+#include <d3d.h>
 #include "Lib/W95/Direct3D.hpp"
 #include "Lib/View/Raster.hpp"
 #include "Lib/Renderer/ScreenRender.hpp"

--- a/jp2_pc/Source/Lib/View/Gamma.hpp
+++ b/jp2_pc/Source/Lib/View/Gamma.hpp
@@ -58,7 +58,7 @@
 //*********************************************************************************************
 //
 template<class T> class CGammaCorrection: 
-	public CFloatTableRound<T, iGAMMA_TABLE_SIZE, 0.0, rvMAX_WHITE>
+	public CFloatTableRound<T, iGAMMA_TABLE_SIZE, 0, static_cast<int>(rvMAX_WHITE)>
 //
 // A gamma-correction and light-value conversion facility.  
 // Converts floating-point lighting values to gamma-corrected values, while scaling and

--- a/jp2_pc/Source/Lib/View/Grab.cpp
+++ b/jp2_pc/Source/Lib/View/Grab.cpp
@@ -345,7 +345,7 @@ public:
 		char str_num[5];
 		sprintf(str_num, "%.4d", iFrameCount);
 
-		string str_name = strBaseName + str_num + ".bmp";
+		std::string str_name = strBaseName + str_num + ".bmp";
 
 		pgrabActive->GrabBackbuffer();
 		pgrabActive->DumpBitmap(str_name.c_str());

--- a/jp2_pc/Source/Lib/View/Grab.hpp
+++ b/jp2_pc/Source/Lib/View/Grab.hpp
@@ -243,7 +243,7 @@ class CAutoGrabber : public CSubsystem
 
 	int iFrameCount;
 
-	string strBaseName;
+	std::string strBaseName;
 
 	//******************************************************************************************
 	//

--- a/jp2_pc/Source/Lib/View/RasterConvertD3D.cpp
+++ b/jp2_pc/Source/Lib/View/RasterConvertD3D.cpp
@@ -41,10 +41,11 @@
 //
 // Necessary includes.
 //
-#include "Set.h"
+#include <set>
 #include "Memory.h"
 #include "Common.hpp"
 #include "RasterConvertD3D.hpp"
+#include <algorithm>
 
 #include "Raster.hpp"
 #include "RasterD3D.hpp"
@@ -321,7 +322,7 @@ public:
 //
 
 // Type of set used to store conversion table pointers.
-typedef set<CRasterConvert, CRasterConvertLess> TSetConv;
+typedef std::set<CRasterConvert, CRasterConvertLess> TSetConv;
 
 
 //
@@ -387,8 +388,8 @@ void ConvertRasterAlpha
 	int i_d3d_stride = pras_d3d->iLinePixels;
 	int i_mem_stride = pras_mem->iLinePixels;
 
-	int i_width  = min(pras_d3d->iWidth,  pras_mem->iWidth);
-	int i_height = min(pras_d3d->iHeight, pras_mem->iHeight);
+	int i_width  = std::min(pras_d3d->iWidth,  pras_mem->iWidth);
+	int i_height = std::min(pras_d3d->iHeight, pras_mem->iHeight);
 
 	// Dumb conversion for now.
 	for (int j = 0; j < i_height; ++j)
@@ -434,8 +435,8 @@ void ConvertRaster(CRasterD3D* pras_d3d, rptr<CRaster> pras_mem, CColour clr)
 	int i_d3d_stride = pras_d3d->iLinePixels;
 	int i_mem_stride = pras_mem->iLinePixels;
 
-	int i_width      = min(pras_d3d->iWidth,  pras_mem->iWidth);
-	int i_height     = min(pras_d3d->iHeight, pras_mem->iHeight);
+	int i_width      = std::min(pras_d3d->iWidth,  pras_mem->iWidth);
+	int i_height     = std::min(pras_d3d->iHeight, pras_mem->iHeight);
 
 	// Dumb conversion for now.
 	for (int j = 0; j < i_height; ++j)

--- a/jp2_pc/Source/Lib/View/RasterD3D.cpp
+++ b/jp2_pc/Source/Lib/View/RasterD3D.cpp
@@ -203,7 +203,7 @@
 #include "Common.hpp"
 #include "RasterD3D.hpp"
 
-#include "map.h"
+#include <map>
 #include "Lib/W95/WinInclude.hpp"
 #include "Lib/W95/DD.hpp"
 #include "Lib/Sys/Profile.hpp"
@@ -390,7 +390,7 @@ template<class T> void ReleasePObject
 
 //**********************************************************************************************
 //
-class CMapDDSurfaces : public map< uint32, LPDIRECTDRAWSURFACE4, less<uint32> >
+class CMapDDSurfaces : public std::map< uint32, LPDIRECTDRAWSURFACE4, std::less<uint32> >
 //
 // Encapsulates an STL map for DirectDraw surfaces.
 //
@@ -475,7 +475,7 @@ public:
 	#ifdef __MWERKS__
 		insert(pair<const uint32, LPDIRECTDRAWSURFACE4>(u4_hash, pdds));
 	#else
-		insert(pair<uint32, LPDIRECTDRAWSURFACE4>(u4_hash, pdds));
+		insert(std::pair<uint32, LPDIRECTDRAWSURFACE4>(u4_hash, pdds));
 	#endif
 
 		Assert(pddsFind(u4_hash));

--- a/jp2_pc/Source/Lib/View/RasterPool.cpp
+++ b/jp2_pc/Source/Lib/View/RasterPool.cpp
@@ -50,8 +50,8 @@
  * 
  **********************************************************************************************/
 
-#include <list.h>
-#include <multimap.h>
+#include <list>
+#include <map>
 #include "Common.hpp"
 #include "RasterPool.hpp"
 
@@ -75,7 +75,7 @@
 
 //**********************************************************************************************
 //
-class CPoolMap : public multimap< uint32, rptr<CRaster>, less<uint32> >
+class CPoolMap : public std::multimap< uint32, rptr<CRaster>, std::less<uint32> >
 //
 // 
 //
@@ -153,7 +153,7 @@ public:
 	#ifdef __MWERKS__
 		insert( pair< const uint32, rptr<CRaster> >(pras->u4GetTypeID(), pras));
 	#else
-		insert( pair< uint32, rptr<CRaster> >(pras->u4GetTypeID(), pras));
+		insert(std::pair< uint32, rptr<CRaster> >(pras->u4GetTypeID(), pras));
 	#endif
 		CRasterPool::iBytesUsed += pras->iSurfaceMemBytes();
 	}
@@ -192,7 +192,7 @@ public:
 
 //**********************************************************************************************
 //
-class CPoolLRU : public list<uint32>
+class CPoolLRU : public std::list<uint32>
 //
 // Object to maintain a least recently used (LRU) list.
 //

--- a/jp2_pc/Source/Lib/W95/DD.hpp
+++ b/jp2_pc/Source/Lib/W95/DD.hpp
@@ -89,7 +89,7 @@
 // as well as all currently accepted notions of sanity.
 // The pragma after the include fixes the problem.
 
-#include <DirectX/DDraw.h>
+#include <ddraw.h>
 
 // Get rid of the bool reserved word warning.
 #pragma warning(disable:4237)

--- a/jp2_pc/Source/Lib/W95/Direct3D.hpp
+++ b/jp2_pc/Source/Lib/W95/Direct3D.hpp
@@ -220,7 +220,7 @@
 #include "Lib/W95/Direct3DCards.hpp"
 #include "dd.hpp"
 #define D3D_OVERLOADS
-#include <DirectX/d3d.h>
+#include <d3d.h>
 
 
 //

--- a/jp2_pc/Source/Lib/W95/Direct3DQuery.cpp
+++ b/jp2_pc/Source/Lib/W95/Direct3DQuery.cpp
@@ -138,9 +138,9 @@
 #include <string.h>
 #include <stdio.h>
 #include <Windows.h>
-#include <DirectX/DDraw.h>
+#include <ddraw.h>
 #define D3D_OVERLOADS
-#include <DirectX/d3d.h>
+#include <d3d.h>
 #include "Common.hpp"
 #include "Direct3DQuery.hpp"
 


### PR DESCRIPTION
In the `View` project, minor adjustments for compilability are made. Mostly the STL includes are modernized and the `std::` namespace specifier is added where necessary. 
Furthermore, the DirectX-related includes are adjusted. There are switched from the ones bundled with the original code to the Windows SDK headers.