### PR TITLE
AI: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Game/AI/AIGraph.cpp
+++ b/jp2_pc/Source/Game/AI/AIGraph.cpp
@@ -528,8 +528,8 @@ bool CAIGraph::bIsSuccessor(int i_from, int i_to)
 	{
 		TReal r_min_downhill_z = paniAnimal->pbrBrain->rMinDownHillNormalZ;
 
-		list<CTerrainKnowledge>* pltk = &paniAnimal->pbrBrain->pwvWorldView->ltkKnowledge;
-		list<CTerrainKnowledge>::iterator ptk = pltk->begin();
+		std::list<CTerrainKnowledge>* pltk = &paniAnimal->pbrBrain->pwvWorldView->ltkKnowledge;
+		std::list<CTerrainKnowledge>::iterator ptk = pltk->begin();
 
 		for ( ; ptk != pltk->end(); ++ptk)
 		{

--- a/jp2_pc/Source/Game/AI/AIMain.cpp
+++ b/jp2_pc/Source/Game/AI/AIMain.cpp
@@ -292,7 +292,7 @@ float fAIDebug3 = 0.5;
 	{
 #if VER_DEBUG
 		// Make sure it isn't already in the list.
-		list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
+		std::list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
 
 		bool b_found_it = false;
 
@@ -311,7 +311,7 @@ float fAIDebug3 = 0.5;
 		DeactivateAnimal(pani);
 
 		// Make sure it isn't already in the list.
-		list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
+		std::list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
 
 		for ( ; ipani != lpaniInactiveAnimals.end(); ++ipani)
 		{
@@ -381,7 +381,7 @@ float fAIDebug3 = 0.5;
 			apaniActiveAnimals[i_free_index] = pani;
 
 			// Remove from inactive list.
-			list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
+			std::list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
 
 			bool b_found_it = false;
 
@@ -419,7 +419,7 @@ float fAIDebug3 = 0.5;
 
 			{
 				// Remove from inactive list.
-				list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
+				std::list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
 				for ( ; ipani != lpaniInactiveAnimals.end(); ++ipani)
 				{
 					if (*ipani == pani)
@@ -454,7 +454,7 @@ float fAIDebug3 = 0.5;
 #if VER_TEST
 				{
 					// Remove from inactive list.
-					list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
+					std::list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
 					for ( ; ipani != lpaniInactiveAnimals.end(); ++ipani)
 					{
 						if (*ipani == pani)
@@ -532,10 +532,10 @@ float fAIDebug3 = 0.5;
 		r_radius *= r_radius;
 
 		// Loop through inactive animals and save a pointer to them if appropriate.
-		list<void*> lpani;
+		std::list<void*> lpani;
 		
 		// Search inactive list.
-		list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
+		std::list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
 
 		for ( ; ipani != lpaniInactiveAnimals.end(); ++ipani)
 		{
@@ -821,7 +821,7 @@ float fAIDebug3 = 0.5;
 		}
 
 		// Iterate through the inactive list, and wake up the first guy within X distance.
-		list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
+		std::list<void*>::iterator ipani = lpaniInactiveAnimals.begin();
 
 		for ( ; ipani != lpaniInactiveAnimals.end(); ++ipani)
 		{
@@ -1281,7 +1281,7 @@ float fAIDebug3 = 0.5;
 		pc = pcSaveT(pc, i_inactive);
 
 		// Make sure it isn't already in the list.
-		list<void*>::const_iterator ipani = lpaniInactiveAnimals.begin();
+		std::list<void*>::const_iterator ipani = lpaniInactiveAnimals.begin();
 		for ( ; ipani != lpaniInactiveAnimals.end(); ++ipani)
 		{
 			pc = pcSaveInstancePointer(pc, (CAnimal*)*ipani);
@@ -1445,7 +1445,7 @@ float fAIDebug3 = 0.5;
 	}
 	
 	
-	typedef set<CAIInfo, less<CAIInfo> > TSAI;
+	typedef std::set<CAIInfo, std::less<CAIInfo> > TSAI;
 	// This guy is here instead of in the class header to cut down on compile times.
 	// Additionally, only the world dbase need know about it (for purging)
 	TSAI tsaiAIInfo;	// A set containing all shared AI infos, for instancing.
@@ -1457,7 +1457,7 @@ float fAIDebug3 = 0.5;
 	)
 	{
 		// Insert or find, please.
-		pair<TSAI::iterator, bool> p = tsaiAIInfo.insert(aii);
+		std::pair<TSAI::iterator, bool> p = tsaiAIInfo.insert(aii);
 
 		// If we found a duplicate, it will do.
 		// If we inserted a new one, the new one will do.

--- a/jp2_pc/Source/Game/AI/AIMain.hpp
+++ b/jp2_pc/Source/Game/AI/AIMain.hpp
@@ -68,7 +68,7 @@
 #ifndef HEADER_GAME_AI_AIMAIN_HPP
 #define HEADER_GAME_AI_AIMAIN_HPP
 
-#include <list.h>
+#include <list>
 #include "Lib\Std\Random.hpp"
 #include "Lib/EntityDBase/Subsystem.hpp"
 
@@ -161,7 +161,7 @@ public:
 	CInstance*		pinsSelected;	// Mostly for debugging-  which instance are we most interested in?
 
 	CSArray<CAnimal* ,iMAX_ACTIVE_ANIMALS>		apaniActiveAnimals;	// The set of active animals.
-	list<void*>     lpaniInactiveAnimals;		// List of all inactive animals.  void * to avoid STL stupidity.
+	std::list<void*>     lpaniInactiveAnimals;		// List of all inactive animals.  void * to avoid STL stupidity.
 
 	CSArray<CAIGraph*,iMAX_ACTIVE_ANIMALS> 		apgraphActiveGraphs;// The shared AI graphs.
 

--- a/jp2_pc/Source/Game/AI/Activity.cpp
+++ b/jp2_pc/Source/Game/AI/Activity.cpp
@@ -93,7 +93,7 @@
 
 #include "PathAStar.hpp"
 
-#include "bstring.h"
+#include <string>
 
 // The target location distance when fleeing.
 #define rFLEE_DISTANCE				50.0

--- a/jp2_pc/Source/Game/AI/Brain.cpp
+++ b/jp2_pc/Source/Game/AI/Brain.cpp
@@ -1191,7 +1191,7 @@ extern int iAnimalVersion;
 
 
 					// Find the Z extents of the node.
-					pair<TReal, TReal> pr_minmaxZ = it.pqnqGetNode()->prrGetWorldZLimits(it.pqrContainer->pqnqRoot);
+					std::pair<TReal, TReal> pr_minmaxZ = it.pqnqGetNode()->prrGetWorldZLimits(it.pqrContainer->pqnqRoot);
 
 					// Make sure we have (min, max)
 					Assert(pr_minmaxZ.first <= pr_minmaxZ.second);
@@ -1794,7 +1794,7 @@ extern int iAnimalVersion;
 			}
 
 
-			list<CTerrainKnowledge>::iterator ptk;
+			std::list<CTerrainKnowledge>::iterator ptk;
 			ptk = pwvWorldView->ltkKnowledge.begin();
 
 			int i_tri_count = 0;

--- a/jp2_pc/Source/Game/AI/Influence.hpp
+++ b/jp2_pc/Source/Game/AI/Influence.hpp
@@ -62,7 +62,7 @@
 //#include "Lib/EntityDBase/Animal.hpp"
 #include "Lib/Sys/Timer.hpp"
 
-#include <set.h>
+#include <set>
 #include "Lib/EntityDBase/Container.hpp"
 
 #include "Classes.hpp"
@@ -396,7 +396,7 @@ public:
 		virtual const char * pcLoad(const char *  pc_buffer);
 	
 
-		operator< (const CInfluence& inf) const
+		bool operator< (const CInfluence& inf) const
 		{
 			return pinsTarget < inf.pinsTarget;
 		}
@@ -421,7 +421,7 @@ public:
 
 //*********************************************************************************************
 //
-class CInfluenceList : public set<CInfluence, less<CInfluence> >
+class CInfluenceList : public std::set<CInfluence, std::less<CInfluence> >
 //
 //	Prefix: infl
 //

--- a/jp2_pc/Source/Game/AI/PathAStar.cpp
+++ b/jp2_pc/Source/Game/AI/PathAStar.cpp
@@ -230,8 +230,8 @@
 			}
 
 			// Check the terrain polys.
-			list<CTerrainKnowledge>* pltk = &pbrBrain->pwvWorldView->ltkKnowledge;
-			list<CTerrainKnowledge>::iterator ptk = pltk->begin();
+			std::list<CTerrainKnowledge>* pltk = &pbrBrain->pwvWorldView->ltkKnowledge;
+			std::list<CTerrainKnowledge>::iterator ptk = pltk->begin();
 
 			for (; ptk != pltk->end(); ++ptk)
 			{

--- a/jp2_pc/Source/Game/AI/Silhouette.hpp
+++ b/jp2_pc/Source/Game/AI/Silhouette.hpp
@@ -54,7 +54,7 @@
 #ifndef HEADER_LIB_AI_SILHOUETTE_HPP
 #define HEADER_LIB_AI_SILHOUETTE_HPP
 
-#include "vector.h"
+#include <vector>
 #include "Lib/Transform/Presence.hpp"
 #include "Lib/Transform/Vector.hpp"
 #include "Lib/EntityDBase/Container.hpp"

--- a/jp2_pc/Source/Game/AI/Synthesizer.hpp
+++ b/jp2_pc/Source/Game/AI/Synthesizer.hpp
@@ -87,7 +87,7 @@
 
 //#include "Brain.hpp"
 #include "Influence.hpp"
-#include <multimap.h>
+#include <map>
 
 #include "Lib\Std\Set.hpp"
 
@@ -204,9 +204,9 @@ public:
 						// The brain currently using this synthesizer.
 
 private:
-	typedef multimap<const CRating, CActBundle, less<CRating> >	TMMapAct;
-	typedef pair<const CRating, CActBundle>						TPairAct;
-	typedef pair<const CRating, CActBundle>					TConstPairAct;
+	typedef std::multimap<const CRating, CActBundle, std::less<CRating> >	TMMapAct;
+	typedef std::pair<const CRating, CActBundle>						TPairAct;
+	typedef std::pair<const CRating, CActBundle>					TConstPairAct;
 
 	TMMapAct				mmapRandomActivities;
 						// The set of all registered activities,

--- a/jp2_pc/Source/Game/AI/WorldView.cpp
+++ b/jp2_pc/Source/Game/AI/WorldView.cpp
@@ -193,7 +193,7 @@ const CInfluence* CWorldView::pinfNotice
 		CInfluence inf_real(paniOwner, pins);
 
 		inf_real.UpdateForMove(paniOwner, s_current_time);
-		pair<CInfluenceList::iterator, bool> p = inflInfluences.insert(inf_real);
+		std::pair<CInfluenceList::iterator, bool> p = inflInfluences.insert(inf_real);
 		Assert(p.second);
 
 		return 0;
@@ -371,7 +371,7 @@ void CWorldView::RemoveSomeInfluences()
 	CInfluenceList::iterator pinf = inflInfluences.begin();
 
 	int i_discardable_count = 0;
-	list<const CInfluence*> lpinf_discard;
+	std::list<const CInfluence*> lpinf_discard;
 
 	// Find the lamest influence and remove it.
 	// For now, we only remove one bad apple each cycle.
@@ -407,7 +407,7 @@ void CWorldView::RemoveSomeInfluences()
 
 	if (i_discardable_count > 10)
 	{
-		list<const CInfluence*>::iterator itpinf;
+		std::list<const CInfluence*>::iterator itpinf;
 		for(itpinf = lpinf_discard.begin(); itpinf != lpinf_discard.end(); ++itpinf)
 		{
 			//   Is it discardable?
@@ -482,7 +482,7 @@ const CInfluence* CWorldView::pinfAddOrUpdate
 		inf_real.UpdatePositionalData(paniOwner);
 
 		// Insert the influence.
-		pair<CInfluenceList::iterator, bool> p = inflInfluences.insert(inf_real);
+		std::pair<CInfluenceList::iterator, bool> p = inflInfluences.insert(inf_real);
 
 		AlwaysAssert(!inf_real.setNodeFlags[ensfIN_GRAPH]);
 
@@ -537,7 +537,7 @@ void CWorldView::MaybeResetTempInfluenceFlags()   // Somewhat misnamed-  also re
 			pinf->ResetTemporaryFlags();
 		}
 
-		list<CTerrainKnowledge>::iterator ptk;
+		std::list<CTerrainKnowledge>::iterator ptk;
 		for (ptk = ltkKnowledge.begin(); ptk != ltkKnowledge.end(); ++ptk)
 		{
 			CTerrainKnowledge* ptk_temp = &(*ptk);
@@ -578,7 +578,7 @@ void CWorldView::ResetMergeTerrain()
 //*********************************************************************************
 void CWorldView::ClearTerrainKnowledge()
 {
-	list<CTerrainKnowledge>::iterator ptk;
+	std::list<CTerrainKnowledge>::iterator ptk;
 
 	if (paniOwner->pbrBrain->paigGraph)
 	{
@@ -596,8 +596,8 @@ void CWorldView::ClearTerrainKnowledge()
 //*********************************************************************************
 void CWorldView::ClearOutsideTerrainKnowledge()
 {
-	list<CTerrainKnowledge>::iterator ptk;
-	list<CTerrainKnowledge>::iterator ptk_last;
+	std::list<CTerrainKnowledge>::iterator ptk;
+	std::list<CTerrainKnowledge>::iterator ptk_last;
 
 	ptk = ltkKnowledge.begin();
 	ptk = ltkKnowledge.end();

--- a/jp2_pc/Source/Game/AI/WorldView.hpp
+++ b/jp2_pc/Source/Game/AI/WorldView.hpp
@@ -107,7 +107,7 @@
 #ifndef HEADER_GAME_AI_WORLDVIEW_HPP
 #define HEADER_GAME_AI_WORLDVIEW_HPP
 
-#include "list.h"
+#include <list>
 #include "Influence.hpp"
 #include "Rating.hpp"
 
@@ -163,7 +163,7 @@ public:
 	TSec			sTimeOfLastTemporaryFlagReset;			
 									// When exactly did we reset the temporary flags last time?
 		
-	list<CTerrainKnowledge>  ltkKnowledge;	
+	std::list<CTerrainKnowledge>  ltkKnowledge;
 									// Some info about the terrain, as perceived by the animal.
 
 	CVector2<>		v2CenterOfTerrainKnowledge;	
@@ -176,7 +176,7 @@ public:
 	int				iSideMerging;
 									// The side of the terrain segment we are trying to merge.
 
-	list<CTerrainKnowledge>::iterator  ptkKnowledgeMerging;	
+	std::list<CTerrainKnowledge>::iterator  ptkKnowledgeMerging;
 									// The terrain segment that we are trying to merge.
 
 	


### PR DESCRIPTION
In the `AI` project, the STL includes are modernized and the `std::` namespace specifier is added where necessary.
This is _not_ sufficient to make `AI` compile.