### PR TITLE
Audio: steps towards compilability

### DIFF
--- a/jp2_pc/Source/Lib/Audio/Audio.hpp
+++ b/jp2_pc/Source/Lib/Audio/Audio.hpp
@@ -211,14 +211,11 @@
 #include "BuildVer.hpp"
 #include "SoundTypes.hpp"
 #include "SoundDefs.hpp"
-#include "DirectX/DDraw.h"
-#include "DirectX/D3D.h"
-#include "DirectX/DSound.h"
-#include "DirectX/d3drmwin.h"
+#include "dsound.h"
 #include "Ia3d.h"
 #include "Lib/Sys/DebugConsole.hpp"
 #include "lib/sys/memorylog.hpp"
-#include "bstring.h"
+#include <string>
 #include "AudioLoader.hpp"
 #include "Subtitle.hpp"
 #include <math.h>
@@ -433,7 +430,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	string& GetBasePathName()
+	std::string& GetBasePathName()
 	{
 		return strBasePath;
 	}
@@ -807,7 +804,7 @@ protected:
 	LPKSPROPERTYSET			pDSPropertySet;
 	uint32					u4EAXPropertySupport;
 
-	string					strBasePath;		// the path to which all samples are loaded from
+	std::string					strBasePath;		// the path to which all samples are loaded from
 
 	float					fListenerX;
 	float					fListenerY;

--- a/jp2_pc/Source/Lib/Audio/AudioADPCM.cpp
+++ b/jp2_pc/Source/Lib/Audio/AudioADPCM.cpp
@@ -33,6 +33,7 @@
 
 #include "Audio.hpp"
 #include "AudioADPCM.hpp"
+#include <algorithm>
 
 //**********************************************************************************************
 // channel header
@@ -174,7 +175,7 @@ uint32 CAudioADPCM::u4DecompressMono16bit
 			pu1Next = pu1BlockBuffer;
 		}
 		
-		u4_count = min(u4_byte_count,u4FreshBytes);
+		u4_count = std::min(u4_byte_count,u4FreshBytes);
 
 		memcpy(pu1_dst,pu1Next,u4_count);
 		pu1_dst+=u4_count;
@@ -237,7 +238,7 @@ uint32 CAudioADPCM::u4DecompressStereo16bit
 			pu1Next = pu1BlockBuffer;
 		}
 		
-		u4_count = min(u4_byte_count,u4FreshBytes);
+		u4_count = std::min(u4_byte_count,u4FreshBytes);
 
 		memcpy(pu1_dst,pu1Next,u4_count);
 		pu1_dst+=u4_count;
@@ -274,7 +275,7 @@ void CAudioADPCM::SetSampleSource
 	// Block size is the number of bytes that each decompression step should decode, it
 	// is either a multiple of the block length or a number of bytes less than the block
 	// length, This is only used for the last block.
-	u4BlockSize			= min(u4_src_len,cauheaderLocal.u4BlockAlignment);
+	u4BlockSize			= std::min(u4_src_len,cauheaderLocal.u4BlockAlignment);
 }
 
 
@@ -704,7 +705,7 @@ static uint32 u4ADPCMDecodeS16
 
     while(u4_src_length!=0)
     {
-        i4_block_length  = min((uint32)u4_block_alignment,(uint32)u4_src_length);
+        i4_block_length  = std::min((uint32)u4_block_alignment,(uint32)u4_src_length);
         u4_src_length   -= i4_block_length;
         i4_block_length -= IMAADPCM_HEADER_LENGTH * 2;
 

--- a/jp2_pc/Source/Lib/Audio/AudioLoad.cpp
+++ b/jp2_pc/Source/Lib/Audio/AudioLoad.cpp
@@ -347,13 +347,13 @@ void CCAULoad::SelectDecoder
 		if (cauheaderLocal.u1Bits == 8)
 		{
 			// mono 8bit
-			u4DecompressBlock = u4DecompressMono8bit;
+			u4DecompressBlock = &CCAULoad::u4DecompressMono8bit;
 			u1SilentValue = 128;
 		}
 		else
 		{
 			// mono 16bit
-			u4DecompressBlock = u4DecompressMono16bit;
+			u4DecompressBlock = &CCAULoad::u4DecompressMono16bit;
 			u1SilentValue = 0;
 		}
 	}
@@ -364,13 +364,13 @@ void CCAULoad::SelectDecoder
 		if (cauheaderLocal.u1Bits == 8)
 		{
 			// mono 8bit
-			u4DecompressBlock = u4DecompressStereo8bit;
+			u4DecompressBlock = &CCAULoad::u4DecompressStereo8bit;
 			u1SilentValue = 128;
 		}
 		else
 		{
 			// mono 16bit
-			u4DecompressBlock = u4DecompressStereo16bit;
+			u4DecompressBlock = &CCAULoad::u4DecompressStereo16bit;
 			u1SilentValue = 0;
 		}
 	}

--- a/jp2_pc/Source/Lib/Audio/AudioLoader.hpp
+++ b/jp2_pc/Source/Lib/Audio/AudioLoader.hpp
@@ -87,7 +87,7 @@
 #pragma warning(disable:4786)
 #include "SoundDefs.hpp"
 #include "Subtitle.hpp"
-#include "map.h"
+#include <map>
 
 #pragma pack(push,1)
 
@@ -328,11 +328,11 @@ protected:
 
 
 //**********************************************************************************************
-typedef map< uint32, SSampleFile*, less<uint32> >		TFileSampleHash;
+typedef std::map< uint32, SSampleFile*, std::less<uint32> >		TFileSampleHash;
 // prefix: fsh
 
 //**********************************************************************************************
-typedef map< uint64, SAudioCollision*, less<uint64> >	TCollisionHash;
+typedef std::map< uint64, SAudioCollision*, std::less<uint64> >	TCollisionHash;
 // prefix: ch
 
 


### PR DESCRIPTION
Various code adjustments are made to make the `Audio` project compilable.
Among other things, the DirectX-related includes are adjusted. There are switched from the ones bundled with the original code to the Windows SDK headers. The graphics-related includes are removed, they have no business in the `Audio` project.