### PR TITLE
Physics: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/Physics/Arms.cpp
+++ b/jp2_pc/Source/Lib/Physics/Arms.cpp
@@ -12,7 +12,7 @@
 #include "Xob_BC.hpp"
 
 #include "Lib/Sys/ConIO.hpp"
-#include <iostream.h>
+#include <iostream>
 
 //	Bad, but OK for now...
 //	-=-=-=-=-=-=-=-=-=-=-=

--- a/jp2_pc/Source/Lib/Physics/BioModel.cpp
+++ b/jp2_pc/Source/Lib/Physics/BioModel.cpp
@@ -13,7 +13,7 @@
 #include "Lib/Math/FastSqrt.hpp"
 
 #include <math.h>
-#include <iostream.h>
+#include <iostream>
 #include <memory.h>
  
 //	State...
@@ -922,7 +922,7 @@ void CBioModel::SetInput( float position[3], float roll, float intensity, int pe
 #include <stdio.h>
 
 //******************************************************************************************
-ostream& operator <<(ostream& os, CPArray<float> pa)
+std::ostream& operator <<(std::ostream& os, CPArray<float> pa)
 {
 	for (int i = 0; i < pa.size(); i++)
 	{
@@ -933,13 +933,13 @@ ostream& operator <<(ostream& os, CPArray<float> pa)
 	return os;
 }
 
-void CBioModel::DumpState(ostream& os)
+void CBioModel::DumpState(std::ostream& os)
 {
 #if VER_TEST
 	int j, k;
 
 	os	<<" DOF=" <<Dof
-		<<endl;
+		<< std::endl;
 
 	os	<<"  Field=";
 	for (j = 0; j < FIELD_DIMENSION; j++)
@@ -947,15 +947,15 @@ void CBioModel::DumpState(ostream& os)
 		os	<<"    ";
 		for (k = 0; k < 3; k++)
 			os	<<CPArray<float>(3, Field[j][k]) <<" ";
-		os	<<endl;
+		os	<< std::endl;
 	}
-	os	<<endl;
+	os	<< std::endl;
 
 	os	<<"  FieldInputs=";
 	for (j = 0; j < FIELD_DIMENSION; j++)
 		os	<<"    " <<CPArray<float>(3, FieldInputs[j])
-			<<endl;
-	os	<<endl;
+			<< std::endl;
+	os	<< std::endl;
 
 	os	<<"  Tensor=";
 	for (j = 0; j < FIELD_DIMENSION; j++)
@@ -963,33 +963,33 @@ void CBioModel::DumpState(ostream& os)
 		os	<<"    ";
 		for (k = 0; k < FIELD_DIMENSION; k++)
 			os	<<int(Tensor[j][k]) <<" ";
-		os	<<endl;
+		os	<< std::endl;
 	}
-	os	<<endl;
+	os	<< std::endl;
 
 	os	<<"  Rho=";
 	for (j = 0; j < FIELD_DIMENSION; j++)
 		os	<<"    " <<CPArray<float>(FIELD_DIMENSION, Rho[j])
-			<<endl;
-	os	<<endl;
+			<< std::endl;
+	os	<< std::endl;
 
 	os	<<"  Psi=";
 	for (j = 0; j < FIELD_DIMENSION; j++)
 		os	<<"    " <<CPArray<float>(5, Psi[j])
-			<<endl;
-	os	<<endl;
+			<< std::endl;
+	os	<< std::endl;
 
 	os	<<"  Offset=" <<CPArray<float>(3, Offset)
-		<<endl;
+		<< std::endl;
 
 	os	<<"  Control=" <<CPArray<float>(5, Control)
-		<<endl;
+		<< std::endl;
 
-	os	<<endl;
+	os	<< std::endl;
 #endif
 }
 
-void DumpBioState(ostream& os)
+void DumpBioState(std::ostream& os)
 {
 #if VER_TEST
 	int i;
@@ -997,9 +997,9 @@ void DumpBioState(ostream& os)
 	for (i = 0; i < MAX_BIOMODELS; i++)
 		if (BioModels[i])
 		{
-			os	<<"BioModel" <<i <<endl;
+			os	<<"BioModel" <<i << std::endl;
 			BioModels[i]->DumpState(os);
 		}
-	os	<<endl;
+	os	<< std::endl;
 #endif
 }

--- a/jp2_pc/Source/Lib/Physics/BioModel.h
+++ b/jp2_pc/Source/Lib/Physics/BioModel.h
@@ -13,7 +13,7 @@
   typedef basic_ostream<char,char_traits<char> > ostream; 
  };
 #else
- class ostream;
+#include <iostream>
 #endif
 
 #pragma warning( disable : 4244 )
@@ -46,7 +46,7 @@ public:
 					    float Y[MAX_JOINTS][3],
 					    float Z[MAX_JOINTS][3] );
 
-	void DumpState(ostream& os);
+	void DumpState(std::ostream& os);
 
 private:
 	void UpdateControl();
@@ -58,7 +58,7 @@ private:
 // Array of biomodel pointers; dynamically allocated.
 extern aptr<CBioModel>	BioModels[MAX_BIOMODELS];
 
-void DumpBioState(ostream& os);
+void DumpBioState(std::ostream& os);
 
 //	 Clear, integrates all ACTIVE Fields...
 void integrate_field( float delta_t );

--- a/jp2_pc/Source/Lib/Physics/InfoBox.cpp
+++ b/jp2_pc/Source/Lib/Physics/InfoBox.cpp
@@ -97,7 +97,7 @@
 #include "Common.hpp"
 #include "InfoBox.hpp"
 
-#include <set.h>
+#include <set>
 #include "Lib/GeomDBase/PartitionPriv.hpp"
 
 #include "PhysicsSystem.hpp"
@@ -122,7 +122,7 @@
 #include "Lib/Std/LocalArray.hpp"
 #include "Lib/Math/MathUtil.hpp"
 
-#include <algo.h>
+#include <algorithm>
 
 // Debugging rendering stuff.
 #include "Lib/Renderer/Camera.hpp"
@@ -187,12 +187,12 @@ extern int iPhysFrame;
 	{
 	public:
 		CVector3<>					v3Min, v3Max;	// Limits of current query box.
-		aptr< list<CInstance*> >	plspinsNear;	// List of inactive objects in this region.
+		aptr< std::list<CInstance*> >	plspinsNear;	// List of inactive objects in this region.
 		aptr<CWDbQueryTerrainTopology>	
 									pwqttopTerrain;	// The current terrain query region.
 		CTerrainObj*				ptoBase;		// The base, or default texture for this region,
 													// if any.
-		list<CTerrainObj*>			lsptoTerrainObjs;// Non-default terrain objects in this query region.
+		std::list<CTerrainObj*>			lsptoTerrainObjs;// Non-default terrain objects in this query region.
 		CAArray<TVectorPair>		pavpEdges;		// Array of terrain edges in this region.
 		aptr<CWDbQueryWater>		pwqwtrWater;	// List of water objects intersecting this region.
 
@@ -1001,7 +1001,7 @@ inline CJoeXob& JoeXob(int i_index)
 		// Find highest encompassing texture.
 		//
 		ptoBase = 0;
-		list<SPartitionListElement>::iterator it = qto.end();
+		std::list<SPartitionListElement>::iterator it = qto.end();
 		if (it != qto.begin())
 		{
 			do
@@ -1061,7 +1061,7 @@ inline CJoeXob& JoeXob(int i_index)
 		Assert(v3Max.tY - v3Min.tY <= rSANE_REGION_SIZE);
 		Assert(v3Max.tZ - v3Min.tZ <= rSANE_REGION_SIZE);
 
-		plspinsNear = new list<CInstance*>;
+		plspinsNear = new std::list<CInstance*>;
 
 		// Query nearby boxes. Add inactive ones to list.
 		CWDbQueryPhysicsBoxFast wqph(bvb, pr3);
@@ -1162,7 +1162,7 @@ inline CJoeXob& JoeXob(int i_index)
 
 		// The list contains all non-base significant textures to check,
 		// with higher textures first.
-		forall (lsptoTerrainObjs, list<CTerrainObj*>, itpto)
+		forall (lsptoTerrainObjs, std::list<CTerrainObj*>, itpto)
 		{
 			if ((*itpto)->pbvBoundingVol()->bContains(v3 / (*itpto)->pr3Presence()))
 			{
@@ -1237,7 +1237,7 @@ inline CJoeXob& JoeXob(int i_index)
 
 
 	// It could be in the class, but that would just slow down the compile times.
-	typedef set<CPhysicsInfoBox, less<CPhysicsInfoBox> > TSPB;
+	typedef std::set<CPhysicsInfoBox, std::less<CPhysicsInfoBox> > TSPB;
 	TSPB tspbPhysicsInfoBox;	// A set containing all shared box infos, for instancing.
 
 	//*****************************************************************************************
@@ -1298,7 +1298,7 @@ inline CJoeXob& JoeXob(int i_index)
 		if (bIsTangible())
 			if (Min(Min(v3_corner.tX, v3_corner.tY), v3_corner.tZ) <= rBOX_DIM_WARN)
 				dout <<"Warning: Physics box " <<pgon->strObjectName <<" is smaller than " <<(rBOX_DIM_WARN*2.0f) <<" m: "
-					 <<(v3_corner*2.0f) <<endl;
+					 <<(v3_corner*2.0f) << std::endl;
 
 		CXob::XOBResize(afConvert(v3_corner));
 		bvbCollideVol = CBoundVolBox(v3_corner / pgon->fScale);
@@ -1385,7 +1385,7 @@ inline CJoeXob& JoeXob(int i_index)
 		}
 */
 		// Insert or find, please.
-		pair<TSPB::iterator, bool> p = tspbPhysicsInfoBox.insert(phib_copy);
+		std::pair<TSPB::iterator, bool> p = tspbPhysicsInfoBox.insert(phib_copy);
 
 		// If we found a duplicate, it will do.
 		// If we inserted a new one, the new one will do.
@@ -1497,7 +1497,7 @@ inline CJoeXob& JoeXob(int i_index)
 				// Sorry, no room.
 				if (!bFailed)
 				{
-					dout <<"Too many boxes! Cannot wake up " <<pins->strGetInstanceName() <<endl;
+					dout <<"Too many boxes! Cannot wake up " <<pins->strGetInstanceName() << std::endl;
 					bFailed = true;
 				}
 				return;
@@ -1514,7 +1514,7 @@ inline CJoeXob& JoeXob(int i_index)
 		CJoeXob& xob = JoeXob(i_index);
 
 		// Get attachment list.
-		list<CMagnetPair*> lspmp;
+		std::list<CMagnetPair*> lspmp;
 		NMagnetSystem::GetAttachedMagnets(pins, &lspmp);
 
 		// Get master of this group.
@@ -1603,7 +1603,7 @@ inline CJoeXob& JoeXob(int i_index)
 		// Make a pass through the list to see what kind of magnets we have.
 		if (b_movable)
 		{
-			forall (lspmp, list<CMagnetPair*>, itpmp)
+			forall (lspmp, std::list<CMagnetPair*>, itpmp)
 			{
 				const CMagnetPair& mp = **itpmp;
 				CSet<EMagnetFlag> set = mp.setemfFlags();
@@ -1687,7 +1687,7 @@ inline CJoeXob& JoeXob(int i_index)
 		int i_elems = 0;
 
 		// Fill the a2pinsActiveBoxes array with all attached box instances.
-		forall (lspmp, list<CMagnetPair*>, itpmp)
+		forall (lspmp, std::list<CMagnetPair*>, itpmp)
 		{
 			const CMagnetPair& mp = **itpmp;
 			CInstance* pins_sub = mp.pinsSlave;
@@ -2279,7 +2279,7 @@ inline CJoeXob& JoeXob(int i_index)
 
 				for 
 				(
-					list<CInstance*>::iterator itpins = pqreg->plspinsNear->begin();
+					std::list<CInstance*>::iterator itpins = pqreg->plspinsNear->begin();
 					itpins != pqreg->plspinsNear->end();
 				)
 				{

--- a/jp2_pc/Source/Lib/Physics/InfoCompound.cpp
+++ b/jp2_pc/Source/Lib/Physics/InfoCompound.cpp
@@ -76,7 +76,7 @@
 //
 
 #if VER_TEST
-	set<uint32, less<uint32> > setSubmodels;
+std::set<uint32, std::less<uint32> > setSubmodels;
 #endif
 
 
@@ -103,7 +103,7 @@
 
 
 	// Just a place to keep the infos in one spot.
-	list<CPhysicsInfoCompound> lphicCompoundInfos;
+std::list<CPhysicsInfoCompound> lphicCompoundInfos;
 
 	//*****************************************************************************************
 	const CPhysicsInfoCompound* CPhysicsInfoCompound::pphicFindShared

--- a/jp2_pc/Source/Lib/Physics/Magnet.cpp
+++ b/jp2_pc/Source/Lib/Physics/Magnet.cpp
@@ -53,8 +53,8 @@
 #include "Lib/Std/StringEx.hpp"
 #include "Lib/Loader/PlatonicInstance.hpp"
 
-#include "set.h"
-#include "multimap.h"
+#include <set>
+#include <map>
 
 //**********************************************************************************************
 //
@@ -62,7 +62,7 @@
 //
 
 	// Static variables.  They could be in the class, but that would just slow down the compile times.
-	typedef set<CMagnet, less<CMagnet> > TSMagnet;
+	typedef std::set<CMagnet, std::less<CMagnet> > TSMagnet;
 	TSMagnet tsmMagnet;	// A set containing all shared magnets, for instancing.
 
 	// Set this to load magnets as instances, to see where they are.
@@ -97,7 +97,7 @@
 //		CMagnet* pmag_ret = new CMagnet(mag);
 
 		// Insert or find, please.
-		pair<TSMagnet::iterator, bool> p = tsmMagnet.insert(mag);
+		std::pair<TSMagnet::iterator, bool> p = tsmMagnet.insert(mag);
 
 		// If we found a duplicate, it will do.
 		// If we inserted a new one, the new one will do.
@@ -225,7 +225,7 @@
 
 			if (CLoadWorld::bVerbose)
 			{
-				dout << "Magnet " << pgon->strObjectName << endl;
+				dout << "Magnet " << pgon->strObjectName << std::endl;
 			}
 
 			//
@@ -342,7 +342,7 @@
 						pins_master = pins;
 					else
 					{
-						dout << "  !Extra attachment " << pins->strGetInstanceName() << endl;
+						dout << "  !Extra attachment " << pins->strGetInstanceName() << std::endl;
 						Assert(false);
 						return 0;
 					}
@@ -363,7 +363,7 @@
 				dout << "  Attaches " << pins_master->strGetInstanceName();
 				if (pins_slave)
 					dout << " and " << pins_slave->strGetInstanceName();
-				dout << endl;
+				dout << std::endl;
 			}
 
 			// Make a CMagnet out of the text props.
@@ -642,9 +642,9 @@
 //
 // Typedefs: cannot be placed in NMagnetSystem, or VC 4.2 barfs.
 //
-typedef multimap<const CInstance* const, CMagnetPair*, less<const CInstance* const> >   TMagnetTable;
-typedef pair<const CInstance* const, CMagnetPair*>							TMagnetTableEntry;
-typedef pair<TMagnetTable::iterator, TMagnetTable::iterator>	TMagnetTableMatches;
+typedef std::multimap<const CInstance* const, CMagnetPair*, std::less<const CInstance* const> >   TMagnetTable;
+typedef std::pair<const CInstance* const, CMagnetPair*>							TMagnetTableEntry;
+typedef std::pair<TMagnetTable::iterator, TMagnetTable::iterator>	TMagnetTableMatches;
 
 //**********************************************************************************************
 //
@@ -693,7 +693,7 @@ namespace NMagnetSystem
 
 #if VER_DEBUG
 		// Get current list of attached magnets, to check for looping.
-		list<CMagnetPair*> lspmp;
+		std::list<CMagnetPair*> lspmp;
 		GetAttachedMagnets(pins_master, &lspmp);
 #endif
 
@@ -1028,7 +1028,7 @@ namespace NMagnetSystem
 	}
 
 	//*****************************************************************************************
-	void GetAttachedMagnets(CInstance* pins, list<CMagnetPair*>* plsmp)
+	void GetAttachedMagnets(CInstance* pins, std::list<CMagnetPair*>* plsmp)
 	{
 		static CMagnetPair mpMaster(0, 0, 0);
 

--- a/jp2_pc/Source/Lib/Physics/Magnet.hpp
+++ b/jp2_pc/Source/Lib/Physics/Magnet.hpp
@@ -35,7 +35,7 @@
 #ifndef HEADER_LIB_PHYSICS_MAGNET_HPP
 #define HEADER_LIB_PHYSICS_MAGNET_HPP
 
-#include <list.h>
+#include <list>
 #include "Lib/EntityDBase/PhysicsInfo.hpp"
 
 #define VER_PARTITION_MAGNETS VER_TEST
@@ -513,7 +513,7 @@ namespace NMagnetSystem
 	void GetAttachedMagnets
 	(
 		CInstance* pins,			// An instance potentially in a magnet group.
-		list<CMagnetPair*>* plsmp	// Returns list of magnet pairs attaching this instance
+		std::list<CMagnetPair*>* plsmp	// Returns list of magnet pairs attaching this instance
 									// to others.
 	);
 	//

--- a/jp2_pc/Source/Lib/Physics/Pelvis.cpp
+++ b/jp2_pc/Source/Lib/Physics/Pelvis.cpp
@@ -22,7 +22,7 @@
 #endif
 
 #include <memory.h>
-#include <iostream.h>
+#include <iostream>
  
 // The globals.
 EPelvisType	Pel_Usage[ NUM_PELVISES ];					//Type of pelvis here, if any.
@@ -1301,7 +1301,7 @@ extern SControlArm	ControlArm;
 extern bool	ArmUnderControl;
 extern float Pelvis_Set_Crouch;
 
-void DumpPelState(ostream& os)
+void DumpPelState(std::ostream& os)
 {
 #if VER_TEST
 
@@ -1311,24 +1311,24 @@ void DumpPelState(ostream& os)
 	if (Pel_Usage[i])
 	{
 		os	<<"Pelvis " <<i <<" Type=" <<(int)Pel_Usage[i]
-			<<endl;
+			<< std::endl;
 
-		os	<<"  Box_BC=" <<CPArray<int>(PELVIS_DOF, Pel_Box_BC[i]) <<endl;
+		os	<<"  Box_BC=" <<CPArray<int>(PELVIS_DOF, Pel_Box_BC[i]) << std::endl;
 
 		os	<<"  State=";
 		for (j = 0; j < PELVIS_DOF; j++)
 		{
 //			os <<endl <<"    " <<CPArray<float>(3, Pel[i][j]);
-			os <<endl <<"    ";
+			os << std::endl <<"    ";
 			for (k = 0; k < 3; k++)
 				os <<double(Pel[i][j][k]) <<" ";
 		}
 
-		os	<<"  History=" <<CPArray<float>(PELVIS_DOF, History[i]) <<endl;
+		os	<<"  History=" <<CPArray<float>(PELVIS_DOF, History[i]) << std::endl;
 
-		os	<<"  BioTag=" <<CPArray<float>(PELVIS_DOF, BioTag[i]) <<endl;
+		os	<<"  BioTag=" <<CPArray<float>(PELVIS_DOF, BioTag[i]) << std::endl;
 
-		os	<<"  Data=" <<CPArray<float>(PELVIS_PARAMETERS, Pel_Data[i]) <<endl;
+		os	<<"  Data=" <<CPArray<float>(PELVIS_PARAMETERS, Pel_Data[i]) << std::endl;
 
 		os	<<"  Hand_Drop_Flag="	<<Hand_Drop_Flag[i]
 			<<" Kontrol="			<<CPArray<float>(6, Kontrol[i])
@@ -1336,23 +1336,23 @@ void DumpPelState(ostream& os)
 			<<" bKontrol_Krouch="	<<bKontrol_Krouch[i]
 			<<" iKontrol_Jump="		<<iKontrol_Jump[i]
 			<<" asFootLatch="		<<(int)asFootLatch[i]
-			<<endl;
-		os	<<endl;
+			<< std::endl;
+		os	<< std::endl;
 	}
-	os	<<endl;
+	os	<< std::endl;
 
 	// Misc stuff.
 	os	<<"ControlArm: PosUrge=" <<ControlArm.fPosUrgency
 		<<" OrientUrge=" <<ControlArm.fOrientUrgency
 		<<" Curl=" <<ControlArm.fFingerCurl
 		<<" UnderControl=" <<ArmUnderControl
-		<<endl;
+		<< std::endl;
 
 	os	<<"Pelvis_Set_Crouch="	<<Pelvis_Set_Crouch
 		<<" Pelvis_Jump="	<<CPArray<float>(3, Pelvis_Jump)
-		<<endl;
+		<< std::endl;
 
-	os	<<endl;
+	os	<< std::endl;
 
 #endif
 }

--- a/jp2_pc/Source/Lib/Physics/PhysicsInfo.cpp
+++ b/jp2_pc/Source/Lib/Physics/PhysicsInfo.cpp
@@ -159,7 +159,7 @@ const CPlacement3<> p3VELOCITY_ZERO(CRotate3<>(0, 0, 0, 0, false), CVector3<>(0,
 
 
 	// Track the skeletons for deletion.
-	list<CPhysicsInfoSkeleton*> lppisPhysicsSkeletons;
+	std::list<CPhysicsInfoSkeleton*> lppisPhysicsSkeletons;
 
 	//*****************************************************************************************
 	const CPhysicsInfo* CPhysicsInfo::pphiFindShared

--- a/jp2_pc/Source/Lib/Physics/PhysicsSystem.cpp
+++ b/jp2_pc/Source/Lib/Physics/PhysicsSystem.cpp
@@ -86,9 +86,9 @@
 #include "Lib/Loader/SaveFile.hpp"
 #include "Lib/Std/PrivSelf.hpp"
 
-#include <fstream.h>
+#include <fstream>
 #include <stdio.h>
-#include <set.h>
+#include <set>
 
 //
 // Danger! Warning! Do no leave this enabled it can and will cause DirectSound to bag.
@@ -140,7 +140,7 @@ CProfileStat
 
 	// Hacky; this shouldn't be global, but we're lazy.
 	// The set of all instance pairs ignoring collisions.
-	typedef set<TInstancePair, CLessInstancePair> TSetInstancePair; 
+	typedef std::set<TInstancePair, CLessInstancePair> TSetInstancePair; 
 	TSetInstancePair setinsprIgnore;
 
 	int iPhysFrame = 0;							// The current physics frame.
@@ -148,7 +148,7 @@ CProfileStat
 	static bool bDump = false,					// Whether to dump phys state every frame.
 				bDumpStep = false;				// Whether to dump phys state every step.
 
-	list<CInstance*> lspinsSettle;
+	std::list<CInstance*> lspinsSettle;
 
 //**********************************************************************************************
 //
@@ -198,7 +198,7 @@ namespace
 		char str_fname[100];
 
 		sprintf(str_fname, "PhyState-%03d.txt", i_num);
-		ofstream os(str_fname);
+		std::ofstream os(str_fname);
 
 		CXob::DumpStateAll(os);
 		DumpPelState(os);
@@ -390,7 +390,7 @@ public:
 	void CPhysicsSystem::CPriv::ApplyImpulses(const CVector3<>& v3_centre, TReal r_radius,
 		TReal r_impulse_max, bool b_ground)
 	{
-		dout <<"Impulses " <<r_impulse_max <<" radius " <<r_radius <<endl;
+		dout <<"Impulses " <<r_impulse_max <<" radius " <<r_radius << std::endl;
 
 		// Create a query sphere.
 		CPartitionSpaceQuery partsq(CPresence3<>(v3_centre), r_radius);

--- a/jp2_pc/Source/Lib/Physics/PhysicsSystem.hpp
+++ b/jp2_pc/Source/Lib/Physics/PhysicsSystem.hpp
@@ -330,7 +330,7 @@ public:
 	// Definitions for implementing IgnoreCollisions.
 	//
 
-	typedef pair<CInstance*, CInstance*> TInstancePair;
+	typedef std::pair<CInstance*, CInstance*> TInstancePair;
 	// Prefix: inspr.
 	// These are always stored in ascending address order, for unambiguity.
 

--- a/jp2_pc/Source/Lib/Physics/Xob_bc.cpp
+++ b/jp2_pc/Source/Lib/Physics/Xob_bc.cpp
@@ -4266,7 +4266,7 @@ void CXob::Reset()
 
 #include "Lib/Std/ArrayIO.hpp"
 
-ostream& operator <<(ostream& os, const SCollision& coll)
+std::ostream& operator <<(std::ostream& os, const SCollision& coll)
 {
 	os	<<(int)coll.ElementCollide
 		<<" " <<(int)coll.LastElementCollide
@@ -4277,7 +4277,7 @@ ostream& operator <<(ostream& os, const SCollision& coll)
 	return os;
 }
 
-void CXob::DumpState(ostream& os)
+void CXob::DumpState(std::ostream& os)
 {
 #if VER_TEST
 	if (Instances[0])
@@ -4289,13 +4289,13 @@ void CXob::DumpState(ostream& os)
 			<< " Elems=" << Data[11]
 			<< " Moved=" << Moved << " bHitAnother=" << bHitAnother
 			<< " Pelvis=" << PelvisModel << ' ' << PelvisElem
-			<< endl;
+			<< std::endl;
 
 		os	<< "  Info=" << Info
 			<< " Movable=" << Movable
 			<< " Anchored=" << Anchored
 			<< " Ignorable_DOF=" << Ignorable_DOF[0] << ' ' << Ignorable_DOF[1] << ' ' << Ignorable_DOF[2]
-			<< endl;
+			<< std::endl;
 
 		os	<< "  State=";
 		for (j = 0; j < 3; j++)
@@ -4305,44 +4305,44 @@ void CXob::DumpState(ostream& os)
 				os	<< double(State[k][j]) << ' ';
 			os << ") ";
 		}
-		os	<< endl;
+		os	<< std::endl;
 
-		os	<< "  Data=" << CPArray<float>(20, Data) << endl;
+		os	<< "  Data=" << CPArray<float>(20, Data) << std::endl;
 
 		os	<< "  Extents=" << CPArray<float>(6, Extents)
 			<< "Radius=" <<Radius <<" ExtentRatio=" <<ExtentRatio
-			<< endl;
+			<< std::endl;
 
-		os	<< "  Tau=" << CPArray<float>(3, Tau) << endl;
+		os	<< "  Tau=" << CPArray<float>(3, Tau) << std::endl;
 
 		os	<< "  Xin=";
 		for (j = 0; j < 2; j++)
 			for (k = 0; k < 3; k++)
 				os << Xin[j][k] << ' ';
-		os	<< endl;
+		os	<< std::endl;
 
-		os	<< "  Impulse=" << CPArray<float>(6, Impulse_Queue) << endl;
+		os	<< "  Impulse=" << CPArray<float>(6, Impulse_Queue) << std::endl;
 
-		os	<< "  BC_semaphore=" << CPArray<int8>(GUYS, BC_semaphore) << endl;
+		os	<< "  BC_semaphore=" << CPArray<int8>(GUYS, BC_semaphore) << std::endl;
 
 		for (j = 0; j < COLLISIONS; j++)
 			if ((int)BoxCollisions[Index()][j].ElementCollide || (int)BoxCollisions[Index()][j].LastElementCollide)
-			os	<<"  Coll " <<j <<": " <<BoxCollisions[Index()][j] <<endl;
-		os	<<endl;
+			os	<<"  Coll " <<j <<": " <<BoxCollisions[Index()][j] << std::endl;
+		os	<< std::endl;
 
 		// Element data.
 		for (j = 0; Instances[j]; j++)
 		{
-			os	<< endl;
+			os	<< std::endl;
 			os	<< "  Elem " << j;
 			if (Instances[j])
 				os	<< " '" << strInstanceName(j) << "'";
-			os	<< endl;
+			os	<< std::endl;
 
 			os	<< "    SuperData=";
 			for (k = 0; k < 6; k++)
 				os	<< SuperData[j][k] << ' ';
-			os	<< endl;
+			os	<< std::endl;
 
 			os	<< "    SuperOrient=";
 			for (k = 0; k < 3; ++k)
@@ -4352,19 +4352,19 @@ void CXob::DumpState(ostream& os)
 					os	<< SuperOrient[j][k][l] << ' ';
 				os	<< ")";
 			}
-			os	<< endl;
+			os	<< std::endl;
 
 			os	<< "    Breakage=" << Breakages[j]
 				<< " TTotal=" << TTotal[j][0] << ' ' << TTotal[j][1] << ' ' << TTotal[j][2]
-				<< endl;
+				<< std::endl;
 		}
 
-		os	<< endl;
+		os	<< std::endl;
 	}
 #endif
 }
 
-void CXob::DumpStateAll(ostream& os)
+void CXob::DumpStateAll(std::ostream& os)
 {
 #if VER_TEST
 	int i;
@@ -4373,7 +4373,7 @@ void CXob::DumpStateAll(ostream& os)
 	// Boxes.
 	//
 
-	os	<<"Last time=" <<current_timeslice <<endl;
+	os	<<"Last time=" <<current_timeslice << std::endl;
 
 	// Active box data
 	for (i = 0; i < iMAX_PHYSICS_OBJECTS; ++i)
@@ -4382,12 +4382,12 @@ void CXob::DumpStateAll(ostream& os)
 	os	<<"OurKappa=" <<OurKappa
 		<<" OurDelta=" <<OurDelta
 		<<" OurMu=" <<OurMu
-		<<endl;
+		<< std::endl;
 	os	<<"anne_this_terrain_bit=" <<(int)anne_this_terrain_bit
 		<<" anne_last_terrain_bit=" <<(int)anne_last_terrain_bit
-		<<endl <<endl;
+		<< std::endl << std::endl;
 
-	os	<< endl;
+	os	<< std::endl;
 #endif
 }
 

--- a/jp2_pc/Source/Lib/Physics/Xob_bc.hpp
+++ b/jp2_pc/Source/Lib/Physics/Xob_bc.hpp
@@ -76,9 +76,6 @@
 
 #include "Lib\Physics\pelvis_def.h"
 
-// Get the STL definition of the bool type and the true and false constants.
-#include <bool.h>
-
 class CInstance;
 class CEntityWater;
 
@@ -90,7 +87,7 @@ class CEntityWater;
   typedef basic_ostream<char,char_traits<char> > ostream; 
  };
 #else
- class ostream;
+#include <iostream>
 #endif
 
 typedef float	TVectorPair[2][3];
@@ -258,7 +255,7 @@ public:
 	//**********************************************************************************************
 	static void DumpStateAll
 	( 
-		ostream& os 
+		std::ostream& os
 	);
 	//
 	// Dumps the state to a text file.
@@ -451,7 +448,7 @@ private:
 
 	static void PD_Integrator_Internals( float delta_t );
 
-	void DumpState(ostream& os);
+	void DumpState(std::ostream& os);
 
 	//
 	// Integration stages.

--- a/jp2_pc/Source/Lib/Physics/dino_biped.cpp
+++ b/jp2_pc/Source/Lib/Physics/dino_biped.cpp
@@ -8,7 +8,7 @@
 #include "Pelvis_Def.h"
 #include "Pelvis.h"
 #include "futil.h"
-#include "iostream.h"
+#include <iostream>
 #include "Lib/Sys/ConIO.hpp"
 #include "Xob_BC.hpp"
 #include "BioModel.h"

--- a/jp2_pc/Source/Lib/Physics/dino_quad.cpp
+++ b/jp2_pc/Source/Lib/Physics/dino_quad.cpp
@@ -8,7 +8,7 @@
 #include "Pelvis_Def.h"
 #include "Pelvis.h"
 #include "futil.h"
-#include "iostream.h"
+#include <iostream>
 #include "Lib/Sys/ConIO.hpp"
 #include "Xob_BC.hpp"
 #include "BioModel.h"

--- a/jp2_pc/Source/Lib/Physics/foot.cpp
+++ b/jp2_pc/Source/Lib/Physics/foot.cpp
@@ -1,7 +1,7 @@
 //	Foot BC for pelvic model...
 //	===========================
 
-#include <iostream.h>
+#include <iostream>
 #include "Common.hpp"
 #include "Lib/Sys/ConIO.hpp"
 #include "Pelvis.h"

--- a/jp2_pc/Source/Lib/Physics/futil.cpp
+++ b/jp2_pc/Source/Lib/Physics/futil.cpp
@@ -10,7 +10,7 @@
 #include "Lib/Sys/DebugConsole.hpp"
 
 #include <math.h>
-#include <iostream.h>
+#include <iostream>
 
 
 

--- a/jp2_pc/Source/Lib/Physics/pelvis.h
+++ b/jp2_pc/Source/Lib/Physics/pelvis.h
@@ -81,7 +81,7 @@ class CInstance;
   typedef basic_ostream<char,char_traits<char> > ostream; 
  };
 #else
- class ostream;
+#include <iostream>
 #endif
 
 //	The shit itself...
@@ -150,7 +150,7 @@ const char* pcLoadPelvis(const char* pc, int i_pel);
 void PelReset();
 
 //	Dumps the state to a text file...
-void DumpPelState( ostream& os );
+void DumpPelState(std::ostream& os );
 
 //	Tools
 //	-----

--- a/jp2_pc/Source/Lib/Physics/pelvis_def.h
+++ b/jp2_pc/Source/Lib/Physics/pelvis_def.h
@@ -46,9 +46,6 @@
 //	Quit your bitching!
 #pragma warning(disable : 4244)
 
-// Get the STL definition of the bool type and the true and false constants.
-#include <bool.h>
-
 //	Amount of shit...
 #define	NUM_PELVISES 8
 #define PELVIS_PARAMETERS 55


### PR DESCRIPTION
In the `Physics` project, the STL includes are modernized and the `std::` namespace specifier is added where necessary.