### PR TITLE
System project: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/Sys/BitBuffer.cpp
+++ b/jp2_pc/Source/Lib/Sys/BitBuffer.cpp
@@ -22,8 +22,8 @@
 #include "GblInc/Common.hpp"
 #include "BitBuffer.hpp"
 
-#include <fstream.h>
-#include <iomanip.h>
+#include <fstream>
+#include <iomanip>
 
 
 //**********************************************************************************************
@@ -42,12 +42,12 @@
 	CBitBuffer::CBitBuffer(const char* str_filename)
 		: uCurrIndex_(0)
 	{
-		ifstream stream_load(str_filename, ios::in | ios::nocreate | ios::binary);
+		std::ifstream stream_load(str_filename, std::ios::in | std::ios::_Nocreate | std::ios::binary);
 
 		AlwaysAssert(stream_load.is_open());
 
 		// Determine the size of the file and round this up to the next buffer allocation unit multiple.
-		stream_load.seekg(0, ios::end);
+		stream_load.seekg(0, std::ios::end);
 	#ifdef __MWERKS__
 		int i_file_len = stream_load.tellg().offset();
 	#else
@@ -58,7 +58,7 @@
 
 		pmbBuffer = new SMemBuffer(u_num_buffer_units);
 
-		stream_load.seekg(0, ios::beg);
+		stream_load.seekg(0, std::ios::beg);
 		stream_load.read(reinterpret_cast<char *>(&pmbBuffer->pabuData[0]), i_file_len);
 	}
 
@@ -110,7 +110,7 @@
 	//******************************************************************************************
 	void CBitBuffer::Save(const char* str_filename) const
 	{
-		ofstream stream_save(str_filename, ios::out | ios::trunc | ios::binary);
+		std::ofstream stream_save(str_filename, std::ios::out | std::ios::trunc | std::ios::binary);
 
 		AlwaysAssert(stream_save.is_open());
 

--- a/jp2_pc/Source/Lib/Sys/DebugConsole.cpp
+++ b/jp2_pc/Source/Lib/Sys/DebugConsole.cpp
@@ -90,7 +90,7 @@ ostream					dout(&debug_stream);
 #elif (DEBUG_OUT == DEBUG_OUTPUT_BOTH)
 
 static	dbgstreambuf	debug_stream("DebugLog.txt");
-ostream					dout(&debug_stream);
+std::ostream			dout(&debug_stream);
 
 #endif
 
@@ -106,7 +106,7 @@ ostream					dout(&debug_stream);
 #ifdef __MWERKS__
 	dbgstreambuf::dbgstreambuf() : streambuf()
 #else
-	dbgstreambuf::dbgstreambuf() : streambuf(NULL,0)
+	dbgstreambuf::dbgstreambuf() : std::streambuf()
 #endif
 	{
 #if VER_DEBUG_TEXT
@@ -121,12 +121,12 @@ ostream					dout(&debug_stream);
 #ifdef __MWERKS__
 	dbgstreambuf::dbgstreambuf(char* str_name) : streambuf()
 #else
-	dbgstreambuf::dbgstreambuf(char* str_name) : streambuf(NULL,0)
+	dbgstreambuf::dbgstreambuf(char* str_name) : std::streambuf()
 #endif
 	{
 #if VER_DEBUG_TEXT
 		u4Off = 0;
-		dbgfile.open(str_name,ios::out|ios::trunc);
+		dbgfile.open(str_name,std::ios::out|std::ios::trunc);
 
 		// set the bfile flag on the state of the open file
 		bFile = dbgfile.is_open();

--- a/jp2_pc/Source/Lib/Sys/FixedHeap.cpp
+++ b/jp2_pc/Source/Lib/Sys/FixedHeap.cpp
@@ -45,8 +45,7 @@
 
 #include "Common.hpp"
 #include <malloc.h>
-#include "Set.h"
-#include "Multiset.h"
+#include <set>
 #include "Lib/W95/Direct3D.hpp"
 #include "TextOut.hpp"
 #include "FixedHeap.hpp"
@@ -179,8 +178,8 @@ public:
 // declarations; therefore 'THeapMem' and 'THeapSize' are declared as classes but use
 // Hungarian notation for typedefs.
 //
-class THeapMem  : public set<CHeapNode, CHeapNodeMemLess>{};
-class THeapSize : public multiset<CHeapNode, CHeapNodeSizeLess>{};
+class THeapMem  : public std::set<CHeapNode, CHeapNodeMemLess>{};
+class THeapSize : public std::multiset<CHeapNode, CHeapNodeSizeLess>{};
 
 
 //

--- a/jp2_pc/Source/Lib/Sys/LRU.cpp
+++ b/jp2_pc/Source/Lib/Sys/LRU.cpp
@@ -40,7 +40,7 @@
 #if defined(__MWERKS__)
 	#include <algorithm>
 #else
-	#include "Algo.h"
+	#include <algorithm>
 #endif
 
 //
@@ -117,7 +117,7 @@ public:
 			return;
 
 		// Use the STL Quicksort routine.
-		sort(papItems->atArray, papItems->atArray + papItems->uLen, CLRUItemCompare());
+		std::sort(papItems->atArray, papItems->atArray + papItems->uLen, CLRUItemCompare());
 
 		// Indicate that the list is now sorted.
 		bSorted = true;

--- a/jp2_pc/Source/Lib/Sys/Profile.cpp
+++ b/jp2_pc/Source/Lib/Sys/Profile.cpp
@@ -69,8 +69,8 @@
 #ifdef __MWERKS__
  #include <vector.h>
 #else
- #include "Stl/vector.h"
- #include "Stl/algo.h"
+ #include <vector>
+ #include <algorithm>
 #endif
 
 //
@@ -223,7 +223,7 @@ bool	gbNormalizeStats = true;					// set to true if stat is required in actual t
 			Assert(ppsParent->pvcList);
 
 			// Remove from list.
-			vector<CProfileStat*>::iterator vci = find(ppsParent->pvcList->begin(), ppsParent->pvcList->end(), this);
+			std::vector<CProfileStat*>::iterator vci = std::find(ppsParent->pvcList->begin(), ppsParent->pvcList->end(), this);
 			if (vci != ppsParent->pvcList->end())
 				ppsParent->pvcList->erase(vci);
 		}
@@ -268,7 +268,7 @@ bool	gbNormalizeStats = true;					// set to true if stat is required in actual t
 			// Subtract separate children from this stat before printing it.
 			TCycles cy_original = cyCycles;
 			if (pvcList)
-				for (vector<CProfileStat*>::iterator it = pvcList->begin(); it != pvcList->end(); it++)
+				for (std::vector<CProfileStat*>::iterator it = pvcList->begin(); it != pvcList->end(); it++)
 					if ((*it)->setepfFlags[epfSEPARATE])
 						cyCycles -= (*it)->cyCycles;
 
@@ -353,7 +353,7 @@ bool	gbNormalizeStats = true;					// set to true if stat is required in actual t
 			TCycles cy_other = cyCycles;
 
 			// Write non-separate children first, indented.
-			vector<CProfileStat*>::iterator it;
+			std::vector<CProfileStat*>::iterator it;
 			for (it = pvcList->begin(); it != pvcList->end(); it++)
 			{
 				if (b_show_hidden || !(*it)->setepfFlags[epfHIDDEN])
@@ -400,7 +400,7 @@ bool	gbNormalizeStats = true;					// set to true if stat is required in actual t
 		iCount = 0;
 
 		if (pvcList)
-			for (vector<CProfileStat*>::iterator it = pvcList->begin(); it != pvcList->end(); it++)
+			for (std::vector<CProfileStat*>::iterator it = pvcList->begin(); it != pvcList->end(); it++)
 				(*it)->Reset();
 	}
 
@@ -409,7 +409,7 @@ bool	gbNormalizeStats = true;					// set to true if stat is required in actual t
 	{
 		// Create list first time.
 		if (!pvcList)
-			pvcList = new vector<CProfileStat*>;
+			pvcList = new std::vector<CProfileStat*>;
 
 		// Add to list.
 		pvcList->push_back(pps);

--- a/jp2_pc/Source/Lib/Sys/Profile.hpp
+++ b/jp2_pc/Source/Lib/Sys/Profile.hpp
@@ -90,7 +90,7 @@
 #ifdef __MWERKS__
 #include <vector.h>
 #else
-template<class T> class vector;
+#include <vector>
 #endif
 
 class CConsoleBuffer;
@@ -231,7 +231,7 @@ protected:
 	CSet<EProfileFlag> setepfFlags;		// Various flags affecting display.
 
 	// A list of references to individual stats, for automatic printing, resetting, etc.
-	vector<CProfileStat*>* pvcList;
+	std::vector<CProfileStat*>* pvcList;
 #endif
 
 public:

--- a/jp2_pc/Source/Lib/Sys/Scheduler.cpp
+++ b/jp2_pc/Source/Lib/Sys/Scheduler.cpp
@@ -84,7 +84,7 @@
 #include "Common.hpp"
 #include "Lib/W95/WinInclude.hpp"
 #include "Lib/Sys/FastHeap.hpp"
-#include "Algo.h"
+#include <algorithm>
 #include "Lib/Sys/Textout.hpp"
 #include "Lib/Sys/Profile.hpp"
 #include "Scheduler.hpp"
@@ -291,7 +291,7 @@ public:
 		StartTimer();
 
 		// Sort by priority using STL's QSort routine.
-		sort(dapscitItems.atArray, dapscitItems.atArray + dapscitItems.uLen,
+		std::sort(dapscitItems.atArray, dapscitItems.atArray + dapscitItems.uLen,
 			 CSchedulerItemCompare());
 
 	#if bLOG_SCHEDULE

--- a/jp2_pc/Source/Lib/Sys/StdDialog.cpp
+++ b/jp2_pc/Source/Lib/Sys/StdDialog.cpp
@@ -47,14 +47,14 @@
 #include "ConIO.hpp"
 #include "Shell/ShellResource.h"
 
-#include "map.h"
+#include <map>
 
 //
 // Module definitions.
 //
 
 // Definition of a string to raster map.
-typedef map<HWND, CStdDialog*, less<HWND> > TMapDialogPump;
+typedef std::map<HWND, CStdDialog*, std::less<HWND> > TMapDialogPump;
 
 
 //


### PR DESCRIPTION
In the `System` project, the STL includes are modernized and the `std::` namespace specifier is added where necessary.