### PR TITLE
Render3D: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/Renderer/DepthSort.cpp
+++ b/jp2_pc/Source/Lib/Renderer/DepthSort.cpp
@@ -424,7 +424,7 @@
 #include "Lib/EntityDBase/WorldDBase.hpp"
 #include "Lib/EntityDBase/QualitySettings.hpp"
 
-#include "Algo.h"
+#include <algorithm>
 #include <Malloc.h>
 
 bool bNoCPPSubtriangle = false;
@@ -3532,7 +3532,7 @@ void DepthSortPolygons(CPipelineHeap& rplh, const CCamera& cam)
 #endif
 	
 	// Sort the polygons using STL's QSort routine.
-	sort(aprpoly, aprpoly + i_num_polys, CPolyFarZ());
+	std::sort(aprpoly, aprpoly + i_num_polys, CPolyFarZ());
 
 #if (DEPTH_SORT_STATS)
 	psQuickSort.Add(ctmr(), i_num_polys);
@@ -3564,7 +3564,7 @@ void DepthSortPolygons(CPipelineHeap& rplh, const CCamera& cam)
 		// Add finished polygon to scan conversion list.
 		rplh.darppolyPolygons << aprpoly[i];
 	}
-	i_num_polys = min(i_num_polys, ptsTolerances.iMaxToDepthsort);
+	i_num_polys = std::min(i_num_polys, ptsTolerances.iMaxToDepthsort);
 
 	// Push as many far away polygons as possible to the render list.
 	{

--- a/jp2_pc/Source/Lib/Renderer/Fog.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Fog.cpp
@@ -173,10 +173,10 @@
 #include "Lib/EntityDBase/Query/QRenderer.hpp"
 
 #if bPRINT_FOG_TABLE
-	#include <fstream.h>
-	#include <iomanip.h>
+	#include <fstream>
+	#include <iomanip>
 
-	ofstream stream;
+	std::ofstream stream;
 #endif
 
 extern bool        bUseOutputFiles;
@@ -212,7 +212,7 @@ extern bool        bUseOutputFiles;
             {
 			    stream.open("fog.txt");
 
-			    stream << setiosflags(ios::left) << setprecision(5);
+			    stream << std::setiosflags(std::ios::left) << std::setprecision(5);
  			    stream << "Fog Creation...\n\n" << "Level to Y\n";
             }
 		#endif
@@ -291,7 +291,7 @@ extern bool        bUseOutputFiles;
 			#if bPRINT_FOG_TABLE
                 if (bUseOutputFiles)
                 {
-				    stream << setw(4) << i_fog_level << " -> " << setw(5) << r_fog_end_y << "  ";
+				    stream << std::setw(4) << i_fog_level << " -> " << std::setw(5) << r_fog_end_y << "  ";
                 }
 			#endif
 
@@ -331,7 +331,7 @@ extern bool        bUseOutputFiles;
 			#if bPRINT_FOG_TABLE
                 if (bUseOutputFiles)
                 {
-				    stream << r_fog_end_y << endl;
+				    stream << r_fog_end_y << std::endl;
                 }
 			#endif
 
@@ -358,8 +358,8 @@ extern bool        bUseOutputFiles;
 
                 if (bUseOutputFiles)
                 {
-				    stream << setw(4) << i_curr_index << " [" << setw(9) << r_range_start << ", " << setw(9) << r_range_end << ")";
-				    stream << " -> " << paiYToLevel[i_curr_index] << ", " << pafYToLevel[i_curr_index] << endl;
+				    stream << std::setw(4) << i_curr_index << " [" << std::setw(9) << r_range_start << ", " << std::setw(9) << r_range_end << ")";
+				    stream << " -> " << paiYToLevel[i_curr_index] << ", " << pafYToLevel[i_curr_index] << std::endl;
                 }
 			}
 

--- a/jp2_pc/Source/Lib/Renderer/GeomTypesCamera.cpp
+++ b/jp2_pc/Source/Lib/Renderer/GeomTypesCamera.cpp
@@ -239,7 +239,7 @@ public:
 	}
 	
 	//******************************************************************************************
-	virtual esfSideOf(const CTransform3<>& tf3_box) const
+	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const
 	{
 		// Intersect with each plane in turn.
 		ESideOf esf = 0;

--- a/jp2_pc/Source/Lib/Renderer/Light.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Light.cpp
@@ -254,11 +254,11 @@
 //
 
 	//******************************************************************************************
-	CLightList::CLightList(const list<CInstance*>& listins_lights)
+	CLightList::CLightList(const std::list<CInstance*>& listins_lights)
 	{
 		lvAmbient = 0;
 
-		list<CInstance*>::const_iterator itins = listins_lights.begin();
+		std::list<CInstance*>::const_iterator itins = listins_lights.begin();
 		for ( ; itins != listins_lights.end(); itins++)
 		{
 			// Retrieve the light from the instance.
@@ -294,7 +294,7 @@
 	void CLightList::SetViewingContext(const CPresence3<>& pr3, const CPresence3<>& pr3_eye)
 	{
 		// Set the viewing context in each of the children.
-		forall (listpltAll, list< rptr<CLightDir> >, it)
+		forall (listpltAll, std::list< rptr<CLightDir> >, it)
 		{
 			(*it)->SetViewingContext(pr3);
 		}
@@ -312,7 +312,7 @@
 	void CLightList::UpdateShadows(CPartition* ppart)
 	{
 		// Update the shadows of all children.
-		forall (listpltAll, list< rptr<CLightDir> >, it)
+		forall (listpltAll, std::list< rptr<CLightDir> >, it)
 		{
 			(*it)->UpdateShadows(ppart);
 		}
@@ -340,7 +340,7 @@
 		{
 			TLightVal lv_specular = 0;
 
-			forall_const (listpltAll, list< rptr<CLightDir> >, it)
+			forall_const (listpltAll, std::list< rptr<CLightDir> >, it)
 			{
 				if ((*it)->bShadowed(v3_pos))
 					continue;
@@ -375,7 +375,7 @@
 		else
 		{
 			// Handle Directional lights explicitly, avoiding a call to ltiGetInfo().
-			forall_const (listpltDir, list< rptr<CLightDirectional> >, it)
+			forall_const (listpltDir, std::list< rptr<CLightDirectional> >, it)
 			{
 				if ((*it)->bShadowed(v3_pos))
 					continue;
@@ -388,7 +388,7 @@
 			}
 
 			// Do the remaining lights.
-			forall_const (listpltPos, list< rptr<CLightDir> >, itd)
+			forall_const (listpltPos, std::list< rptr<CLightDir> >, itd)
 			{
 				if ((*itd)->bShadowed(v3_pos))
 					continue;
@@ -443,7 +443,7 @@
 			if (listpltAll.size() != 0)
 			{
 				// Yes!  Add them up.
-				forall_const (listpltAll, list< rptr<CLightDir> >, it)
+				forall_const (listpltAll, std::list< rptr<CLightDir> >, it)
 				{
 					if ((*it)->bShadowed(v3_pos))
 						continue;
@@ -517,7 +517,7 @@
 		blt.lvAmbient = lvAmbient;
 
 		// Iterate through directional lights, finding strongest.
-		forall_const (listpltDir, list< rptr<CLightDirectional> >, it)
+		forall_const (listpltDir, std::list< rptr<CLightDirectional> >, it)
 			SetMax(blt.lvStrength, (*it)->lvIntensity);
 
 		// We do not need light direction or width; just ignore these.

--- a/jp2_pc/Source/Lib/Renderer/Light.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Light.hpp
@@ -73,7 +73,7 @@
 #include "GeomTypes.hpp"
 #include "Shadow.hpp"
 
-#include <list.h>
+#include <list>
 
 //
 // Opaque declarations.
@@ -501,10 +501,10 @@ class CLightList
 {
 protected:
 	TLightVal						lvAmbient;		// The total ambient light in the list.
-	list< rptr<CLightDirectional> >	listpltDir;		// Directional, non-positional lights.
+	std::list< rptr<CLightDirectional> >	listpltDir;		// Directional, non-positional lights.
 													// Stored in a separate list for optimisation.
-	list< rptr<CLightDir> >			listpltPos;		// Positional lights.
-	list< rptr<CLightDir> >			listpltAll;		// Union of above two lists.
+	std::list< rptr<CLightDir> >			listpltPos;		// Positional lights.
+	std::list< rptr<CLightDir> >			listpltAll;		// Union of above two lists.
 	CDir3<>							d3Eye;			// Cached eye direction for scene.
 
 public:
@@ -515,7 +515,7 @@ public:
 
 	CLightList
 	(
-		const list<CInstance*>& listins_lights	// A list of instances whose render types are lights.
+		const std::list<CInstance*>& listins_lights	// A list of instances whose render types are lights.
 	);
 
 	//******************************************************************************************

--- a/jp2_pc/Source/Lib/Renderer/LineSide2D.cpp
+++ b/jp2_pc/Source/Lib/Renderer/LineSide2D.cpp
@@ -93,8 +93,8 @@
 // Required includes.
 //
 #include <math.h>
-#include "algo.h"
-#include "multiset.h"
+#include <algorithm>
+#include <set>
 #include "Common.hpp"
 #include "Lib/Std/CircularList.hpp"
 #include "LineSide2D.hpp"
@@ -606,7 +606,7 @@ void RadialOrder(CPArray< CVector2<> >& rpav2, TCList& clist)
 #endif // bOUTPUT_LINESIDE2D_DATA
 
 	// Sort the radial array using STL's QSort routine.
-	sort(parad.atArray, parad.atArray + parad.uLen, CRadial());
+	std::sort(parad.atArray, parad.atArray + parad.uLen, CRadial());
 
 	RemoveSameAnglePoints(parad, v2);
 

--- a/jp2_pc/Source/Lib/Renderer/Material.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Material.cpp
@@ -67,7 +67,7 @@
 #include "Lib/Sys/DebugConsole.hpp"
 
 #include <math.h>
-#include <set.h>
+#include <set>
 #include <memory.h>
 
 
@@ -185,7 +185,7 @@
 		return pmatFindShared(&mat);
 	}
 
-	typedef set<CMaterial, less<CMaterial> > TSM;
+	typedef std::set<CMaterial, std::less<CMaterial> > TSM;
 	TSM tsmMaterialInstances;
 
 	//**************************************************************************************
@@ -199,7 +199,7 @@
 			return &matDEFAULT;
 
 		// Insert or find, please.
-		pair<TSM::iterator, bool> p = tsmMaterialInstances.insert(*pmat);
+		std::pair<TSM::iterator, bool> p = tsmMaterialInstances.insert(*pmat);
 
 		// If we found a duplicate, it will do.
 		// If we inserted a new one, the new one will do.

--- a/jp2_pc/Source/Lib/Renderer/Occlude.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Occlude.cpp
@@ -126,7 +126,7 @@
 
 #include "Common.hpp"
 #include "Lib/Sys/Profile.hpp"
-#include "Algo.h"
+#include <algorithm>
 #include "Lib/Transform/VectorRange.hpp"
 #include "Lib/Renderer/GeomTypes.hpp"
 #include "Lib/Renderer/Camera.hpp"
@@ -836,7 +836,7 @@ void CopyOccludePolygons(CPArray<COcclude*>& rpapoc, const CCamera& cam, TOcclud
 	rpapoc.uLen = uint(i);
 
 	// Sort occlusion object by size from the largest to the smallest.
-	sort(rpapoc.atArray, rpapoc.atArray + rpapoc.uLen, CSortOcclude());
+	std::sort(rpapoc.atArray, rpapoc.atArray + rpapoc.uLen, CSortOcclude());
 
 	// Cap the number of occluding objects that can be considered.
 	rpapoc.uLen = Min(rpapoc.uLen, uint(COcclude::iMaxNumOccludeObjects));

--- a/jp2_pc/Source/Lib/Renderer/Occlude.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Occlude.hpp
@@ -115,7 +115,7 @@
 //
 // Required includes.
 //
-#include "list.h"
+#include <list>
 #include "Lib/GeomDBase/Partition.hpp"
 #include "Lib/GeomDBase/Mesh.hpp"
 #include "Lib/Sys/FastHeap.hpp"
@@ -143,7 +143,7 @@ class COcclude;
 //
 
 // Type describing a container of pointers to occluding polygons.
-typedef CContainer< list<COcclude> > TOccludeList;
+typedef CContainer< std::list<COcclude> > TOccludeList;
 // Prefix: polylist
 
 // Switch to apply a slight bias to occlusion planes to make them more tolerant.

--- a/jp2_pc/Source/Lib/Renderer/Overlay.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Overlay.cpp
@@ -25,7 +25,7 @@
 //
 // Defines and pragmas.
 //
-#include <map.h>
+#include <map>
 #include <math.h>
 #include <memory.h>
 #include "Common.hpp"

--- a/jp2_pc/Source/Lib/Renderer/Particles.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Particles.cpp
@@ -110,7 +110,7 @@
 #include "Lib/GeomDBase/Terrain.hpp"
 #include "Lib/EntityDBase/Query/QTerrain.hpp"
 
-#include <map.h>
+#include <map>
 #include <math.h>
 #include <memory.h>
 
@@ -166,7 +166,7 @@ static CRandom rndParticles;
 
 //******************************************************************************************
 //
-class CTextureColours : public map< TD3DPixel, CTexture*, less<TD3DPixel> >
+class CTextureColours : public std::map< TD3DPixel, CTexture*, std::less<TD3DPixel> >
 //
 // Less than comparison class for texture colours.
 //
@@ -239,7 +239,7 @@ public:
 		#ifdef __MWERKS__
 			insert(pair<const TD3DPixel, CTexture*>(clr.d3dcolGetD3DColour(), ptex));
 		#else
-			insert(pair<TD3DPixel, CTexture*>(clr.d3dcolGetD3DColour(), ptex));
+			insert(std::pair<TD3DPixel, CTexture*>(clr.d3dcolGetD3DColour(), ptex));
 		#endif
 
 			// Find the colour back.
@@ -647,7 +647,7 @@ protected:
 
 //*********************************************************************************************
 //
-class CParticleList : public list<CParticleBase>
+class CParticleList : public std::list<CParticleBase>
 //
 // Object describes a list of particles.
 //

--- a/jp2_pc/Source/Lib/Renderer/PipeLine.cpp
+++ b/jp2_pc/Source/Lib/Renderer/PipeLine.cpp
@@ -1836,7 +1836,7 @@ public:
 	}
 
 	//******************************************************************************************
-	void CRenderer::RenderScene(const CCamera& cam, const list<CInstance*>& listins_lights,
+	void CRenderer::RenderScene(const CCamera& cam, const std::list<CInstance*>& listins_lights,
 			                    CPartition* ppart_scene, const CPArray<COcclude*>& rpapoc,
 								ESideOf esf_view, CPartition* ppart_terrain)
 	{
@@ -1885,7 +1885,7 @@ public:
 		CPipelineHeap plh;			// Local version of the pipeline heap.
 
 		// Create the rendering context for this scene.
-		CLightList ltl(list<CInstance*>());
+		CLightList ltl = std::list<CInstance*>();
 
 		CRenderContext renc(*this, plh, cam, ltl);
 

--- a/jp2_pc/Source/Lib/Renderer/PipeLine.hpp
+++ b/jp2_pc/Source/Lib/Renderer/PipeLine.hpp
@@ -251,7 +251,7 @@
 #include "ScreenRender.hpp"
 #include "Lib/EntityDBase/Instance.hpp"
 
-#include <list.h>
+#include <list>
 
 //********************************************************************************************
 //
@@ -453,7 +453,7 @@ public:
 	void RenderScene
 	(
 		const CCamera& cam,							// Camera for this scene.
-		const list<CInstance*>& listins_lights,		// A list of lights in the scene.
+		const std::list<CInstance*>& listins_lights,		// A list of lights in the scene.
 		CPartition* ppart_scene,					// The world partition to render.
 		const CPArray<COcclude*>& rpapoc,				// Array of occluding objects.
 		ESideOf esf_view = esfINTERSECT,			// The presumed relation of the scene to the

--- a/jp2_pc/Source/Lib/Renderer/PipeLineHelp.cpp
+++ b/jp2_pc/Source/Lib/Renderer/PipeLineHelp.cpp
@@ -85,8 +85,8 @@
 #include "RenderDefs.hpp"
 #include "Camera.hpp"
 
-#include <list.h>
-#include <multiset.h>
+#include <list>
+#include <set>
 
 //
 // Defines.
@@ -360,8 +360,8 @@ void SetCompareValues
 
 		if (bFrontToBack)
 		{
-			multiset<CRenderPolygon*, CPolyCompLess> mset_rpoly;
-			multiset<CRenderPolygon*, CPolyCompLess>::iterator itmset;
+			std::multiset<CRenderPolygon*, CPolyCompLess> mset_rpoly;
+			std::multiset<CRenderPolygon*, CPolyCompLess>::iterator itmset;
 
 			// Set the pointer values in the array.
 			int i_start = rplh.darppolyPolygons.uLen;
@@ -383,8 +383,8 @@ void SetCompareValues
 		}
 		else
 		{
-			multiset<CRenderPolygon*, CPolyCompGT> mset_rpoly;
-			multiset<CRenderPolygon*, CPolyCompGT>::iterator itmset;
+			std::multiset<CRenderPolygon*, CPolyCompGT> mset_rpoly;
+			std::multiset<CRenderPolygon*, CPolyCompGT>::iterator itmset;
 
 			// Set the pointer values in the array.
 			int i_start = rplh.darppolyPolygons.uLen;

--- a/jp2_pc/Source/Lib/Renderer/RenderCache.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCache.hpp
@@ -75,7 +75,7 @@
 //
 // Includes.
 //
-#include <set.h>
+#include <set>
 #include "RenderCacheInterface.hpp"
 #include "Lib/GeomDBase/Mesh.hpp"
 #include "Lib/Renderer/Pipeline.hpp"
@@ -586,7 +586,7 @@ class CRenderCacheList
 {
 public:
 
-	typedef set<CPartition*, less<CPartition*> > TCacheSet;
+	typedef std::set<CPartition*, std::less<CPartition*> > TCacheSet;
 	TCacheSet partlistCached;
 
 public:

--- a/jp2_pc/Source/Lib/Renderer/RenderCacheInterface.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCacheInterface.hpp
@@ -75,7 +75,7 @@
 #include "Lib/EntityDBase/Instance.hpp"
 #include "Lib/GeomDBase/Shape.hpp"
 #include "Lib/EntityDBase/WorldDBase.hpp"
-#include "List.h"
+#include <list>
 
 
 //

--- a/jp2_pc/Source/Lib/Renderer/ScreenPolygon.cpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenPolygon.cpp
@@ -36,9 +36,8 @@
 //
 // Includes.
 //
-#include "Algo.h"
-#include "vector.h"
-#include "TempBuf.cpp"
+#include <algorithm>
+#include <vector>
 #include "Common.hpp"
 #include "Lib/W95/Direct3D.hpp"
 #include "ScreenRender.hpp"
@@ -60,7 +59,7 @@
 #define iMAX_POLY_VERTICES (40)
 
 // Definition of a line segment array.
-typedef vector<CLine2D> TVLines;
+typedef std::vector<CLine2D> TVLines;
 
 bool bDumpPolylist = false;
 

--- a/jp2_pc/Source/Lib/Renderer/ScreenRender.hpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenRender.hpp
@@ -322,6 +322,8 @@ struct SRenderCoord
 		};
 	};
 	CVector3<>		v3Screen;			// Screen X, Y and 1/Z coords.
+
+	SRenderCoord() : iYScr(0) {}
 };
 
 //**********************************************************************************************

--- a/jp2_pc/Source/Lib/Renderer/Shadow.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Shadow.cpp
@@ -307,7 +307,7 @@ struct SRenderSettingsShadow: public CRenderer::SSettings
 
 		// Render all world objects with this camera and renderer.
 		//pscren->BeginFrame();
-		ren.RenderScene(cam, list<CInstance*>(), wWorld.ppartPartitionList(), papoc);
+		ren.RenderScene(cam, std::list<CInstance*>(), wWorld.ppartPartitionList(), papoc);
 		pscren->EndFrame();
 	}
 
@@ -391,7 +391,7 @@ struct SRenderSettingsShadow: public CRenderer::SSettings
 		CLArray(COcclude*, paoc, 0);
 
 		// Render with our camera, and an empty light list.
-		ren.RenderScene(*pCamera, list<CInstance*>(), ppart, paoc);
+		ren.RenderScene(*pCamera, std::list<CInstance*>(), ppart, paoc);
 		psr_context->EndFrame();
 	}
 

--- a/jp2_pc/Source/Lib/Renderer/Shadow.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Shadow.hpp
@@ -67,7 +67,7 @@
 #include "Lib/EntityDBase/Instance.hpp"
 #include "Lib/Renderer/GeomTypes.hpp"
 
-#include <list.h>
+#include <list>
 
 //
 // Definitions for CShadowBuffer.

--- a/jp2_pc/Source/Lib/Renderer/Sky.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Sky.cpp
@@ -224,6 +224,9 @@
 #include "lib/W95/WinInclude.hpp"
 #include "Lib/GeomDBase/PartitionPriv.hpp"
 #include "Sky.hpp"
+
+#include <algorithm>
+
 #include "Lib/Groff/ValueTable.hpp"
 #include "Lib/Loader/Loader.hpp"
 #include "Lib/Sys/W95/Render.hpp"
@@ -1106,7 +1109,7 @@ LINE_DONE:
 		for (int i_pixel = iRENDER_BLOCK_SIZE; i_pixel < u4ScreenWidth; i_pixel += iRENDER_BLOCK_SIZE)
 		{
 			psv_saved = &asv_saved[0];
-			int i4_width = min(iRENDER_BLOCK_SIZE, (int)u4ScreenWidth - i_pixel);
+			int i4_width = std::min(iRENDER_BLOCK_SIZE, (int)u4ScreenWidth - i_pixel);
 
 			for (i_line = 0; i_line < i_lines_drawn; i_line++)
 			{


### PR DESCRIPTION
In the `Render3D` project, the STL includes are modernized and the `std::` namespace specifier is added where necessary, and a couple of other minor corrections are made.