### PR TITLE
ScreenRenderDWI: STL includes and std::* treatment

### DIFF
--- a/jp2_pc/Source/Lib/Renderer/Primitives/FastBump.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Primitives/FastBump.cpp
@@ -94,7 +94,7 @@
 #include <string.h>
 #include <memory.h>
 #include <math.h>
-#include <map.h>
+#include <map>
 
 #define bAXIS_SWAP			(1)
 
@@ -1903,7 +1903,7 @@ void MatrixFromHash
 //
 // Set of bump map matrices.
 //
-typedef map< int, CMatrix3<>*, less<int> > TMapMatrixHash;
+typedef std::map< int, CMatrix3<>*, std::less<int> > TMapMatrixHash;
 TMapMatrixHash* pmapBumpMatrices = 0;
 
 

--- a/jp2_pc/Source/Lib/Renderer/RenderCache.cpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCache.cpp
@@ -1638,7 +1638,7 @@ static CProfileStat psFailed("Failed", &proHardware.psHardware);
 	{
 		if (rcsRenderCacheSettings.bFreezeCaches)
 			return;
-		list<CPartition*> list_partremove;	// List of partitions to remove.
+		std::list<CPartition*> list_partremove;	// List of partitions to remove.
 
 		//
 		// Iterate through the list of partitions with caches.
@@ -1659,7 +1659,7 @@ static CProfileStat psFailed("Failed", &proHardware.psHardware);
 
 		// Euthanize old caches.
 		{
-			list<CPartition*>::iterator it_partlist = list_partremove.begin();
+			std::list<CPartition*>::iterator it_partlist = list_partremove.begin();
 			for (; it_partlist != list_partremove.end(); it_partlist++)
 				(*it_partlist)->DeleteRenderCache();
 		}

--- a/jp2_pc/Source/Lib/Renderer/RenderCache.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCache.hpp
@@ -75,7 +75,7 @@
 //
 // Includes.
 //
-#include <set.h>
+#include <set>
 #include "RenderCacheInterface.hpp"
 #include "Lib/GeomDBase/Mesh.hpp"
 #include "Lib/Renderer/Pipeline.hpp"
@@ -586,7 +586,7 @@ class CRenderCacheList
 {
 public:
 
-	typedef set<CPartition*, less<CPartition*> > TCacheSet;
+	typedef std::set<CPartition*, std::less<CPartition*> > TCacheSet;
 	TCacheSet partlistCached;
 
 public:

--- a/jp2_pc/Source/Lib/Renderer/RenderCacheHelp.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCacheHelp.hpp
@@ -72,7 +72,7 @@
 //
 // Includes.
 //
-#include "list.h"
+#include <list>
 #include "Lib/Transform/Vector.hpp"
 #include "Lib/Transform/Rotate.hpp"
 #include "Lib/Sys/FastHeap.hpp"
@@ -98,7 +98,7 @@ class CRaster;
 //
 
 // Type used to maintain a list of partition pointers.
-typedef list<CPartition*> TPPartitionList;
+typedef std::list<CPartition*> TPPartitionList;
 
 
 //

--- a/jp2_pc/Source/Lib/Renderer/RenderCacheInterface.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCacheInterface.hpp
@@ -75,7 +75,7 @@
 #include "Lib/EntityDBase/Instance.hpp"
 #include "Lib/GeomDBase/Shape.hpp"
 #include "Lib/EntityDBase/WorldDBase.hpp"
-#include "List.h"
+#include <list>
 
 
 //

--- a/jp2_pc/Source/Lib/Renderer/RenderType.cpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderType.cpp
@@ -74,7 +74,7 @@
 #include "Lib\Sys\Profile.hpp"
 
 
-extern map<uint32, SMeshInstance, less<uint32> > mapMeshInstances;
+extern std::map<uint32, SMeshInstance, std::less<uint32> > mapMeshInstances;
 extern uint g_u_Version_Number;
 
 

--- a/jp2_pc/Source/Lib/Renderer/ScreenRenderAuxD3D.cpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenRenderAuxD3D.cpp
@@ -184,7 +184,7 @@
 //
 // Includes.
 //
-#include "Algo.h"
+#include <algorithm>
 #include "Common.hpp"
 #include "Lib/W95/WinInclude.hpp"
 #include "Lib/W95/Direct3D.hpp"
@@ -1197,7 +1197,7 @@ public:
 		agpAGPTextureMemManager.MakeCurrentList();
 
 		// Sort the polygons by largest area first.
-		sort(arp.atArray, arp.atArray + arp.uLen, CPolyArea());
+		std::sort(arp.atArray, arp.atArray + arp.uLen, CPolyArea());
 
 		// Upload textures.
 		priv_self.UploadPolygonArray(arp);

--- a/jp2_pc/Source/Lib/Renderer/ScreenRenderAuxD3DBatch.cpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenRenderAuxD3DBatch.cpp
@@ -102,7 +102,7 @@
 //
 // Includes.
 //
-#include "Algo.h"
+#include <algorithm>
 #include "Common.hpp"
 #include "ScreenRenderAuxD3DBatch.hpp"
 
@@ -570,7 +570,7 @@ void RasterizeBatch(CPArray<CRenderPolygon>& parpoly)
 	}
 
 	// Sort all the opaque textures by texture.
-	sort(appoly_opaque.atArray, appoly_opaque.atArray + appoly_opaque.uLen, CSortByD3DTexture());
+	std::sort(appoly_opaque.atArray, appoly_opaque.atArray + appoly_opaque.uLen, CSortByD3DTexture());
 
 	// Initialize for hardware rasterizing.
 	srd3dRenderer.SetD3DMode(ed3drHARDWARE_LOCK);
@@ -613,7 +613,7 @@ void RasterizeCacheBatch(CPArray<CRenderPolygon>& parpoly)
 	if (d3dDriver.bIsPageManaged())
 	{
 		// Sort the list by Direct3D texture address.
-		sort(appoly.atArray, appoly.atArray + appoly.uLen, CSortByBaseTexture());
+		std::sort(appoly.atArray, appoly.atArray + appoly.uLen, CSortByBaseTexture());
 	}
 
 	// Initialize for hardware rasterizing.
@@ -705,7 +705,7 @@ void RasterizeTerrainBatch(CPArray<CRenderPolygon>& parpoly)
 	}
 
 	// Sort the list by Direct3D texture address.
-	sort(appoly.atArray, appoly.atArray + appoly.uLen, CSortByBaseTexture());
+	std::sort(appoly.atArray, appoly.atArray + appoly.uLen, CSortByBaseTexture());
 
 	// Calculate offset.
 	CScreenRenderAuxD3D::fOffsetX = float(prasMainScreen->iOffsetX) + CScreenRenderAuxD3D::fOffsetXBase;
@@ -825,7 +825,7 @@ void RemovePrerasterized(CPArray<CRenderPolygon>& parpoly)
 	//
 
 	// Sort by maximum z.
-	sort(appoly_software.atArray, appoly_software.atArray + appoly_software.uLen, CPolyFarZ());
+	std::sort(appoly_software.atArray, appoly_software.atArray + appoly_software.uLen, CPolyFarZ());
 
 	// Cull as many polygons as possible.
 	for (i_poly_pre = 0; i_poly_pre < int(appoly_prerast.uLen); ++i_poly_pre)


### PR DESCRIPTION
In the `ScreenRenderDWI` project, the STL includes are modernized and the `std::` namespace specifier is added where necessary.