### PR TITLE
Compile EntityDBbase, GeomDBbase, Render3d

### DIFF
--- a/jp2_pc/Source/Lib/EntityDBase/FilterIterator.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/FilterIterator.hpp
@@ -65,7 +65,7 @@ template<class C, class T> class CIteratorFilter
 public:
 
 	C* pContainer;				// Pointer to the STL container.
-	C::iterator itContainer;	// Iterator for the STL container.
+	typename C::iterator itContainer;	// Iterator for the STL container.
 
 public:
 

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes.cpp
@@ -283,7 +283,7 @@ extern CProfileStat psMsgSubscribe, psMoveMsgQuery;
 	{
 		CMessageTrigger* pmsg_new = new(frhFrameHeap) CMessageTrigger(ptrGetActivatedTrigger());
 		*pmsg_new = *this;
-		qmQueueMessage.pdqwmNextMessages->push(pmsg_new);
+		qmQueueMessage.pdqwmNextMessages->push({ pmsg_new });
 	}
 
 
@@ -769,5 +769,5 @@ namespace
 	{
 		CMessageAudio* pmsg_new = new(frhFrameHeap) CMessageAudio();
 		*pmsg_new = *this;
-		qmQueueMessage.pdqwmNextMessages->push(pmsg_new);
+		qmQueueMessage.pdqwmNextMessages->push({ pmsg_new });
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/QueueMessage.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/QueueMessage.cpp
@@ -138,7 +138,7 @@
 		//
 		while (!pdqwmCurrentMessages->empty())
 		{
-			(pdqwmCurrentMessages->front())->Send();
+			pdqwmCurrentMessages->front().front()->Send();
 			pdqwmCurrentMessages->pop();
 		}
 		

--- a/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
@@ -2178,7 +2178,7 @@ CRenderDB*  ps_renderDB = 0;
 		// Query the terrain partition for objects at X,Y
 		
 		// Make a tiny spatial partition.
-		CPartitionSpace ps(CBoundVolPoint());
+		CPartitionSpace ps = CBoundVolPoint();
 		ps.SetPos(CVector3<>(r_x,r_y,0.0f));
 
 		CWDbQueryTerrainObj qto(&ps);

--- a/jp2_pc/Source/Lib/GeomDBase/PartitionPriv.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/PartitionPriv.hpp
@@ -289,10 +289,7 @@ public:
 
 private:
 
-	class CPartition::CPriv;
-
 	friend class CPartition;
-	friend class CPartition::CPriv;
 	friend float CPartitionSpace::fDistanceFromGlobalCameraSqr() const;
 	friend float CInstance::fDistanceFromGlobalCameraSqr() const;
 

--- a/jp2_pc/Source/Lib/GeomDBase/PartitionSpace.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/PartitionSpace.hpp
@@ -143,6 +143,32 @@ public:
 	virtual ~CPartitionSpace();
 
 
+	//Copy constructor
+	CPartitionSpace(const CPartitionSpace& other)
+		: CPartition(other),
+		v3Position(other.v3Position),
+		bvbBox(other.bvbBox)
+	{
+		//Copy only box, assuming it is the largest union member
+		static_assert(sizeof(bviInfinite) <= sizeof(bvbBox) && sizeof(bvsSphere) <= sizeof(bvbBox));
+	}
+
+	//Copy assignment operator
+	CPartitionSpace& operator=(const CPartitionSpace& other)
+	{
+		if (this == &other)
+			return *this;
+
+		CPartition::operator =(other); //Parent class
+		v3Position = other.v3Position;
+		
+		//Copy only box, assuming it is the largest union member
+		static_assert(sizeof(bviInfinite) <= sizeof(bvbBox) && sizeof(bvsSphere) <= sizeof(bvbBox));
+		bvbBox = other.bvbBox;
+		
+		return *this;
+	}
+	
 	//*****************************************************************************************
 	//
 	// Member functions.

--- a/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.hpp
@@ -58,6 +58,7 @@ namespace NMultiResolution
 {
 	class CQuadNodeTIN;
 	class CQuadRootTIN;
+	class CScheduleTerrainTextureItem;
 
 	//Default amount memory to allocate for terrain textures, in KB.
 	#define iDEFAULT_TERRAIN_TEXTURE_MEMORY_KB					1200
@@ -88,6 +89,7 @@ namespace NMultiResolution
 	private:
 		class CPriv;
 		friend class CPriv;
+		friend class CScheduleTerrainTextureItem;
 
 		friend class CBlockAllocator<CTextureNode>;
 		static CBlockAllocator<CTextureNode>::SStore stStore; // Storage for the types.

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTree.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTree.cpp
@@ -523,7 +523,7 @@ namespace NMultiResolution
 
 
 	// Constant used in expressions to avoid crummy code generation by the fucked-up compiler.
-	static const CQuadNodeTIN::TState stMASK_TRI = Set(CQuadNodeTIN::estLEAF) + CQuadNodeTIN::estLEAF_COMBINE;
+	static const CQuadNodeTIN::TState stMASK_TRI = CQuadNodeTIN::TState() + CQuadNodeTIN::estLEAF + CQuadNodeTIN::estLEAF_COMBINE;
 
 	//******************************************************************************************
 	int CQuadNodeTIN::iEvaluateBranch(const CQuadRootTIN* pqntin_root)

--- a/jp2_pc/Source/Lib/Renderer/ScreenRender.hpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenRender.hpp
@@ -323,7 +323,10 @@ struct SRenderCoord
 	};
 	CVector3<>		v3Screen;			// Screen X, Y and 1/Z coords.
 
-	SRenderCoord() : iYScr(0) {}
+	SRenderCoord() : v3Cam()
+	{
+		static_assert(sizeof(v3Cam) >= sizeof(iYScr)); //Ensure we init the biggest union member
+	}
 };
 
 //**********************************************************************************************


### PR DESCRIPTION
Various adjustments to make the projects `EntityDBase` and `GeomDBase`, and also a small fix in `Render3D`.
The details will be explained in additional review comments.
Note that `static_assert` instructions are evaluated at compile time and impose no runtime cost.