### PR TITLE
Math and Std projects: STL includes and std::* treatment  GamerDude27

### DIFF
--- a/jp2_pc/Source/Lib/Std/ArrayIO.hpp
+++ b/jp2_pc/Source/Lib/Std/ArrayIO.hpp
@@ -19,10 +19,10 @@
 
 #include "Array.hpp"
 
-#include <iostream.h>
+#include <iostream>
 
 //******************************************************************************************
-template<class T, class A> ostream& operator <<(ostream& os, CArrayT<T, A> a)
+template<class T, class A> std::ostream& operator <<(std::ostream& os, CArrayT<T, A> a)
 {
 	for (int i = 0; i < a.size(); i++)
 		os << a[i] << ' ';

--- a/jp2_pc/Source/Lib/Std/CircularList.hpp
+++ b/jp2_pc/Source/Lib/Std/CircularList.hpp
@@ -145,7 +145,7 @@ public:
 
 	//******************************************************************************************
 	//
-	N::TData operator*()
+	typename N::TData operator*()
 	//
 	// Dereferences the data associated with the iterator.
 	//
@@ -156,7 +156,7 @@ public:
 
 	//******************************************************************************************
 	//
-	N::TData operator*() const
+	typename N::TData operator*() const
 	//
 	// Dereferences the data associated with the iterator.
 	//
@@ -490,9 +490,9 @@ public:
 //
 // Static variables for memory allocation.
 //
-template<class T> CCircularList<T>::TNode* CCircularList<T>::pAllocator;
-template<class T> CCircularList<T>::TNode* CCircularList<T>::pBeginAllocation;
-template<class T> CCircularList<T>::TNode* CCircularList<T>::pMaxAllocation;
+template<class T> typename CCircularList<T>::TNode* CCircularList<T>::pAllocator;
+template<class T> typename CCircularList<T>::TNode* CCircularList<T>::pBeginAllocation;
+template<class T> typename CCircularList<T>::TNode* CCircularList<T>::pMaxAllocation;
 
 
 #endif // HEADER_STD_CIRCULARBUFFER_HPP

--- a/jp2_pc/Source/Lib/Std/TreeList.hpp
+++ b/jp2_pc/Source/Lib/Std/TreeList.hpp
@@ -528,7 +528,7 @@ public:
 
 	//******************************************************************************************
 	//
-	forceinline N::TData operator*()
+	forceinline typename N::TData operator*()
 	//
 	// Dereferences the data associated with the iterator.
 	//
@@ -637,7 +637,7 @@ public:
 
 	//******************************************************************************************
 	//
-	forceinline N::TData operator*()
+	forceinline typename N::TData operator*()
 	//
 	// Dereferences the data associated with the iterator.
 	//
@@ -765,7 +765,7 @@ public:
 
 	//******************************************************************************************
 	//
-	forceinline N::TData& operator*()
+	forceinline typename N::TData& operator*()
 	//
 	// Dereferences the data associated with the iterator.
 	//
@@ -1286,8 +1286,8 @@ public:
 //
 // Static variables for memory allocation.
 //
-template<class K, class T> CTreeList<K, T>::TNode* CTreeList<K, T>::ptreeAllocator;
-template<class K, class T> CTreeList<K, T>::TNode* CTreeList<K, T>::ptreeMaxAllocation;
+template<class K, class T> typename CTreeList<K, T>::TNode* CTreeList<K, T>::ptreeAllocator;
+template<class K, class T> typename CTreeList<K, T>::TNode* CTreeList<K, T>::ptreeMaxAllocation;
 template<class K, class T> CFastHeap* CTreeList<K, T>::pfhAllocator;
 
 

--- a/jp2_pc/Source/Lib/Transform/TransformIO.hpp
+++ b/jp2_pc/Source/Lib/Transform/TransformIO.hpp
@@ -25,7 +25,7 @@
 #define HEADER_LIB_TRANSFORM_TRANSFORMIO_HPP
 
 #include "Transform.hpp"
-#include <iostream.h>
+#include <iostream>
 
 //*********************************************************************************************
 //
@@ -33,13 +33,13 @@
 //
 
 	//*********************************************************************************************
-	template<class T> ostream& operator <<(ostream& os, const CVector2<T>& v2)
+	template<class T> std::ostream& operator <<(std::ostream& os, const CVector2<T>& v2)
 	{
 		return os << v2.tX << ' ' << v2.tY;
 	}
 
 	//*********************************************************************************************
-	template<class T> istream& operator >>(istream& is, CVector2<T>& v2)
+	template<class T> std::istream& operator >>(std::istream& is, CVector2<T>& v2)
 	{
 		return is >> v2.tX >> v2.tY;
 	}
@@ -50,13 +50,13 @@
 //
 
 	//*********************************************************************************************
-	template<class T> ostream& operator <<(ostream& os, const CVector3<T>& v3)
+	template<class T> std::ostream& operator <<(std::ostream& os, const CVector3<T>& v3)
 	{
 		return os << v3.tX << ' ' << v3.tY << ' ' << v3.tZ;
 	}
 
 	//*********************************************************************************************
-	template<class T> istream& operator >>(istream& is, CVector3<T>& v3)
+	template<class T> std::istream& operator >>(std::istream& is, CVector3<T>& v3)
 	{
 		return is >> v3.tX >> v3.tY >> v3.tZ;
 	}
@@ -67,13 +67,13 @@
 //
 
 	//*********************************************************************************************
-	template<class T> ostream& operator <<(ostream& os, const CRotate3<T>& r3)
+	template<class T> std::ostream& operator <<(std::ostream& os, const CRotate3<T>& r3)
 	{
 		return os << r3.tC << ' ' << r3.v3S;
 	}
 
 	//*********************************************************************************************
-	template<class T> istream& operator >>(istream& is, CRotate3<T>& r3)
+	template<class T> std::istream& operator >>(std::istream& is, CRotate3<T>& r3)
 	{
 		T t_c;
 		CVector3<T> v3;
@@ -90,13 +90,13 @@
 //
 
 	//*********************************************************************************************
-	template<class T> ostream& operator <<(ostream& os, const CPlacement3<T>& p3)
+	template<class T> std::ostream& operator <<(std::ostream& os, const CPlacement3<T>& p3)
 	{
 		return os << p3.v3Pos << ' ' << p3.r3Rot;
 	}
 
 	//*********************************************************************************************
-	template<class T> istream& operator >>(istream& is, CPlacement3<T>& p3)
+	template<class T> std::istream& operator >>(std::istream& is, CPlacement3<T>& p3)
 	{
 		return is >> p3.v3Pos >> p3.r3Rot;
 	}

--- a/jp2_pc/Source/Lib/Transform/Vector.hpp
+++ b/jp2_pc/Source/Lib/Transform/Vector.hpp
@@ -655,6 +655,15 @@ public:
 	}
 
 
+	forceinline bool operator !=(const CVector3<TR>& v3) const
+	{
+		//lint -save -e777
+		//  Yes, we really want to compare floats with != here.
+		return tX != v3.tX || tY != v3.tY || tZ != v3.tZ;
+		//lint -restore
+	}
+
+
 	//******************************************************************************************
 	//
 	// Member functions.

--- a/jp2_pc/Source/Lib/Types/FixedP.hpp
+++ b/jp2_pc/Source/Lib/Types/FixedP.hpp
@@ -147,7 +147,7 @@
 #ifndef HEADER_LIB_TYPES_FIXEDP_HPP
 #define HEADER_LIB_TYPES_FIXEDP_HPP
 
-#include <function.h>
+#include <functional>
 #include "Lib/Math/FloatDef.hpp"
 
 
@@ -312,9 +312,33 @@ public:
 	}
 
 
+	forceinline bool operator !=(fixed fx) const
+	{
+		return i4Fx != fx.i4Fx;
+	}
+
+
 	forceinline bool operator <(fixed fx) const
 	{
 		return i4Fx < fx.i4Fx;
+	}
+
+
+	forceinline bool operator <=(fixed fx) const
+	{
+		return i4Fx <= fx.i4Fx;
+	}
+
+
+	forceinline bool operator >(fixed fx) const
+	{
+		return i4Fx > fx.i4Fx;
+	}
+
+
+	forceinline bool operator >=(fixed fx) const
+	{
+		return i4Fx >= fx.i4Fx;
 	}
 
 


### PR DESCRIPTION
As expected, some more fixes are required in the header-focussed `Math` and `Std` projects. 
- Includes are modernized
- the `std::` namespace specifier is added where necessary
- the `typename` keyword as added where necessary
- Missing comparison operator methods are defined