### PR TITLE
CSetHelper copy-constructor and copy-assignment operator

### DIFF
--- a/jp2_pc/Source/Lib/Std/Set.hpp
+++ b/jp2_pc/Source/Lib/Std/Set.hpp
@@ -302,6 +302,18 @@ public:
 			u4Mask |= 1<<i;
 			return *this;
 		}
+
+		forceinline CSetHelper(const CSetHelper& other) : CSetHelperConst(other) {}
+
+		forceinline CSetHelper& operator=(const CSetHelper& other)
+		{
+			if (this == &other)
+				return *this;
+			
+			*this = static_cast<int>(other); //Call other copy-assignment operator
+
+			return *this;
+		}
 	};
 
 	//******************************************************************************************


### PR DESCRIPTION
The `CSet` class manages bitfields. It has an `[]` operator which gives write access to a specific bit wrapped in a `CSetHelper`.
A copy-constructor and a copy-assignment operator are added to `CSetHelper`. The new copy-assignment operator wraps the existing one.
This is required for `CSetHelper` assignments where the rhs expression is also a `CSetHelper`, like this:
`CSet<int> set; set[4] = set[5];`

Works as probably intended in a standalone program. We should take a mental note to add a unit test for this if we ever integrate a unit test framework.