### PR TITLE
CRefObj: reenable delete operator

### DIFF
--- a/jp2_pc/Source/Lib/Std/Ptr.hpp
+++ b/jp2_pc/Source/Lib/Std/Ptr.hpp
@@ -492,6 +492,7 @@ public:
 	//**********************************
 		FN_TRACK_RPTR
 
+/*
 protected:
 
 	// delete is unavailable to the general public, because you should never delete these objects!
@@ -501,6 +502,14 @@ protected:
 		::operator delete(pv);
 	}
 
+	//Unfortunately, CRefObjs are often deleted anyway,
+	//especially when not used in an rptr context.
+	//The compiler also complains when CRefObjs are used with
+	//rptr_new and rptr_cast.
+
+	//As a workaround until all that is sorted out,
+	//using the delete operator as public is permitted.
+*/
 };
 
 #if VER_TRACK_RPTR


### PR DESCRIPTION
Trespasser has the smart pointer `rptr` which does reference counting and deletes the object if no references are left. The idea is comparable to `std::shared_ptr` from C++11.
Objects for `rptr` need to be instances of the `CRefObj` interface, which stores the reference count. The `delete` operator for `CRefObj` has `protected` visibility so that they are only deleted when the reference count reaches zero.

Unfortunately we are drowning in compiler errors because of this. Sometimes `CRefObj` objects are used and deleted outside of an `rptr`. But most errors come from places where rptr objects are created from the `rptr_new` and `rptr_cast` macros.

Besides from a complete overhaul of the `rptr` mechanism, I can offer no better workaround than reenabling the `delete` operator for the public.