### PR TITLE
CHandle disambiguation

### DIFF
--- a/jp2_pc/Source/Game/AI/AIInfo.hpp
+++ b/jp2_pc/Source/Game/AI/AIInfo.hpp
@@ -148,7 +148,7 @@ public:
 	CAIInfo
 	(
 		const CGroffObjectName*		pgon,
-		const CHandle&				h_obj,				// Handle to the object in the value table.
+		const ::CHandle&				h_obj,				// Handle to the object in the value table.
 		CValueTable*				pvtable,			// Pointer to the value table.
 		CLoadWorld*					pload				// the loader.
 	);
@@ -204,7 +204,7 @@ public:
 	static const CAIInfo* paiiFindShared
 	(
 		const CGroffObjectName*			pgon,
-		const CHandle&				h_obj,				// Handle to the object in the value table.
+		const ::CHandle&				h_obj,				// Handle to the object in the value table.
 		CValueTable*				pvtable,			// Pointer to the value table.
 		CLoadWorld*					pload				// the loader.
 	);

--- a/jp2_pc/Source/Game/AI/AIMain.hpp
+++ b/jp2_pc/Source/Game/AI/AIMain.hpp
@@ -353,7 +353,7 @@ public:
 		(
 			CGroffObjectName* pgon,
 			 CLoadWorld*	pload,
-			 const CHandle& h,
+			 const ::CHandle& h,
 			 CValueTable* pvt,
 			 const CInfo* pinfo
 		);

--- a/jp2_pc/Source/Game/AI/Brain.hpp
+++ b/jp2_pc/Source/Game/AI/Brain.hpp
@@ -323,7 +323,7 @@ public:
 		CAnimal*				pani_owner,	// The animal that has this brain.
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);

--- a/jp2_pc/Source/Game/DesignDaemon/Gun.hpp
+++ b/jp2_pc/Source/Game/DesignDaemon/Gun.hpp
@@ -146,7 +146,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -194,7 +194,7 @@ public:
 	// current object being loaded until the next pass.
 	static bool bValidateGunProperties
 	(
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				pload		// The loader.
 	);
@@ -222,7 +222,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);

--- a/jp2_pc/Source/Game/DesignDaemon/Player.hpp
+++ b/jp2_pc/Source/Game/DesignDaemon/Player.hpp
@@ -117,7 +117,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	) = 0;
@@ -132,7 +132,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	) = 0;

--- a/jp2_pc/Source/Lib/EntityDBase/Animal.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Animal.hpp
@@ -143,7 +143,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);

--- a/jp2_pc/Source/Lib/EntityDBase/Animate.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Animate.hpp
@@ -247,7 +247,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -265,7 +265,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -544,7 +544,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);

--- a/jp2_pc/Source/Lib/EntityDBase/Entity.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Entity.hpp
@@ -129,7 +129,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	) : CInstance(pgon, pload, h_object, pvtable,pinfo)
@@ -236,7 +236,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);

--- a/jp2_pc/Source/Lib/EntityDBase/Instance.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Instance.hpp
@@ -596,7 +596,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -610,7 +610,7 @@ public:
 //		const SInstanceData& insd		// Extra initialisation data (from GROFF).
 		CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			ph_object,	// Handle to the object in the value table.
+		const ::CHandle&			ph_object,	// Handle to the object in the value table.
 		CValueTable*			pvtable,	// The value table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -1295,7 +1295,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);

--- a/jp2_pc/Source/Lib/EntityDBase/PhysicsInfo.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/PhysicsInfo.hpp
@@ -298,7 +298,7 @@ public:
 	CPhysicsInfo
 	(
 		const CGroffObjectName*		pgon,
-		const CHandle&				h_obj,				// Handle to the object in the value table.
+		const ::CHandle&				h_obj,				// Handle to the object in the value table.
 		CValueTable*				pvtable,			// Pointer to the value table.
 		CLoadWorld*					pload				// the loader.
 	);
@@ -339,7 +339,7 @@ public:
 	(
 		const rptr<CRenderType>&	prdt,		// The mesh of the object needing the physics data.
 		const CGroffObjectName*	pgon,				// Object using the physics info- needed for compound info construction
-		const CHandle&		h_obj,				// Handle to the object in the value table.
+		const ::CHandle&		h_obj,				// Handle to the object in the value table.
 		CValueTable*		pvtable,			// Pointer to the value table.
 		CLoadWorld*			pload				// the loader.
 	);

--- a/jp2_pc/Source/Lib/EntityDBase/Water.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Water.hpp
@@ -139,7 +139,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo
 	);

--- a/jp2_pc/Source/Lib/Groff/Groff.hpp
+++ b/jp2_pc/Source/Lib/Groff/Groff.hpp
@@ -143,7 +143,7 @@ public:
 	float		   fScale;				// The scaling factor for the object.
 
 	/* Version 12 - GROFF file format changes. */
-	CHandle		   hAttributeHandle;	// A handle to the object value container.
+	::CHandle		   hAttributeHandle;	// A handle to the object value container.
 
 	//******************************************************************************************
 	//
@@ -211,7 +211,7 @@ public:
 	float		   fScale;					// Unit cube scale value.
 	
 	/* Version 12 - GROFF file format changes. */
-	CHandle		   hAttributeHandle;		// Handle to object base-value container in value table.
+	::CHandle		   hAttributeHandle;		// Handle to object base-value container in value table.
 	bool		   bDoneLoading;			// True when the object has correctly loaded.  This
 											// really does not belong in this structure!!!
 
@@ -239,7 +239,7 @@ public:
 		fvector3	   fv3_position,
 		fvector3	   fv3_rotation,
 		float		   f_scale,
-		CHandle		   h_handle				// Attribute handle.	(Version 12 Changes)
+		::CHandle		   h_handle				// Attribute handle.	(Version 12 Changes)
 	);
 	//
 	// Returns:
@@ -289,7 +289,7 @@ public:
 		fvector3		fv3_position,
 		fvector3		fv3_rotation,
 		float			f_scale,
-		CHandle			h_handle			// Attribute handle.	(Version 12 Changes)
+		::CHandle			h_handle			// Attribute handle.	(Version 12 Changes)
 	);
 	//
 	// Returns:

--- a/jp2_pc/Source/Lib/Groff/GroffIO.hpp
+++ b/jp2_pc/Source/Lib/Groff/GroffIO.hpp
@@ -188,7 +188,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,				// Pointer to GROFF name.
 		CLoadWorld*				pload,				// Pointer to loader.
-		const CHandle&			h_obj,				// Handle to the base object in the value table.
+		const ::CHandle&			h_obj,				// Handle to the base object in the value table.
 		CValueTable*			pvtable				// Pointer to the value table.
 	);
 

--- a/jp2_pc/Source/Lib/Groff/ObjectHandle.hpp
+++ b/jp2_pc/Source/Lib/Groff/ObjectHandle.hpp
@@ -264,7 +264,7 @@ public:
 // Define the "NULL" handle.
 //
 
-static const CHandle hNULL_HANDLE;
+static const ::CHandle hNULL_HANDLE;
 
 
 //**********************************************************************************************
@@ -349,7 +349,7 @@ public:
 
 	//******************************************************************************************
 	//
-	CHandle hNext
+	::CHandle hNext
 	(
 	);
 

--- a/jp2_pc/Source/Lib/Groff/SymbolTable.hpp
+++ b/jp2_pc/Source/Lib/Groff/SymbolTable.hpp
@@ -80,7 +80,7 @@ class CSymbolEntry
 //
 {
 	CEasyString	estrSymbolName;
-	CHandle		hSymbolHandle;
+	::CHandle		hSymbolHandle;
 
 public:
 
@@ -96,7 +96,7 @@ public:
 	CSymbolEntry
 	(
 		const CEasyString&	estr_symbol_name,
-		const CHandle&		h_handle
+		const ::CHandle&		h_handle
 	);
 
 
@@ -133,7 +133,7 @@ public:
 	
 	//******************************************************************************************
 	//
-	CHandle& hHandle
+	::CHandle& hHandle
 	(
 	);
 
@@ -242,7 +242,7 @@ class CNewSymbolTable
 	std::map< CEasyString, CSymbolEntry*, std::less<CEasyString> >	asiSymbolIndex;
 
 	// Fast associative access to the element through this type. 
-	std::map< CHandle, CSymbolEntry*, std::less<CHandle> >			asiHandleIndex;
+	std::map<::CHandle, CSymbolEntry*, std::less<::CHandle> >			asiHandleIndex;
 
 public:   // Need access to verify validity of loaded value table.
 	// Storage container for the element type.
@@ -274,7 +274,7 @@ public:
 
 	//******************************************************************************************
 	//
-	const CHandle& operator[]
+	const ::CHandle& operator[]
 	(
 		const CEasyString& estr_symbol
 	);
@@ -285,13 +285,13 @@ public:
 
 	const CEasyString& operator[]
 	(
-		CHandle h_handle
+		::CHandle h_handle
 	);
 
 
 	//******************************************************************************************
 	//
-	CHandle hSymbol
+	::CHandle hSymbol
 	(
 		const CEasyString& estr_symbol
 	);

--- a/jp2_pc/Source/Lib/Groff/VTParse.hpp
+++ b/jp2_pc/Source/Lib/Groff/VTParse.hpp
@@ -97,7 +97,7 @@ inline CObjectValue* povalCast(CBaseValue* pbv)
 
 inline CBaseValue* pbvLookupValue
 (
-	const CHandle&		h_symbol,
+	const ::CHandle&		h_symbol,
 	CObjectValue*		poval_parent,
 	CValueTable*		pvtable,
 	int					i_start
@@ -143,7 +143,7 @@ inline CBaseValue* pbvLookupValue
 inline bool bFillBool
 (
 	bool *pb_value,						// The value to set.
-	const CHandle& h_symbol,			// The symbol to find.
+	const ::CHandle& h_symbol,			// The symbol to find.
 	CObjectValue* poval_parent,	// The object containing the value.
 	CValueTable* pvtable,			// The vtable to use.	
 	int *pi_best_guess_index			// The best place to start looking for the symbol.
@@ -176,7 +176,7 @@ inline bool bFillBool
 inline bool bFillChar
 (
 	char *pc_value,						// The value to set.
-	const CHandle& h_symbol,			// The symbol to find.
+	const ::CHandle& h_symbol,			// The symbol to find.
 	CObjectValue* poval_parent,	// The object containing the value.
 	CValueTable* pvtable,			// The vtable to use.	
 	int *pi_best_guess_index			// The best place to start looking for the symbol.
@@ -209,7 +209,7 @@ inline bool bFillChar
 inline bool bFillInt
 (
 	int *pi_value,						// The value to set.
-	const CHandle& h_symbol,			// The symbol to find.
+	const ::CHandle& h_symbol,			// The symbol to find.
 	CObjectValue* poval_parent,	// The object containing the value.
 	CValueTable* pvtable,			// The vtable to use.	
 	int *pi_best_guess_index			// The best place to start looking for the symbol.
@@ -242,7 +242,7 @@ inline bool bFillInt
 inline bool bFillFloat
 (
 	float *pf_value,						// The value to set.
-	const CHandle& h_symbol,			// The symbol to find.
+	const ::CHandle& h_symbol,			// The symbol to find.
 	CObjectValue* poval_parent,	// The object containing the value.
 	CValueTable* pvtable,			// The vtable to use.	
 	int *pi_best_guess_index			// The best place to start looking for the symbol.
@@ -275,7 +275,7 @@ inline bool bFillFloat
 inline bool bFillString
 (
 	const CEasyString **ppestr_value,						// The value to set.
-	const CHandle& h_symbol,			// The symbol to find.
+	const ::CHandle& h_symbol,			// The symbol to find.
 	CObjectValue* poval_parent,	// The object containing the value.
 	CValueTable* pvtable,			// The vtable to use.	
 	int *pi_best_guess_index			// The best place to start looking for the symbol.
@@ -308,7 +308,7 @@ inline bool bFillString
 bool bGetObject
 (
 	CObjectValue **ppoval_value,			// The value to set.
-	const CHandle& h_symbol,			// The symbol to find.
+	const ::CHandle& h_symbol,			// The symbol to find.
 	CObjectValue* poval_parent,	// The object containing the value.
 	CValueTable* pvtable,			// The vtable to use.	
 	int *pi_best_guess_index			// The best place to start looking for the symbol.

--- a/jp2_pc/Source/Lib/Groff/ValueTable.hpp
+++ b/jp2_pc/Source/Lib/Groff/ValueTable.hpp
@@ -156,9 +156,9 @@ class CBaseValue
 	EVarType	evtVarType;			// The type of value we are looking at.
 	EVarScope	evsVarScope;		// Variable scope classification.
 	ERefStatus	ersRefStatus;		// State of the resolution of this variable. 
-	CHandle		hValueHandle;		// Handle to this value entry record.
-	CHandle		hSymbolHandle;		// Handle to this symbol.
-	CHandle		hTargetHandle;		// Handle to the target symbol.
+	::CHandle		hValueHandle;		// Handle to this value entry record.
+	::CHandle		hSymbolHandle;		// Handle to this symbol.
+	::CHandle		hTargetHandle;		// Handle to the target symbol.
 
 public:
 
@@ -174,7 +174,7 @@ public:
 	(
 		const EVarType	evt_var_type,
 		const EVarScope evs_var_scope,
-		const CHandle	h_symbol_handle
+		const ::CHandle	h_symbol_handle
 	);
 
 
@@ -192,13 +192,13 @@ public:
 	//
 	void Handle
 	(
-		const CHandle& h_value_handle
+		const ::CHandle& h_value_handle
 	);
 
 
 	//******************************************************************************************
 	//
-	CHandle hHandle
+	::CHandle hHandle
 	(
 	) const;
 
@@ -207,13 +207,13 @@ public:
 	//
 	void Symbol
 	(
-		const CHandle& h_symbol_handle
+		const ::CHandle& h_symbol_handle
 	);
 
 
 	//******************************************************************************************
 	//
-	const CHandle& hSymbol
+	const ::CHandle& hSymbol
 	(
 	) const;
 
@@ -237,13 +237,13 @@ public:
 	//
 	void Target
 	(
-		const CHandle& h_target_handle
+		const ::CHandle& h_target_handle
 	);
 
 
 	//******************************************************************************************
 	//
-	const CHandle& hTarget
+	const ::CHandle& hTarget
 	(
 	) const;
 
@@ -349,7 +349,7 @@ public:
 	CBoolValue
 	(
 		const EVarScope	evs_var_scope,
-		const CHandle	h_symbol_handle,
+		const ::CHandle	h_symbol_handle,
 		const bool		b_value
 	);
 
@@ -465,7 +465,7 @@ public:
 	CCharValue
 	(
 		const EVarScope	evs_var_scope,
-		const CHandle	h_symbol_handle,
+		const ::CHandle	h_symbol_handle,
 		const char		c_value
 	);
 
@@ -578,7 +578,7 @@ public:
 	CIntValue
 	(
 		const EVarScope	evs_var_scope,
-		const CHandle	h_symbol_handle,
+		const ::CHandle	h_symbol_handle,
 		const int		i_value
 	);
 
@@ -692,7 +692,7 @@ public:
 	CFloatValue
 	(
 		const EVarScope	evs_var_scope,
-		const CHandle	h_symbol_handle,
+		const ::CHandle	h_symbol_handle,
 		const float		f_value
 	);
 
@@ -806,7 +806,7 @@ public:
 	CStringValue
 	(
 		const EVarScope		evs_var_scope,
-		const CHandle		h_symbol_handle,
+		const ::CHandle		h_symbol_handle,
 		const CEasyString	estr_string
 	);
 
@@ -899,15 +899,15 @@ class CHandleList
 {
 private:
 	int			i_count;					// Number of elements.
-	CHandle		ah_static[i_static_size];	// Statically allocated handles.
+	::CHandle		ah_static[i_static_size];	// Statically allocated handles.
 	int			i_buf_size;					// Allocated size.
-	CHandle*	ph_array;					// Array of allocated handles.
+	::CHandle*	ph_array;					// Array of allocated handles.
 
 	// Re-allocate the allocated array.
 	void reallocate(int i_alloc_size)
 	{
 		// Allocate new buffer.
-		CHandle* ph_new = new CHandle[i_alloc_size];
+		::CHandle* ph_new = new ::CHandle[i_alloc_size];
 
 		if (ph_array)
 		{
@@ -954,7 +954,7 @@ public:
 		delete[] ph_array;
 	}
 
-	const CHandle& operator[] (const int index) const
+	const ::CHandle& operator[] (const int index) const
 	{
 		if (index < i_static_size)
 			return ah_static[index];
@@ -983,7 +983,7 @@ public:
 		return i_count;
 	}
 
-	void push_back(const CHandle& h_handle)
+	void push_back(const ::CHandle& h_handle)
 	{
 		if (i_count < 4)
 		{
@@ -1025,7 +1025,7 @@ public:
 	CObjectValue
 	(
 		const EVarScope	evs_var_scope,		// Scope of visibility of this object.
-		const CHandle	h_symbol_handle		// Handle to the symbol for this object.
+		const ::CHandle	h_symbol_handle		// Handle to the symbol for this object.
 	);
 
 
@@ -1047,13 +1047,13 @@ public:
 	//
 	uint uAddElement
 	(
-		const CHandle& h_handle
+		const ::CHandle& h_handle
 	);
 	
 
 	//******************************************************************************************
 	//
-	const CHandle& hElementHandle
+	const ::CHandle& hElementHandle
 	(
 		const uint u_index
 	);
@@ -1121,7 +1121,7 @@ class CValueTable : public CNewSymbolTable
 	CHandleManager								hmgrManager;
 
 	// Provide fast access to the value record through it's handle. 
-	std::map< CHandle, CBaseValue*, std::less<CHandle> >	aviValueIndex;
+	std::map< ::CHandle, CBaseValue*, std::less<::CHandle> >	aviValueIndex;
 
 public:
 
@@ -1149,7 +1149,7 @@ public:
 
 	//******************************************************************************************
 	//
-	CHandle hBaseValue
+	::CHandle hBaseValue
 	(
 		CBaseValue* pbasev_value
 	);
@@ -1160,7 +1160,7 @@ public:
 
 	CBaseValue& operator[]
 	(
-		const CHandle& h_handle
+		const ::CHandle& h_handle
 	);
 
 

--- a/jp2_pc/Source/Lib/Loader/Loader.hpp
+++ b/jp2_pc/Source/Lib/Loader/Loader.hpp
@@ -700,7 +700,7 @@ public:
 	//	Ex.      ahSymbols[esClass]  references the string "Class" in the value table,
 	//									or is NULL if "Class" does not appear in the table.
 	
-	CHandle ahSymbols[esEND];
+	::CHandle ahSymbols[esEND];
 
 
 	int iNumSelected;					// The number of objects that have been selected by the loader. (UI)
@@ -731,7 +731,7 @@ public:
 	);
 
 
-	inline const CHandle& hSymbol(ESymbol es)
+	inline const ::CHandle& hSymbol(ESymbol es)
 	{
 		return ahSymbols[es];
 	}

--- a/jp2_pc/Source/Lib/Physics/InfoBox.hpp
+++ b/jp2_pc/Source/Lib/Physics/InfoBox.hpp
@@ -117,7 +117,7 @@ public:
 	CPhysicsInfoBox
 	(
 		const rptr<CRenderType>&	prdt,				// The rendering shape.
-		const CHandle&				h_obj,				// Handle to the object in the value table.
+		const ::CHandle&				h_obj,				// Handle to the object in the value table.
 		const CGroffObjectName*		pgon,
 		CValueTable*				pvtable,			// Pointer to the value table.
 		CLoadWorld*					pload				// the loader.

--- a/jp2_pc/Source/Lib/Physics/InfoSkeleton.hpp
+++ b/jp2_pc/Source/Lib/Physics/InfoSkeleton.hpp
@@ -147,7 +147,7 @@ public:
 	//
 	void ParseProps
 	(
-		const CHandle&				h_obj,				// Handle to the object in the value table.
+		const ::CHandle&				h_obj,				// Handle to the object in the value table.
 		const CGroffObjectName*		pgon,
 		CValueTable*				pvtable,			// Pointer to the value table.
 		CLoadWorld*					pload				// the loader.

--- a/jp2_pc/Source/Lib/Physics/Magnet.hpp
+++ b/jp2_pc/Source/Lib/Physics/Magnet.hpp
@@ -128,7 +128,7 @@ public:
 	//
 	static const CMagnet* pmagFindShared
 	(
-		const CHandle&	h, 
+		const ::CHandle&	h,
 		CObjectValue*	poval_cmagnet, 
 		CValueTable*	pvt, 
 		CLoadWorld*		pload
@@ -158,7 +158,7 @@ public:
 	(
 		CGroffObjectName* pgon,
 		CLoadWorld*	pload,
-		const CHandle& h,
+		const ::CHandle& h,
 		CValueTable* pvt
 	);
 	//
@@ -170,7 +170,7 @@ public:
 	(
 		CGroffObjectName* pgon,
 		CLoadWorld*	pload,
-		const CHandle& h,
+		const ::CHandle& h,
 		CValueTable* pvt
 	);
 	//

--- a/jp2_pc/Source/Lib/Renderer/RenderType.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderType.hpp
@@ -222,7 +222,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,				// Pointer to GROFF name.
 		CLoadWorld*				pload,				// Pointer to loader.
-		const CHandle&			h_obj,				// Handle to the base object in the value table.
+		const ::CHandle&			h_obj,				// Handle to the base object in the value table.
 		CValueTable*			pvtable				// Pointer to the value table.
 	);
 	// Obtain a RenderType that has the requested data.

--- a/jp2_pc/Source/Lib/Renderer/Sky.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Sky.hpp
@@ -281,7 +281,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				pload,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);

--- a/jp2_pc/Source/Lib/Trigger/Trigger.hpp
+++ b/jp2_pc/Source/Lib/Trigger/Trigger.hpp
@@ -162,7 +162,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -312,7 +312,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -477,7 +477,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,		// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -573,7 +573,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -644,7 +644,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -692,7 +692,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -721,7 +721,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -764,7 +764,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -791,7 +791,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -829,7 +829,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -853,7 +853,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -900,7 +900,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -927,7 +927,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -964,7 +964,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -1004,7 +1004,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -1045,7 +1045,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -1078,7 +1078,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -1106,7 +1106,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -1132,7 +1132,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -1169,7 +1169,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -1201,7 +1201,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -1251,7 +1251,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);
@@ -1274,7 +1274,7 @@ public:
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
 		CLoadWorld*				p_load,		// The loader.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
 	);
@@ -1314,7 +1314,7 @@ public:
 	static bool bValidateTriggerProperties
 	(
 		const CGroffObjectName*	pgon,		// Object to load.
-		const CHandle&			h_object,	// handle of object in value table.
+		const ::CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		CLoadWorld*				p_load		// The loader.
 	);


### PR DESCRIPTION
`Lib/Groff/ObjectHandle.hpp` declares a class `CHandle`. Microsoft's ATL library declares a class `ATL:: CHandle`. However, the ATL headers also contain a `using namespace ATL; `instruction, which causes a name collision.
A namespace qualifier is added to resolve the name collision.
The collisions all occur in library code, which does not use ATL. Only some tools, especially GUIApp, use ATL. Because of that, only header files need to be fixed.