### PR TITLE
Replace destroy with std::destroy_at

### DIFF
--- a/jp2_pc/Source/GUIApp/GUIAppDlg.cpp
+++ b/jp2_pc/Source/GUIApp/GUIAppDlg.cpp
@@ -7033,7 +7033,7 @@ void CGUIAppDlg::ExitApp()
 	// shut the performance system
 	PSClose();
 
-	destroy(&prasMainScreen);
+	std::destroy_at(&prasMainScreen);
 }
 
 BOOL CGUIAppDlg::DestroyWindow() 

--- a/jp2_pc/Source/Lib/Sys/W95/Render.cpp
+++ b/jp2_pc/Source/Lib/Sys/W95/Render.cpp
@@ -227,7 +227,7 @@ int iGetScreenBitdepth();
 		}
 
 		// We must destroy the current screen before creating a new one, or DirectDraw complains.
-		destroy(&prasMainScreen);
+		std::destroy_at(&prasMainScreen);
 
 		// Create a new instance of prasMainScreen.
 		prasMainScreen = rptr_new CRasterWin(hwndMain, i_screen_width, i_screen_height, i_screen_bits, 

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -321,7 +321,7 @@ void TrespassExceptionCleanup()
 	// Remove the audio, we are about to quit.
 	delete CAudio::pcaAudio;
 
-	destroy(&prasMainScreen);
+	std::destroy_at(&prasMainScreen);
 
 	g_initDD.ReleaseAll();
 
@@ -669,7 +669,7 @@ Cleanup:
 	if (prasMainScreen)
 	{
 		prasMainScreen->uRefs = 1;
-		destroy(&prasMainScreen);
+		std::destroy_at(&prasMainScreen);
 	}
 	g_initDD.ReleaseAll();
 

--- a/jp2_pc/Source/Trespass/mainwnd.cpp
+++ b/jp2_pc/Source/Trespass/mainwnd.cpp
@@ -377,7 +377,7 @@ void CMainWnd::OnActivateApp(HWND hwnd, BOOL fActivate, DWORD dwThreadId)
 
 			// Delete renderer stuff if required.
 			if (g_CTPassGlobals.bInGame)
-				destroy(&prasMainScreen);
+				std::destroy_at(&prasMainScreen);
         }
 
         m_pUIMgr->m_bActive = FALSE;

--- a/jp2_pc/Source/Trespass/tpassglobals.cpp
+++ b/jp2_pc/Source/Trespass/tpassglobals.cpp
@@ -344,7 +344,7 @@ void CTPassGlobals::HardScreenReset(BOOL b_reset_world)
 	if (b_reset_world)
 		wWorld.Reset();
 	prasMainScreen->uRefs = 1;
-	destroy(&prasMainScreen);
+	std::destroy_at(&prasMainScreen);
 	g_initDD.ReleaseAll();
 	g_initDD.BaseInit();
 


### PR DESCRIPTION
The bundled STL had a `destroy` function in `defalloc.h` which called the destructor of an object. In C++17, `std::destroy` is for iterators, but `std::destroy_at` does the same thing as the the old `destroy`.