### PR TITLE
Compile GroffExp

### DIFF
--- a/jp2_pc/Inc/maxsdk/Max.h
+++ b/jp2_pc/Inc/maxsdk/Max.h
@@ -17,7 +17,7 @@
 #include <strbasic.h>
 #include <windows.h>
 #include <windowsx.h>
-#include <ctl3d.h>
+//#include <ctl3d.h>
 #include <commctrl.h>
 
 // Some standard library includes

--- a/jp2_pc/Inc/maxsdk/tab.h
+++ b/jp2_pc/Inc/maxsdk/tab.h
@@ -40,7 +40,7 @@
 
 #define __TAB__
 
-#include <iostream.h>
+#include <iostream>
 #include <malloc.h>
 
 typedef int CNT;

--- a/jp2_pc/Source/Tools/GroffExp/Bitmap.cpp
+++ b/jp2_pc/Source/Tools/GroffExp/Bitmap.cpp
@@ -31,7 +31,7 @@
 #include <memory.h>
 #include <string.h>
 #include <stdio.h>
-#include <fstream.h>
+#include <fstream>
 
 #include "max.h"
 #include "bmmlib.h"
@@ -1026,7 +1026,7 @@ CBitmapImage& CBitmapImage::operator =(CBitmapImage& bmi_src)
 		if (!bCreate(bmi_src.biBitmapInfo()))
 		{
 			// Bad situation has occurred.  We are out of heap memory.  Blow up for now.
-			assert(0);
+			Assert(0);
 		}
 
 		// Get a copy of the bitmap info for the host.
@@ -1395,7 +1395,7 @@ bool CBitmapUtil::bMeanColor(CBitmapImage& bmi_bitmap_image, SColor24& c24_mean_
 bool CBmpBitmap::bDetectBitmap(const char* str_bitmap_name)
 {
 	// Attempt to open the file and see if it exists.
-	ifstream ifile(str_bitmap_name, ios::binary | ios::nocreate);
+	std::ifstream ifile(str_bitmap_name, std::ios::binary | std::ios::_Nocreate);
 
 	// Were we able to open the file?
 	if (!ifile)
@@ -1408,7 +1408,7 @@ bool CBmpBitmap::bDetectBitmap(const char* str_bitmap_name)
 	SFileHeader fh_file_header;
 
 	// Read in the file header.
-	ifile.read((uint8 *) &fh_file_header, sizeof(SFileHeader));
+	ifile.read((char *) &fh_file_header, sizeof(SFileHeader));
 
 	ifile.close();
 
@@ -1429,7 +1429,7 @@ bool CBmpBitmap::bRead(const char* str_bitmap_name, CBitmapImage& bmi_bitmap_ima
 	}
 
 	// Attempt to open the bitmap file.
-	ifstream ifile(str_bitmap_name, ios::binary | ios::nocreate);
+	std::ifstream ifile(str_bitmap_name, std::ios::binary | std::ios::_Nocreate);
 
 	// Were we successful?
 	if (!ifile)
@@ -1442,7 +1442,7 @@ bool CBmpBitmap::bRead(const char* str_bitmap_name, CBitmapImage& bmi_bitmap_ima
 	SFileHeader fh_file_header;
 
 	// Read in the file header.
-	ifile.read((uint8 *) &fh_file_header, sizeof(SFileHeader));
+	ifile.read((char *) &fh_file_header, sizeof(SFileHeader));
 
 	// Is this a Windows bitmap?
 	if (fh_file_header.u2FileType != WINDOWS_BMP_MAGIC_NUMBER)
@@ -1457,7 +1457,7 @@ bool CBmpBitmap::bRead(const char* str_bitmap_name, CBitmapImage& bmi_bitmap_ima
 	SBitmapHeader bmh_bitmap_header;
 
 	// Read in the file header.
-	ifile.read((uint8 *) &bmh_bitmap_header, sizeof(SBitmapHeader));
+	ifile.read((char *) &bmh_bitmap_header, sizeof(SBitmapHeader));
 
 	// Is this a Windows bitmap?
 	if (bmh_bitmap_header.uHeaderSize != sizeof(SBitmapHeader))
@@ -1515,7 +1515,7 @@ bool CBmpBitmap::bRead(const char* str_bitmap_name, CBitmapImage& bmi_bitmap_ima
 	ifile.seekg(0);
 
 	// Read in the entire file.
-	ifile.read(u1_buffer, fh_file_header.uFileSize);
+	ifile.read((char*)u1_buffer, fh_file_header.uFileSize);
 
 	// Close the file since the image is now entirely located in the smart buffer.
 	ifile.close();
@@ -1601,7 +1601,7 @@ bool CBmpBitmap::bRead(const char* str_bitmap_name, CBitmapImage& bmi_bitmap_ima
 		int* pi_buffer = (int *) (u1_buffer + fh_file_header.uBitmapOffset);
 		
 		// Loop through the scanlines and load them into the image data.
-		for (u_i = 0; u_i < (uint) bmh_bitmap_header.lHeight; u_i++)
+		for (uint u_i = 0; u_i < (uint) bmh_bitmap_header.lHeight; u_i++)
 		{
 			// Attempt to write the data into the bitmap image buffer.  Were we successful?
 			if (bmi_bitmap_image.uSetPalettedPixels(0, u_i, bmh_bitmap_header.lWidth, (uint8 *) pi_buffer) != (uint) bmh_bitmap_header.lWidth)
@@ -1868,7 +1868,7 @@ bool CBmpBitmap::bWrite(CBitmapImage& bmi_bitmap_image)
 	// Is this buffer the correct size?
 
 	// Attempt to open the output file.
-	ofstream ofile(bi_bitmap_info.strName(), ios::binary | ios::trunc);
+	std::ofstream ofile(bi_bitmap_info.strName(), std::ios::binary | std::ios::trunc);
 
 	// Were we able to open the file?
 	if (!ofile)

--- a/jp2_pc/Source/Tools/GroffExp/Bitmap.hpp
+++ b/jp2_pc/Source/Tools/GroffExp/Bitmap.hpp
@@ -29,7 +29,7 @@
 #ifndef HEADER_TOOLS_BITMAP_HPP
 #define HEADER_TOOLS_BITMAP_HPP
 
-#include <fstream.h>
+#include <fstream>
 #include <stdio.h>
 
 

--- a/jp2_pc/Source/Tools/GroffExp/GroffExp.cpp
+++ b/jp2_pc/Source/Tools/GroffExp/GroffExp.cpp
@@ -117,7 +117,7 @@
 #include "Geometry.hpp"
 #include "Lib/Sys/SysLog.hpp"
 #include "Bitmap.hpp"
-#include "Symtab.hpp"
+#include "Lib/Sys/Symtab.hpp"
 #include "Export.hpp"
 #include "GUIInterface.hpp"
 #include "Mathematics.hpp"
@@ -296,6 +296,7 @@ class CClassDesc: public ClassDesc
 {
 public:
 
+
 	//******************************************************************************************
 	//
 	int IsPublic
@@ -310,7 +311,7 @@ public:
 	//
 	void* Create
 	(
-		bool loading = false
+		BOOL loading = false
 	)
 	{ 
 		return new JP2Export;
@@ -2939,7 +2940,7 @@ uint uExtractFaces(Mesh& mesh, CMathematicsUtil& mutil_utils)
 	mutil_utils.slLogfile.Printf(mutil_utils.guiInterface.strGetString(IDS_FACE_NORMAL_TITLE), u_faces);
 
 	// Loop through all the faces in the list and get the face normals.
-	for (u_face = 0; u_face < u_faces; u_face++) 
+	for (uint u_face = 0; u_face < u_faces; u_face++) 
 	{
 		// Get the face normal.
 		Point3& pt3_normal = mesh.getFaceNormal(u_face);
@@ -2955,7 +2956,7 @@ uint uExtractFaces(Mesh& mesh, CMathematicsUtil& mutil_utils)
 	mutil_utils.slLogfile.Printf(mutil_utils.guiInterface.strGetString(IDS_VERTEX_NORMAL_TITLE), u_faces);
 
 	// Now get the vertex normal list.
-	for (u_face = 0; u_face < u_faces; u_face++) 
+	for (uint u_face = 0; u_face < u_faces; u_face++) 
 	{
 		// Get the face vertex indices.
 		Face& face = mesh.faces[u_face];
@@ -3078,7 +3079,7 @@ uint uExtractTextureVertices(Mesh& mesh, CMathematicsUtil& mutil_utils)
 	mutil_utils.slLogfile.Printf(mutil_utils.guiInterface.strGetString(IDS_TFACE_TITLE), i_face_count);
 
 	// Process the texture face list
-	for (i_i = 0; i_i < i_face_count; i_i++)
+	for (int i_i = 0; i_i < i_face_count; i_i++)
 	{
 		// Dump the texture face definition into the logfile.
 		mutil_utils.slLogfile.Printf(mutil_utils.guiInterface.strGetString(IDS_TFACE_DEFS), i_i, 

--- a/jp2_pc/Source/Tools/GroffExp/ObjectDef.cpp
+++ b/jp2_pc/Source/Tools/GroffExp/ObjectDef.cpp
@@ -1740,7 +1740,7 @@ void CObjectDefList::Dump()
 		sl_glog.Printf("\nObject faces: %d\n", pod_node->uFaceCount);
 
 		// Dump the object faces
-		for (u_i = 0; u_i < pod_node->uFaceCount; u_i++)
+		for (uint u_i = 0; u_i < pod_node->uFaceCount; u_i++)
 		{
 			// Display the vertex
 			sl_glog.Printf("Face %4d: x -> %4d, y -> %4d, z -> %4d\n", u_i, 
@@ -1750,7 +1750,7 @@ void CObjectDefList::Dump()
 		sl_glog.Printf("\nObject face normals: %d\n", pod_node->uFaceNormalCount);
 
 		// Dump the object normals
-		for (u_i = 0; u_i < pod_node->uFaceNormalCount; u_i++)
+		for (uint u_i = 0; u_i < pod_node->uFaceNormalCount; u_i++)
 		{
 			// Display the normals
 			sl_glog.Printf("Normal %4d: x -> %.3f, y -> %3.f, z -> %.3f\n", u_i, 
@@ -1760,7 +1760,7 @@ void CObjectDefList::Dump()
 		sl_glog.Printf("\nObject face vertex normals: %d\n", pod_node->uVertexNormalCount);
 
 		// Dump the object normals
-		for (u_i = 0; u_i < pod_node->uVertexNormalCount; u_i+=3)
+		for (uint u_i = 0; u_i < pod_node->uVertexNormalCount; u_i+=3)
 		{
 			// Display the vertex normals.
 			sl_glog.Printf("Face %4d: Vertex 0: x -> %.3f, y -> %.3f, z -> %.3f\n", u_i/3, 
@@ -1779,7 +1779,7 @@ void CObjectDefList::Dump()
 			sl_glog.Printf("\nObject texture vertices: %d\n", pod_node->uTextureVertexCount);
 
 			// Dump the object vertices
-			for (u_i = 0; u_i < pod_node->uTextureVertexCount; u_i++)
+			for (uint u_i = 0; u_i < pod_node->uTextureVertexCount; u_i++)
 			{
 				// Display the texture vertices
 				sl_glog.Printf("Texture vertex %4d: u -> %.3f, v -> %.3f\n", u_i, 
@@ -1793,7 +1793,7 @@ void CObjectDefList::Dump()
 			if (pod_node->uMaterialCount == 1)
 			{
 				// Dump the object faces
-				for (u_i = 0; u_i < pod_node->uTextureFaceCount; u_i++)
+				for (uint u_i = 0; u_i < pod_node->uTextureFaceCount; u_i++)
 				{
 					// Display the texture faces
 					sl_glog.Printf("Texture face %4d: x -> %4d, y -> %4d, z -> %4d\n", u_i, 
@@ -1866,7 +1866,7 @@ void CObjectDefList::Dump()
 			else
 			{
 				// Dump the object faces
-				for (u_i = 0; u_i < pod_node->uTextureFaceCount; u_i++)
+				for (uint u_i = 0; u_i < pod_node->uTextureFaceCount; u_i++)
 				{
 					// Display the texture faces
 					sl_glog.Printf("Texture face %4d: x -> %4d, y -> %4d, z -> %4d\n", u_i, 
@@ -1877,7 +1877,7 @@ void CObjectDefList::Dump()
 				sl_glog.Printf("Object materials: %d\n", (int) pod_node->uMaterialCount);
 
 				// Dump the object faces
-				for (u_i = 0; u_i < pod_node->uMaterialCount; u_i++)
+				for (uint u_i = 0; u_i < pod_node->uMaterialCount; u_i++)
 				{
 					// Display any materials which may be present.
 					if (pod_node->astrTextureMap != 0)

--- a/jp2_pc/Source/Tools/GroffExp/StandardTypes.hpp
+++ b/jp2_pc/Source/Tools/GroffExp/StandardTypes.hpp
@@ -20,21 +20,7 @@
 #ifndef HEADER_TOOLS_GROFFEXP_STANDARDTYPES_HPP
 #define HEADER_TOOLS_GROFFEXP_STANDARDTYPES_HPP
 
-//
-// Define boolean type, if it hasn't been defined.
-//
-
-#ifndef bool
-#define bool int
-#endif
-
-#ifndef false
-#define false 0
-#endif
-
-#ifndef true
-#define true 1
-#endif
+#include "Lib/Groff/Groff.hpp"
 
 //
 // Define signed scalar types.
@@ -73,61 +59,6 @@ typedef unsigned short int uint16;
 typedef unsigned int uint32;
 #endif
 
-
-//
-// Define the floating point 2 and 3 element vector types.
-//
-
-#ifndef fvector2
-typedef struct 
-//
-// Prefix: fv2
-//
-{
-	float X;
-	float Y;
-} fvector2;
-#endif
-
-#ifndef fvector3
-typedef struct 
-//
-// Prefix: fv3
-//
-{
-	float X;
-	float Y;
-	float Z;
-} fvector3;
-#endif
-
-
-//
-// Define the unsigned integer 2 and 3 element vector types.
-//
-
-#ifndef uvector2
-typedef struct 
-//
-// Prefix: uv2
-//
-{
-	uint	X;
-	uint	Y;
-} uvector2;
-#endif
-
-#ifndef uvector3
-typedef struct 
-//
-// Prefix: uv3
-//
-{
-	uint	X;
-	uint	Y;
-	uint	Z;
-} uvector3;
-#endif
 
 
 //


### PR DESCRIPTION
Minor code changes are made to make the GroffExp project more compilable.

Small changes are also required in the MaxSDK headers because Windows and STL header have changed. As an alternative to that, the missing header files could be mocked up.