### PR TITLE
Compile Trespass

### DIFF
--- a/jp2_pc/Source/Trespass/DDDevice.cpp
+++ b/jp2_pc/Source/Trespass/DDDevice.cpp
@@ -118,9 +118,9 @@
 #include "../Lib/Sys/Reg.h"
 
 #if (1)
-	#include "/jp2_pc/inc/DirectX/ddraw.h"
+	#include "ddraw.h"
 	#define D3D_OVERLOADS
-	#include "/jp2_pc/inc/DirectX/d3d.h"
+	#include "d3d.h"
 #endif
 
 #include "Lib/Sys/DebugConsole.hpp"
@@ -693,7 +693,7 @@ CEnumerateDevices::CEnumerateDevices()
 			&Devices[i].d3dDevice
 		);
 	}
-	for (i = iNumDevices - 1; i >= 0; --i)
+	for (int i = iNumDevices - 1; i >= 0; --i)
 	{
 		if (!Devices[i].bD3DDeviceFound)
 			RemoveDevice(i);

--- a/jp2_pc/Source/Trespass/DDDevice.hpp
+++ b/jp2_pc/Source/Trespass/DDDevice.hpp
@@ -83,7 +83,7 @@ struct SResolution
 	int iWidth;
 	int iHeight;
 	int iRefreshHz;
-	static iResolutionsCount;
+	static int iResolutionsCount;
 
 	SResolution()
 		: iWidth(0), iHeight(0), iRefreshHz(0)

--- a/jp2_pc/Source/Trespass/ctrls.cpp
+++ b/jp2_pc/Source/Trespass/ctrls.cpp
@@ -1251,9 +1251,9 @@ int CUIListbox::AddItem(LPCSTR pszText, DWORD dwParam, int iIndex, WORD wFlags)
     else
     {
         int i;
-        vector<CUILISTBOXINFO>::iterator    ppinfo;
+        std::vector<CUILISTBOXINFO>::iterator    ppinfo;
 
-        for (i = 0, ppinfo = m_vInfo.begin(); i < iIndex && ppinfo; i++, ppinfo++)
+        for (i = 0, ppinfo = m_vInfo.begin(); i < iIndex; i++, ppinfo++)
         {
             ;
         }
@@ -1267,7 +1267,7 @@ int CUIListbox::AddItem(LPCSTR pszText, DWORD dwParam, int iIndex, WORD wFlags)
 
 BOOL CUIListbox::RemoveItem(int iIndex)
 {
-    vector<CUILISTBOXINFO>::iterator    ppinfo;
+    std::vector<CUILISTBOXINFO>::iterator    ppinfo;
 
     int     i;
 
@@ -1276,7 +1276,7 @@ BOOL CUIListbox::RemoveItem(int iIndex)
         ;
     }
 
-    if (ppinfo)
+    if (ppinfo != m_vInfo.end())
     {
         delete [] (*ppinfo).psz;
         m_vInfo.erase(ppinfo);
@@ -1311,7 +1311,7 @@ BOOL CUIListbox::RemoveItem(int iIndex)
 
 BOOL CUIListbox::RemoveAllItems()
 {
-    vector<CUILISTBOXINFO>::iterator    pinfo;
+    std::vector<CUILISTBOXINFO>::iterator    pinfo;
 
     for (pinfo = m_vInfo.begin(); pinfo < m_vInfo.end(); pinfo++)
     {
@@ -1329,7 +1329,7 @@ BOOL CUIListbox::RemoveAllItems()
 
 int CUIListbox::FindItem(LPCSTR pszText)
 {
-    vector<CUILISTBOXINFO>::iterator    pinfo;
+    std::vector<CUILISTBOXINFO>::iterator    pinfo;
     int  i;
     int  iIndex = -1;
 
@@ -1385,10 +1385,10 @@ int CUIListbox::GetItem(LPSTR psz, int icText, DWORD & dwParam, WORD & wFlags, i
 
 int CUIListbox::SetItem(LPSTR psz, DWORD dwParam, WORD wFlags, int iIndex)
 {
-    vector<CUILISTBOXINFO>::iterator    pinfo;
+    std::vector<CUILISTBOXINFO>::iterator    pinfo;
 
     pinfo = m_vInfo.begin() + iIndex;
-    if (!pinfo)
+    if (pinfo >= m_vInfo.end())
     {
         return -1;
     }
@@ -1485,7 +1485,7 @@ void CUIListbox::Update()
     HBRUSH              hbr;
     int                 i;
     int                 iStop;
-    vector<CUILISTBOXINFO>::iterator    pinfo;
+    CUILISTBOXINFO*     pinfo;
     LPSTR               pszText;
     HFONT               hfontOld;
     WORD                wFill;
@@ -2830,7 +2830,7 @@ void CUIEditbox::Update()
 
     SetTextColor(hdc, m_crFGColor);
 
-    psz = m_vInfo.begin();
+    psz = m_vInfo.data();
     if (psz == NULL)
     {
         iLen = 0;
@@ -2990,7 +2990,7 @@ LPSTR CUIEditbox::GetText()
 {
     if (!m_vInfo.empty())
     {
-        return (LPSTR)m_vInfo.begin();
+        return (LPSTR)m_vInfo.data();
     }
 
     return NULL;
@@ -3020,7 +3020,7 @@ BOOL CUIEditbox::SetText(LPSTR pszNew)
         {
             m_vInfo.erase(m_vInfo.begin(), m_vInfo.end());
             m_vInfo.insert(m_vInfo.begin(), strlen(pszNew) + 1, '\0');
-            strcpy(m_vInfo.begin(), pszNew);
+            strcpy(m_vInfo.data(), pszNew);
         }
         else
         {
@@ -3193,7 +3193,7 @@ void CUIEditbox::OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags)
                 iSize = m_vInfo.size();
                 if (iSize > 1)
                 {
-                    vector<char>::iterator  pch;
+                    std::vector<char>::iterator  pch;
 
                     pch = m_vInfo.end() - 2;
                     m_vInfo.erase(pch);

--- a/jp2_pc/Source/Trespass/ctrls.h
+++ b/jp2_pc/Source/Trespass/ctrls.h
@@ -270,7 +270,7 @@ public:
     virtual void    SetFontSize(BOOL bFontSize) { m_bFontSize = bFontSize; m_bUpdate = TRUE;}
     
 private:
-    vector<CUILISTBOXINFO>     m_vInfo;
+    std::vector<CUILISTBOXINFO>     m_vInfo;
 
     CUIButton  *    m_pScroll[2];
     BOOL            m_bCaptured : 1;
@@ -498,7 +498,7 @@ public:
 
 protected:
     int             m_iMaxSize;
-    vector<char>    m_vInfo;
+    std::vector<char>    m_vInfo;
     CRasterDC *     m_pras;
     BOOL            m_bUpdate;
     COLORREF        m_crBkColor;

--- a/jp2_pc/Source/Trespass/dlgrender.cpp
+++ b/jp2_pc/Source/Trespass/dlgrender.cpp
@@ -203,7 +203,7 @@ void CConfigureWnd::InitializeResolutions()
 	wsprintf(str_desc, "%ld x %ld", i_width, i_height);
 
     // Select this in the Adapter listing
-    i = ComboBox_SelectString(m_hwndResolutions, -1, str_desc);
+    int i = ComboBox_SelectString(m_hwndResolutions, -1, str_desc);
     if (i == CB_ERR)
     {
 	    // Set the first device as the default.

--- a/jp2_pc/Source/Trespass/gamewnd.cpp
+++ b/jp2_pc/Source/Trespass/gamewnd.cpp
@@ -664,7 +664,7 @@ void CGameWnd::InnerLoopCall()
 	// Check for pending save.
 	if (wWorld.bIsSavePending())
 	{
-		const string &strName = wWorld.strGetPendingSave();
+		const std::string &strName = wWorld.strGetPendingSave();
 
 		// Stop simulation.
 		CMessageSystem(escSTOP_SIM).Dispatch();
@@ -679,7 +679,7 @@ void CGameWnd::InnerLoopCall()
 	// Check for pending level load.
 	if (wWorld.bIsLoadPending())
 	{
-		const string &strName = wWorld.strGetPendingLoad();
+		const std::string &strName = wWorld.strGetPendingLoad();
 
 		// Stop simulation.
 		CMessageSystem(escSTOP_SIM).Dispatch();

--- a/jp2_pc/Source/Trespass/mainwnd.cpp
+++ b/jp2_pc/Source/Trespass/mainwnd.cpp
@@ -434,7 +434,7 @@ void CMainWnd::OnActivateApp(HWND hwnd, BOOL fActivate, DWORD dwThreadId)
 
 void CMainWnd::OnTimer(HWND hwnd, UINT id)
 {
-    vector<CUIWnd *>::iterator      i;
+    std::vector<CUIWnd *>::iterator      i;
 
     for (i = m_pUIMgr->m_vUIWnd.end() - 1; i >= m_pUIMgr->m_vUIWnd.begin(); i--)
     {

--- a/jp2_pc/Source/Trespass/precomp.h
+++ b/jp2_pc/Source/Trespass/precomp.h
@@ -20,7 +20,7 @@
 // We want to include the resource IDs for the OEM settings as well
 #define OEMRESOURCE
 #include "..\lib\w95\wininclude.hpp"
-#include <smack.h>
+#include <smacker/smack.h>
 #include "..\gblinc\common.hpp"
 #include "..\Lib\GeomDBase\PartitionPriv.hpp"
 #include "..\lib\std\memlimits.hpp"

--- a/jp2_pc/Source/Trespass/saveload.cpp
+++ b/jp2_pc/Source/Trespass/saveload.cpp
@@ -48,13 +48,13 @@ extern HWND		    g_hwnd;
 //  History:    10-Jul-98    SHernd  Created
 //
 //---------------------------------------------------------------------------
-void AddToLoadGameVector(SAVEGAMEINFO * psgi, vector<SAVEGAMEINFO> * pInfo)
+void AddToLoadGameVector(SAVEGAMEINFO * psgi, std::vector<SAVEGAMEINFO> * pInfo)
 {
     bool                            fEntered;
-    vector<SAVEGAMEINFO>::iterator  ppinfo;
+    std::vector<SAVEGAMEINFO>::iterator  ppinfo;
 
     for (ppinfo = pInfo->begin(), fEntered = false; 
-         ppinfo <= pInfo->end() && ppinfo && !fEntered; 
+         ppinfo <= pInfo->end() && !fEntered; 
          ppinfo++)
     {
         if (CompareFileTime(&ppinfo->ft, &psgi->ft) == -1)
@@ -123,7 +123,7 @@ BOOL ExtractDataFromSaveFile(LPSTR pszFile, SAVEGAMEINFO * psgi)
 //  History:    01-Jun-97    SHernd  Created
 //
 //---------------------------------------------------------------------------
-BOOL EnterSavedGamesIntoLoadGameVector(vector<SAVEGAMEINFO> * pInfo)
+BOOL EnterSavedGamesIntoLoadGameVector(std::vector<SAVEGAMEINFO> * pInfo)
 {
     char                szPath[_MAX_PATH];
     char                szBase[_MAX_PATH];
@@ -181,15 +181,15 @@ BOOL EnterSavedGamesIntoLoadGameVector(vector<SAVEGAMEINFO> * pInfo)
 }
 
 
-void FindSavedGames(CUIListbox * plist, vector<SAVEGAMEINFO> * psgi)
+void FindSavedGames(CUIListbox * plist, std::vector<SAVEGAMEINFO> * psgi)
 {
-    vector<SAVEGAMEINFO>::iterator  ppinfo;
+    std::vector<SAVEGAMEINFO>::iterator  ppinfo;
 
     EnterSavedGamesIntoLoadGameVector(psgi);
 
-    for (ppinfo = psgi->begin(); ppinfo && ppinfo != psgi->end(); ppinfo++)
+    for (ppinfo = psgi->begin(); ppinfo != psgi->end(); ppinfo++)
     {
-        plist->AddItem(ppinfo->szName, (DWORD)ppinfo, -1, 0);
+        plist->AddItem(ppinfo->szName, (DWORD)&(*ppinfo), -1, 0);
     }
 }
 
@@ -205,9 +205,9 @@ CLoadGameWnd::CLoadGameWnd(CUIManager * puimgr) : CUIDlg(puimgr)
 
 CLoadGameWnd::~CLoadGameWnd()
 {
-    vector<SAVEGAMEINFO>::iterator  ppinfo;
+    std::vector<SAVEGAMEINFO>::iterator  ppinfo;
 
-    for (ppinfo = m_vInfo.begin(); ppinfo && ppinfo != m_vInfo.end(); ppinfo++)
+    for (ppinfo = m_vInfo.begin(); ppinfo != m_vInfo.end(); ppinfo++)
     {
         delete ppinfo->pdib;
     }
@@ -311,7 +311,7 @@ void CLoadGameWnd::UIListboxClick(CUICtrl * pctrl, int iIndex)
     DWORD           dwParam;
     WORD            wFlags;
     CUIStatic *     pstatic;
-    vector<SAVEGAMEINFO>::iterator  ppinfo;
+    SAVEGAMEINFO*   ppinfo;
 
     if (iIndex == -1)
     {
@@ -385,9 +385,9 @@ CSaveGameWnd::CSaveGameWnd(CUIManager * puimgr) : CUIDlg(puimgr)
 
 CSaveGameWnd::~CSaveGameWnd()
 {
-    vector<SAVEGAMEINFO>::iterator  ppinfo;
+    std::vector<SAVEGAMEINFO>::iterator  ppinfo;
 
-    for (ppinfo = m_vInfo.begin(); ppinfo && ppinfo != m_vInfo.end(); ppinfo++)
+    for (ppinfo = m_vInfo.begin(); ppinfo != m_vInfo.end(); ppinfo++)
     {
         delete ppinfo->pdib;
     }
@@ -540,7 +540,7 @@ void CSaveGameWnd:: UIListboxClick(CUICtrl * pctrl, int iIndex)
     DWORD           dwParam;
     WORD            wFlags;
     CUIStatic *     pstatic;
-    vector<SAVEGAMEINFO>::iterator  ppinfo;
+    SAVEGAMEINFO*   ppinfo;
 
     pstatic = (CUIStatic *)GetUICtrl(1003);
 

--- a/jp2_pc/Source/Trespass/supportfn.cpp
+++ b/jp2_pc/Source/Trespass/supportfn.cpp
@@ -354,9 +354,9 @@ void CenterUIWindow(CUIWnd * puiwnd)
         return;
     }
 
-    vector<CUICtrl *>::iterator      i;
+    std::vector<CUICtrl *>::iterator      i;
 
-    for (i = puiwnd->m_vUICtrls.begin(); i < puiwnd->m_vUICtrls.end() && i; i++)
+    for (i = puiwnd->m_vUICtrls.begin(); i < puiwnd->m_vUICtrls.end() && *i; i++)
     {
         (*i)->GetRect(&rcClient);
         OffsetRect(&rcClient, x, y);

--- a/jp2_pc/Source/Trespass/uidlgs.h
+++ b/jp2_pc/Source/Trespass/uidlgs.h
@@ -279,7 +279,7 @@ public:
     void ActualLoad();
 
     CUIListbox *            m_pSaveGameList;
-    vector<SAVEGAMEINFO>    m_vInfo;
+    std::vector<SAVEGAMEINFO>    m_vInfo;
 };
 
 
@@ -306,7 +306,7 @@ public:
 
     CUIEditbox *            m_pGameName;
     CUIListbox *            m_pSaveGameList;
-    vector<SAVEGAMEINFO>    m_vInfo;
+    std::vector<SAVEGAMEINFO>    m_vInfo;
 };
 
 

--- a/jp2_pc/Source/Trespass/uiwnd.cpp
+++ b/jp2_pc/Source/Trespass/uiwnd.cpp
@@ -67,7 +67,7 @@ BOOL CUIManager::Attach(CUIWnd * puiwnd)
 BOOL CUIManager::Detach(CUIWnd * puiwnd)
 {
     BOOL                            bRet = FALSE;
-    vector<CUIWnd *>::iterator      i;
+    std::vector<CUIWnd *>::iterator      i;
 
     for (i = m_vUIWnd.end(); i >= m_vUIWnd.begin(); i--)
     {
@@ -120,14 +120,14 @@ void CUIManager::DrawWindowChain(LPBYTE pbDst,
                                  int iDstBytes,
                                  RECT * prcClip)
 {
-    vector<CUIWnd *>::iterator      i;
+    std::vector<CUIWnd *>::iterator      i;
 
     if (m_vUIWnd.size() == 0)
     {
         return;
     }
 
-    for (i = m_vUIWnd.begin(); i < m_vUIWnd.end() && i; i++)
+    for (i = m_vUIWnd.begin(); i < m_vUIWnd.end() && *i; i++)
     {
         (*i)->DrawIntoSurface(pbDst, 
                               iDstWidth, 
@@ -141,14 +141,14 @@ void CUIManager::DrawWindowChain(LPBYTE pbDst,
 
 void CUIManager::DrawWindowChain(CRaster * pRaster, RECT * prcClip)
 {
-    vector<CUIWnd *>::iterator      i;
+    std::vector<CUIWnd *>::iterator      i;
 
     if (m_vUIWnd.size() == 0)
     {
         return;
     }
 
-    for (i = m_vUIWnd.begin(); i < m_vUIWnd.end() && i; i++)
+    for (i = m_vUIWnd.begin(); i < m_vUIWnd.end() && *i; i++)
     {
         (*i)->DrawIntoSurface(pRaster, prcClip);
     }
@@ -157,14 +157,14 @@ void CUIManager::DrawWindowChain(CRaster * pRaster, RECT * prcClip)
 
 void CUIManager::ResizeScreen()
 {
-    vector<CUIWnd *>::iterator      i;
+    std::vector<CUIWnd *>::iterator      i;
     int                             iWidth;
     int                             iHeight;
 
     iWidth = prasMainScreen->iWidthFront;
     iHeight = prasMainScreen->iHeightFront;
 
-    for (i = m_vUIWnd.begin(); i < m_vUIWnd.end() && i; i++)
+    for (i = m_vUIWnd.begin(); i < m_vUIWnd.end() && *i; i++)
     {
         (*i)->ResizeScreen(iWidth, iHeight);
     }
@@ -525,14 +525,14 @@ BOOL CUIWnd::AddToUICtrlSet(CUICtrl * pctrl)
 
 void CUIWnd::DoUIHandling()
 {
-    vector<CUICtrl*>::iterator      i;
+    std::vector<CUICtrl*>::iterator      i;
 
     if (m_vUICtrls.size() == 0)
     {
         return;
     }
 
-    for (i = m_vUICtrls.end() - 1; i >= m_vUICtrls.begin() && i; i--)
+    for (i = m_vUICtrls.end() - 1; i >= m_vUICtrls.begin() && *i; i--)
     {
         (*i)->DoFrame(m_pUIMgr->m_ptMouse);
     }
@@ -664,14 +664,14 @@ void CUIWnd::DrawUICtrls(LPBYTE pbDst,
                          int iDstBytes,
                          RECT * prc)
 {
-    vector<CUICtrl *>::iterator     i;
+    std::vector<CUICtrl *>::iterator     i;
 
     if (m_pUIMgr->GetActiveUIWnd() != this)
     {
         return;
     }
 
-    for (i = m_vUICtrls.begin(); i < m_vUICtrls.end() && i; i++)
+    for (i = m_vUICtrls.begin(); i < m_vUICtrls.end() && *i; i++)
     {
         (*i)->Draw(pbDst, iDstWidth, iDstHeight, iDstPitch, iDstBytes, prc);
     }
@@ -680,14 +680,14 @@ void CUIWnd::DrawUICtrls(LPBYTE pbDst,
 
 void CUIWnd::DrawUICtrls(CRaster * pRaster, RECT * prc)
 {
-    vector<CUICtrl *>::iterator     i;
+    std::vector<CUICtrl *>::iterator     i;
 
     if (m_pUIMgr->GetActiveUIWnd() != this)
     {
         return;
     }
 
-    for (i = m_vUICtrls.begin(); i < m_vUICtrls.end() && i; i++)
+    for (i = m_vUICtrls.begin(); i < m_vUICtrls.end() && *i; i++)
     {
         (*i)->Draw(pRaster, prc);
     }
@@ -919,8 +919,8 @@ Error:
 
 BOOL CUIWnd::OnCreate()
 {
-    vector<CUIWnd *>::iterator  iuiwnd;
-    vector<CUICtrl*>::iterator  iuictrl;
+    std::vector<CUIWnd *>::iterator  iuiwnd;
+    std::vector<CUICtrl*>::iterator  iuictrl;
 
     BOOL        bRet;
 	POINT		pt;
@@ -931,7 +931,7 @@ BOOL CUIWnd::OnCreate()
     if (iuiwnd >= m_pUIMgr->m_vUIWnd.begin())
     {
         for (iuictrl = (*iuiwnd)->m_vUICtrls.begin();
-             iuictrl < (*iuiwnd)->m_vUICtrls.end() && iuictrl;
+             iuictrl < (*iuiwnd)->m_vUICtrls.end() && *iuictrl;
              iuictrl++)
         {
             pt.x = pt.y = -1;
@@ -961,7 +961,7 @@ Error:
 
 void CUIWnd::OnDestroy()
 {
-    vector<CUICtrl*>::iterator      iuictrl;
+    std::vector<CUICtrl*>::iterator      iuictrl;
 
     InvalidateRect(NULL);
 
@@ -979,7 +979,7 @@ void CUIWnd::OnDestroy()
 
 CUICtrl * CUIWnd::GetUICtrl(DWORD dwID)
 {
-    vector<CUICtrl*>::iterator      iuictrl;
+    std::vector<CUICtrl*>::iterator      iuictrl;
 
     for (iuictrl = m_vUICtrls.begin(); 
          iuictrl < m_vUICtrls.end();
@@ -1012,14 +1012,14 @@ void CUIWnd::OnMouseMove(int x, int y, UINT keyFlags)
 
 void CUIWnd::OnLButtonDown(BOOL fDoubleClick, int x, int y, UINT keyFlags)
 {
-    vector<CUICtrl*>::iterator          i;
+    std::vector<CUICtrl*>::iterator          i;
 
     if (m_vUICtrls.size() == 0)
     {
         return;
     }
 
-    for (i = m_vUICtrls.end() - 1; i >= m_vUICtrls.begin() && i; i--)
+    for (i = m_vUICtrls.end() - 1; i >= m_vUICtrls.begin() && *i; i--)
     {
         if (*i && 
             (*i)->HitTest(m_pUIMgr->m_ptMouse.x, m_pUIMgr->m_ptMouse.y) &&
@@ -1041,14 +1041,14 @@ void CUIWnd::OnLButtonUp(int x, int y, UINT keyFlags)
     }
     else
     {
-        vector<CUICtrl*>::iterator          i;
+        std::vector<CUICtrl*>::iterator          i;
 
         if (m_vUICtrls.size() == 0)
         {
             return;
         }
 
-        for (i = m_vUICtrls.end() - 1; i >= m_vUICtrls.begin() && i; i--)
+        for (i = m_vUICtrls.end() - 1; i >= m_vUICtrls.begin() && *i; i--)
         {
             if (*i && 
                 (*i)->HitTest(m_pUIMgr->m_ptMouse.x, m_pUIMgr->m_ptMouse.y) &&

--- a/jp2_pc/Source/Trespass/uiwnd.h
+++ b/jp2_pc/Source/Trespass/uiwnd.h
@@ -17,7 +17,7 @@
 #ifndef __UIWND_H__
 #define __UIWND_H__
 
-#include <vector.h>
+#include <vector>
 
 #include "ctrls.h"
 
@@ -68,7 +68,7 @@ public:
     WORD            m_wTransColor;
     CUICtrl *       m_pUICtrlMouseCaptured;
 
-    vector<CUIWnd *>> m_vUIWnd;
+    std::vector<CUIWnd *> m_vUIWnd;
 
 };
 
@@ -83,7 +83,7 @@ public:
     DWORD       m_dwExitValue;      // exit value of UIWnd handler
 
     RECT        m_rc;               // window rect
-    vector<CUICtrl *>> m_vUICtrls;
+    std::vector<CUICtrl *> m_vUICtrls;
 
     CRaster *   m_pRaster;          // Background To Draw
 	static BOOL bIgnoreSysKey;

--- a/jp2_pc/Source/Trespass/video.h
+++ b/jp2_pc/Source/Trespass/video.h
@@ -20,7 +20,7 @@
 
 
 #include "uiwnd.h"
-#include "smack.h"
+#include "smacker/smack.h"
 
 
 //+--------------------------------------------------------------------------


### PR DESCRIPTION
Various changes are made to make `trespass`, the game executable, more compilable.
Apparantly in old STL implementations, an iterator of a vector was the same as a pointer. That is no longer the case, we have to distinguish between the two.