### PR TITLE
CMake: add Windows libs & adjustments for GroffExp 

### DIFF
--- a/jp2_pc/cmake/AITest/CMakeLists.txt
+++ b/jp2_pc/cmake/AITest/CMakeLists.txt
@@ -56,4 +56,9 @@ target_link_libraries(${PROJECT_NAME}
     WinShell
 
     lz32
+    winmm
+
+    dxguid
+    dsound
+    ddraw
 )

--- a/jp2_pc/cmake/CollisionEditor/CMakeLists.txt
+++ b/jp2_pc/cmake/CollisionEditor/CMakeLists.txt
@@ -55,4 +55,8 @@ target_link_libraries(${PROJECT_NAME}
     View
 
     lz32
+    winmm
+
+    dxguid
+    dsound
 )

--- a/jp2_pc/cmake/GUIApp/CMakeLists.txt
+++ b/jp2_pc/cmake/GUIApp/CMakeLists.txt
@@ -138,4 +138,9 @@ target_link_libraries(${PROJECT_NAME}
     View
 
     lz32
+    winmm
+
+    dxguid
+    dsound
+    ddraw
 )

--- a/jp2_pc/cmake/GroffBuild/CMakeLists.txt
+++ b/jp2_pc/cmake/GroffBuild/CMakeLists.txt
@@ -52,4 +52,9 @@ target_link_libraries(${PROJECT_NAME}
     lz32
     version
     comctl32
+    winmm
+
+    dxguid
+    dsound
+    ddraw
 )

--- a/jp2_pc/cmake/GroffExp/CMakeLists.txt
+++ b/jp2_pc/cmake/GroffExp/CMakeLists.txt
@@ -51,6 +51,50 @@ add_library(${PROJECT_NAME} SHARED ${GroffExp_Inc} ${GroffExp_Src} ${GroffExp_Rs
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tools)
 
-#target_link_libraries(${PROJECT_NAME}
-#TODO add dependencies here
-#)
+set_target_properties(${PROJECT_NAME} PROPERTIES SUFFIX ".dle") #Replace .dll with .dle
+
+target_link_options(${PROJECT_NAME} PUBLIC "/SAFESEH:NO") #Needed for old 3DS Max SDK
+
+target_link_libraries(${PROJECT_NAME}
+    AI
+    Audio
+    EntityDBase
+    Game
+    GeomDBase
+    Loader
+    Math
+    Physics
+    Render3D
+    ScreenRenderDWI
+    Std
+    System
+    View
+
+    comctl32
+    lz32
+    winmm
+
+    ddraw
+    dsound
+    dxguid
+
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/BMM.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/CLIENT.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/CORE.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/EXPR.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/FLILIBD.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/FLILIBH.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/FLILIBR.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/FLT.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/GCOMM.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/GEOM.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/GFX.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/MESH.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/NURBS.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/PARTICLE.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/PATCH.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/RESMGR.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/UTIL.LIB
+    ${CMAKE_SOURCE_DIR}/Lib/MaxSDK/VIEWFILE.LIB
+)
+

--- a/jp2_pc/cmake/MathTest/CMakeLists.txt
+++ b/jp2_pc/cmake/MathTest/CMakeLists.txt
@@ -43,4 +43,9 @@ target_link_libraries(${PROJECT_NAME}
     WinShell
 
     lz32
+    winmm
+
+    dxguid
+    dsound
+    ddraw
 )

--- a/jp2_pc/cmake/PhysicsTest/CMakeLists.txt
+++ b/jp2_pc/cmake/PhysicsTest/CMakeLists.txt
@@ -43,4 +43,9 @@ target_link_libraries(${PROJECT_NAME}
     WinShell
 
     lz32
+    winmm
+
+    ddraw
+    dxguid
+    dsound
 )

--- a/jp2_pc/cmake/trespass/CMakeLists.txt
+++ b/jp2_pc/cmake/trespass/CMakeLists.txt
@@ -81,7 +81,12 @@ target_link_libraries(${PROJECT_NAME}
     View
 
     comctl32
-    lz32
+    lz32    
+    winmm
+
+    ddraw
+    dsound
+    dxguid
 
     ${CMAKE_SOURCE_DIR}/lib/smacker/SMACKW32.LIB
 )


### PR DESCRIPTION
Some Windows libraries (especially DirectX-related) were missing from the linker input lists for the EXE projects. They are added to the lists.
For `GroffExp`, the linker input list is defined for the first time and some small adjustments are made to the project configuration.