### PR TITLE
Global variables and functions, GroffBuild details

### DIFF
--- a/jp2_pc/Source/GUIApp/GUIApp.cpp
+++ b/jp2_pc/Source/GUIApp/GUIApp.cpp
@@ -1389,3 +1389,7 @@ float fGetFloatFromString(char* str_float)
 	Verify(sscanf(str_float, "%f", &f) == 1);
 	return f;
 }
+
+//Global variables and functions declared elsewhere as extern
+//needed by the libraries
+void LineColour(int, int, int) {}

--- a/jp2_pc/Source/Game/AI/Port.cpp
+++ b/jp2_pc/Source/Game/AI/Port.cpp
@@ -34,8 +34,6 @@ void DrawSilhouette(const CSilhouette*){}
 
 void DrawFeeling(const CFeeling &, const CVector2<>&){}
 
-void LineColour(int,int,int){}
-
 bool IsMenuItemChecked(unsigned int){return false;}
 
 void Line(CVector2<>, CVector2<>){}

--- a/jp2_pc/Source/GroffBuild/main.cpp
+++ b/jp2_pc/Source/GroffBuild/main.cpp
@@ -290,4 +290,13 @@ void ResetAppData()
 
 	// None for Trespass at this time.
 }
- 
+
+
+//Global variables and functions declared elsewhere as extern
+//needed by the libraries
+bool bIsTrespasser = false;
+bool bInvertMouse = false;
+unsigned int g_u4NotifyParam = 0;
+unsigned int u4LookupResourceString(int, char*, unsigned int) { return 0; }
+void LineColour(int, int, int) {}
+PFNWORLDLOADNOTIFY g_pfnWorldLoadNotify = nullptr;

--- a/jp2_pc/Source/GroffBuild/maindlg.cpp
+++ b/jp2_pc/Source/GroffBuild/maindlg.cpp
@@ -22,7 +22,7 @@
 #include "dialogs.h"
 #include "main.h"
 #include "utils.h"
-#include "reg.h"
+#include "Lib/Sys/reg.h"
 
 extern HINSTANCE    g_hInst;
 

--- a/jp2_pc/Source/Test/Physics/PhysicsTestShell.cpp
+++ b/jp2_pc/Source/Test/Physics/PhysicsTestShell.cpp
@@ -37,6 +37,7 @@
 #include "Lib/Sys/W95/Render.hpp"
 #include "PhysicsTestShell.hpp"
 #include "PhysicsTest.hpp"
+#include "Lib/Loader/Loader.hpp"
 
 
 //
@@ -283,3 +284,14 @@ void WindowsEvent(uint u_message, WPARAM wp_param, LPARAM lp_param)
 			break;
 	}
 }
+
+
+//Global variables and functions declared elsewhere as extern
+//needed by the libraries
+bool bIsTrespasser = false;
+bool bUseReplayFile = false;
+bool bInvertMouse = false;
+bool bUseOutputFiles = false;
+unsigned int g_u4NotifyParam = 0;
+unsigned int u4LookupResourceString(int, char*, unsigned int) { return 0; }
+PFNWORLDLOADNOTIFY g_pfnWorldLoadNotify = nullptr;

--- a/jp2_pc/Source/Test/TestMath.cpp
+++ b/jp2_pc/Source/Test/TestMath.cpp
@@ -56,6 +56,7 @@
 #include "Lib/Math/FastSqrt.hpp"
 #include "Lib/Sys/TextOut.hpp"
 #include "Lib/Sys/ConIO.hpp"
+#include "Lib/Loader/Loader.hpp"
 #include "Shell/AppShell.hpp"
 #include "Shell/AppShell.hpp"
 #include "TestMath.hpp"
@@ -185,3 +186,15 @@ public:
 
 
 CAppShell* pappMain = new CAppShellTestMath;
+
+
+//Global variables and functions declared elsewhere as extern
+//needed by the libraries
+bool bIsTrespasser = false;
+bool bUseReplayFile = false;
+bool bInvertMouse = false;
+bool bUseOutputFiles = false;
+unsigned int g_u4NotifyParam = 0;
+unsigned int u4LookupResourceString(int, char*, unsigned int) { return 0; }
+void LineColour(int,int,int) {}
+PFNWORLDLOADNOTIFY g_pfnWorldLoadNotify = nullptr;

--- a/jp2_pc/Source/Tools/GroffExp/GroffExp.cpp
+++ b/jp2_pc/Source/Tools/GroffExp/GroffExp.cpp
@@ -3714,3 +3714,18 @@ int JP2Export::DoExport(const TCHAR* tchr_export_filename, ExpInterface* pei_exp
 	// Set the GUI interface pointer to null.
 	return true;                                                  
 }
+
+
+//Global variables and functions declared elsewhere as extern
+//needed by the libraries
+bool bIsTrespasser = false;
+bool bUseReplayFile = false;
+bool bInvertMouse = false;
+bool bUseOutputFiles = false;
+unsigned int g_u4NotifyParam = 0;
+unsigned int u4LookupResourceString(int, char*, unsigned int) { return 0; }
+void LineColour(int, int, int) {}
+void* hwndGetMainHwnd() { return nullptr; }
+HINSTANCE hinstGetMainHInstance() { return nullptr; }
+void ResetAppData() {}
+PFNWORLDLOADNOTIFY g_pfnWorldLoadNotify = nullptr;

--- a/jp2_pc/Source/Trespass/tpassglobals.cpp
+++ b/jp2_pc/Source/Trespass/tpassglobals.cpp
@@ -36,6 +36,7 @@ const float                 g_afGamma[10] =
     0.0f,
 };
 
+void LineColour(int, int, int) {}
 
 uint32 __stdcall TPassLoadNotify(uint32 dwContext, 
                                  uint32 dwParam1, 

--- a/jp2_pc/cmake/GroffBuild/CMakeLists.txt
+++ b/jp2_pc/cmake/GroffBuild/CMakeLists.txt
@@ -4,8 +4,8 @@ list(APPEND GroffBuild_Inc
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/dialogs.h
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/gbuilder.h
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/main.h
-    #${CMAKE_SOURCE_DIR}/Source/GroffBuild/reg.h
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/utils.h
+    ${CMAKE_SOURCE_DIR}/Source/GroffBuild/precomp.h
 )
 
 list(APPEND GroffBuild_Src
@@ -13,7 +13,6 @@ list(APPEND GroffBuild_Src
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/gbuilder.cpp
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/main.cpp
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/maindlg.cpp
-    #${CMAKE_SOURCE_DIR}/Source/GroffBuild/reg.cpp
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/Utils.cpp
 )
 
@@ -29,6 +28,8 @@ include_directories(
 add_common_options()
 
 add_executable(${PROJECT_NAME} WIN32 ${GroffBuild_Inc} ${GroffBuild_Src} ${GroffBuild_Rsc} )
+
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/Source/GroffBuild/precomp.h)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tools)
 


### PR DESCRIPTION
The libraries use various global variables and functions, often declared as `extern`. That global stuff was missing for some executable projects, causing linker errors.
The empty implementation of `LineColour` in `AI/Port.cpp` caused conflicts with the non-empty implementations in `PhysicsTest`, so it was removed. Consequently, some new empty `LineColour` implementations were added elsewhere as required.

Furthermore, some details in `GroffBuild` are resolved. `reg.h and reg.cpp` are removed from the project, their usage is redirected to the existing implementation from `System`. `precomp.h` is added to the source list and used as the precompiled header.