### PR TITLE
CMake: deduplicate file references

### DIFF
--- a/jp2_pc/cmake/AITest/CMakeLists.txt
+++ b/jp2_pc/cmake/AITest/CMakeLists.txt
@@ -6,7 +6,6 @@ list(APPEND AITest_Inc
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/AStarTest.hpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/FakePhysics.hpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/FakeShape.hpp
-    ${CMAKE_SOURCE_DIR}/Source/GUIApp/PredefinedShapes.hpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/TestAnimal.hpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/TestBrains.hpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/UIModes.hpp
@@ -18,7 +17,6 @@ list(APPEND AITest_Src
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/AStarTest.cpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/FakePhysics.cpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/FakeShape.cpp
-    ${CMAKE_SOURCE_DIR}/Source/GUIApp/PreDefinedShapes.cpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/TestAnimal.cpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/TestBrains.cpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/UIModes.cpp

--- a/jp2_pc/cmake/Game/CMakeLists.txt
+++ b/jp2_pc/cmake/Game/CMakeLists.txt
@@ -17,7 +17,6 @@ list(APPEND Game_Inc
 )
 
 list(APPEND Game_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/File/Image.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Trigger/Action.cpp
     ${CMAKE_SOURCE_DIR}/Source/Game/DesignDaemon/BloodSplat.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Trigger/BooleanTrigger.cpp

--- a/jp2_pc/cmake/GeomDBase/CMakeLists.txt
+++ b/jp2_pc/cmake/GeomDBase/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(GeomDBase)
 
 list(APPEND GeomDBase_Inc
-    ${CMAKE_SOURCE_DIR}/Source/Lib/File/Image.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/GeomDBase/ClipMesh.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/EntityDBase/Container.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/GeomTypes.hpp
@@ -37,7 +36,6 @@ list(APPEND GeomDBase_Inc
 )
 
 list(APPEND GeomDBase_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/File/Image.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/GeomDBase/ClipMesh.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/GeomTypes.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/GeomTypesBox.cpp

--- a/jp2_pc/cmake/GroffExp/CMakeLists.txt
+++ b/jp2_pc/cmake/GroffExp/CMakeLists.txt
@@ -2,18 +2,11 @@ project(GroffExp)
 
 list(APPEND GroffExp_Inc
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Bitmap.hpp
-    ${CMAKE_SOURCE_DIR}/source/Lib/Groff/EasyString.hpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Export.hpp
-    ${CMAKE_SOURCE_DIR}/source/Lib/Groff/FileIO.hpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Geometry.hpp
-    ${CMAKE_SOURCE_DIR}/source/Lib/Groff/Groff.hpp
     ${CMAKE_SOURCE_DIR}/source/Tools/GroffExp/GUIInterface.hpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Mathematics.hpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/ObjectDef.hpp
-    ${CMAKE_SOURCE_DIR}/source/Lib/Groff/ObjectHandle.hpp
-    ${CMAKE_SOURCE_DIR}/source/Lib/Sys/SmartBuffer.hpp
-    ${CMAKE_SOURCE_DIR}/source/Lib/Sys/Symtab.hpp
-    ${CMAKE_SOURCE_DIR}/source/Lib/Sys/SysLog.hpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/GroffExp.h
 )
 
@@ -24,19 +17,12 @@ list(APPEND GroffExp_Rsc
 
 list(APPEND GroffExp_Src
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Bitmap.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Groff/EasyString.cpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Export.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Groff/FileIO.cpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Geometry.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Groff/Groff.cpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/GroffExp.cpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/GUIInterface.cpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/Mathematics.cpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/ObjectDef.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Groff/ObjectHandle.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/SmartBuffer.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Symtab.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/SysLog.cpp
 )
 
 include_directories(

--- a/jp2_pc/cmake/MathTest/CMakeLists.txt
+++ b/jp2_pc/cmake/MathTest/CMakeLists.txt
@@ -8,11 +8,6 @@ list(APPEND MathTest_Src
     ${CMAKE_SOURCE_DIR}/Source/Test/TestMath.cpp
 )
 
-list(APPEND MathTest_Rsc
-    ${CMAKE_SOURCE_DIR}/Source/Shell/WinShell.rc
-
-)
-
 include_directories(
     ${CMAKE_SOURCE_DIR}/Source
     ${CMAKE_SOURCE_DIR}/Source/gblinc
@@ -21,7 +16,7 @@ include_directories(
 
 add_common_options()
 
-add_executable(${PROJECT_NAME} WIN32 ${MathTest_Inc} ${MathTest_Src} ${MathTest_Rsc} )
+add_executable(${PROJECT_NAME} WIN32 ${MathTest_Inc} ${MathTest_Src} )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tests)
 

--- a/jp2_pc/cmake/Physics/CMakeLists.txt
+++ b/jp2_pc/cmake/Physics/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(Physics)
 
 list(APPEND Physics_Inc
-    ${CMAKE_SOURCE_DIR}/source/Lib/Loader/ASyncLoader.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Physics/Arms.h
     ${CMAKE_SOURCE_DIR}/Source/Lib/Physics/BioModel.h
     ${CMAKE_SOURCE_DIR}/Source/Lib/Physics/BioStructure.h
@@ -26,7 +25,6 @@ list(APPEND Physics_Inc
 )
 
 list(APPEND Physics_Src
-    ${CMAKE_SOURCE_DIR}/Source/Lib/Loader/AsyncLoader.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Physics/Arms.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Physics/BioModel.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Physics/dino_biped.cpp

--- a/jp2_pc/cmake/PhysicsTest/CMakeLists.txt
+++ b/jp2_pc/cmake/PhysicsTest/CMakeLists.txt
@@ -10,10 +10,6 @@ list(APPEND PhysicsTest_Src
     ${CMAKE_SOURCE_DIR}/Source/Test/Physics/PhysicsTestShell.cpp
 )
 
-list(APPEND PhysicsTest_Rsc
-    ${CMAKE_SOURCE_DIR}/Source/Shell/WinShell.rc
-)
-
 include_directories(
     ${CMAKE_SOURCE_DIR}/Source
     ${CMAKE_SOURCE_DIR}/Source/gblinc
@@ -22,7 +18,7 @@ include_directories(
 
 add_common_options()
 
-add_executable(${PROJECT_NAME} WIN32 ${PhysicsTest_Inc} ${PhysicsTest_Src} ${PhysicsTest_Rsc} )
+add_executable(${PROJECT_NAME} WIN32 ${PhysicsTest_Inc} ${PhysicsTest_Src} )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tests)
 

--- a/jp2_pc/cmake/PipelineTest/CMakeLists.txt
+++ b/jp2_pc/cmake/PipelineTest/CMakeLists.txt
@@ -10,10 +10,6 @@ list(APPEND PipelineTest_Src
     ${CMAKE_SOURCE_DIR}/Source/Test/TestPipeLine.cpp
 )
 
-list(APPEND PipelineTest_Rsc
-    ${CMAKE_SOURCE_DIR}/Source/Shell/WinShell.rc
-)
-
 include_directories(
     ${CMAKE_SOURCE_DIR}/Source
     ${CMAKE_SOURCE_DIR}/Source/gblinc
@@ -21,6 +17,6 @@ include_directories(
 
 add_common_options()
 
-add_executable(${PROJECT_NAME} WIN32 ${PipelineTest_Inc} ${PipelineTest_Src} ${PipelineTest_Rsc} )
+add_executable(${PROJECT_NAME} WIN32 ${PipelineTest_Inc} ${PipelineTest_Src} )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tests)

--- a/jp2_pc/cmake/System/CMakeLists.txt
+++ b/jp2_pc/cmake/System/CMakeLists.txt
@@ -1,7 +1,6 @@
 project(System)
 
 list(APPEND System_Inc
-    ${CMAKE_SOURCE_DIR}/Source/Lib/File/Image.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Sys/BitBuffer.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/W95/Com.hpp
     ${CMAKE_SOURCE_DIR}/Source/GblInc/Config.hpp

--- a/jp2_pc/cmake/WaveTest/CMakeLists.txt
+++ b/jp2_pc/cmake/WaveTest/CMakeLists.txt
@@ -2,7 +2,6 @@ project(WaveTest)
 
 list(APPEND WaveTest_Src
     ${CMAKE_SOURCE_DIR}/Source/Test/Physics/WaveTest.cpp
-    ${CMAKE_SOURCE_DIR}/Source/Shell/WinShell.rc
 )
 
 add_common_options()

--- a/jp2_pc/cmake/WinShell/CMakeLists.txt
+++ b/jp2_pc/cmake/WinShell/CMakeLists.txt
@@ -12,6 +12,11 @@ list(APPEND WinShell_Src
     ${CMAKE_SOURCE_DIR}/Source/Shell/winshell.cpp
 )
 
+list(APPEND WinShell_Rsc
+    ${CMAKE_SOURCE_DIR}/Source/Shell/WinShell.rc
+
+)
+
 include_directories(
     ${CMAKE_SOURCE_DIR}/Source
     ${CMAKE_SOURCE_DIR}/Source/gblinc
@@ -19,6 +24,6 @@ include_directories(
 
 add_common_options()
 
-add_library(${PROJECT_NAME} STATIC ${WinShell_Inc} ${WinShell_Src} )
+add_library(${PROJECT_NAME} STATIC ${WinShell_Inc} ${WinShell_Src} ${WinShell_Rsc} )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tests)


### PR DESCRIPTION
Some source files were associated with multiple projects. 
The CMake files are cleaned up. The result is that each source file is associated with at most one project.
In an aside note, some of those duplications were copypaste errors from when the CMake structure was first created.