### PR TITLE
CMake: add some missing files

### DIFF
--- a/jp2_pc/cmake/AI/CMakeLists.txt
+++ b/jp2_pc/cmake/AI/CMakeLists.txt
@@ -27,6 +27,14 @@ list(APPEND AI_Inc
     ${CMAKE_SOURCE_DIR}/Source/Game/AI/Synthesizer.hpp
     ${CMAKE_SOURCE_DIR}/Source/Game/AI/TestActivities.hpp
     ${CMAKE_SOURCE_DIR}/Source/Game/AI/WorldView.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/ActivityEnum.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/Classes.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/Feeling.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/Graph.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/Modifier.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/ActivityEnum.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/Rating.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/AI/PathFailure.hpp
 )
 
 list(APPEND AI_Src

--- a/jp2_pc/cmake/AITest/CMakeLists.txt
+++ b/jp2_pc/cmake/AITest/CMakeLists.txt
@@ -10,6 +10,9 @@ list(APPEND AITest_Inc
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/TestAnimal.hpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/TestBrains.hpp
     ${CMAKE_SOURCE_DIR}/Source/Test/AI/UIModes.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Test/AI/AIResource.h
+    ${CMAKE_SOURCE_DIR}/Source/Test/AI/QueryTest.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Test/AI/TestTree.hpp
 )
 
 list(APPEND AITest_Src

--- a/jp2_pc/cmake/Audio/CMakeLists.txt
+++ b/jp2_pc/cmake/Audio/CMakeLists.txt
@@ -9,6 +9,10 @@ list(APPEND Audio_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/Audio/AudioVOICE.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Audio/SoundDefs.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Audio/SoundTypes.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Audio/eax.h
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Audio/Ia3d.h
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Audio/Material.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Audio/Subtitle.hpp
 )
 
 list(APPEND Audio_Src

--- a/jp2_pc/cmake/Bugs/CMakeLists.txt
+++ b/jp2_pc/cmake/Bugs/CMakeLists.txt
@@ -8,12 +8,17 @@ list(APPEND Bugs_Src
     ${CMAKE_SOURCE_DIR}/Source/Bugs/DynamicCastConst.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/FriendOperator.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/FriendSpecialise.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Bugs/MissingDefault.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Bugs/NestedTypeScope.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/NoConvert.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/PartialSpecialise.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Bugs/RandomCrash.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/TemplateAmbiguity.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/TemplateDefaultError.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/TemplateDefaultRedef.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Bugs/TemplateDefaultValue.cpp
     ${CMAKE_SOURCE_DIR}/Source/Bugs/TemplateNested.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Bugs/WackyMessage.cpp
 )
 
 add_common_options()

--- a/jp2_pc/cmake/EntityDBase/CMakeLists.txt
+++ b/jp2_pc/cmake/EntityDBase/CMakeLists.txt
@@ -44,6 +44,11 @@ list(APPEND EntityDBase_Inc
     ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/Teleport.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/Water.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/WorldDBase.hpp    
+    ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/FilterIterator.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/MessageTypes.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/Instancer.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/Subsystem.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/EntityDBase/WorldPriv.hpp
 )
 
 list(APPEND EntityDBase_Src

--- a/jp2_pc/cmake/File/CMakeLists.txt
+++ b/jp2_pc/cmake/File/CMakeLists.txt
@@ -3,6 +3,7 @@ project(File)
 list(APPEND File_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/File/Image.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/File/Section.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/File/Spec.hpp
 )
 
 list(APPEND File_Src

--- a/jp2_pc/cmake/GUIApp/CMakeLists.txt
+++ b/jp2_pc/cmake/GUIApp/CMakeLists.txt
@@ -46,6 +46,8 @@ ${CMAKE_SOURCE_DIR}/Source/GUIApp/SoundPropertiesDlg.hpp
 ${CMAKE_SOURCE_DIR}/Source/GUIApp/StdAfx.h
 ${CMAKE_SOURCE_DIR}/Source/GUIApp/TerrainTest.hpp
 ${CMAKE_SOURCE_DIR}/Source/GUIApp/Toolbar.hpp
+${CMAKE_SOURCE_DIR}/Source/GUIApp/resource.h
+${CMAKE_SOURCE_DIR}/Source/GUIApp/DialogScrollBars.hpp
 )
 
 list(APPEND GUIApp_Src

--- a/jp2_pc/cmake/Game/CMakeLists.txt
+++ b/jp2_pc/cmake/Game/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND Game_Inc
     ${CMAKE_SOURCE_DIR}/Source/Game/DesignDaemon/PlayerSettings.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/EntityDBase/TextOverlay.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Trigger/Trigger.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Game/DesignDaemon/Socket.hpp
 )
 
 list(APPEND Game_Src

--- a/jp2_pc/cmake/GeomDBase/CMakeLists.txt
+++ b/jp2_pc/cmake/GeomDBase/CMakeLists.txt
@@ -34,6 +34,15 @@ list(APPEND GeomDBase_Inc
     ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/WaveletQuadTreeQuery.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/WaveletQuadTreeTForm.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/WaveletStaticData.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/InvisibleShape.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/LightShape.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/LineSegment.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/PartitionBuildBase.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/PartitionPrivClass.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/Plane.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/PlaneAxis.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/GeomDBase/WaveletCoef.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/GeomTypesPriv.hpp
 )
 
 list(APPEND GeomDBase_Src

--- a/jp2_pc/cmake/GroffBuild/CMakeLists.txt
+++ b/jp2_pc/cmake/GroffBuild/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND GroffBuild_Inc
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/main.h
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/utils.h
     ${CMAKE_SOURCE_DIR}/Source/GroffBuild/precomp.h
+    ${CMAKE_SOURCE_DIR}/Source/GroffBuild/resource.h
 )
 
 list(APPEND GroffBuild_Src

--- a/jp2_pc/cmake/GroffExp/CMakeLists.txt
+++ b/jp2_pc/cmake/GroffExp/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND GroffExp_Inc
     ${CMAKE_SOURCE_DIR}/source/Lib/Sys/Symtab.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Sys/SysLog.hpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/GroffExp.h
+    ${CMAKE_SOURCE_DIR}/Source/Tools/GroffExp/StandardTypes.hpp
 )
 
 list(APPEND GroffExp_Rsc

--- a/jp2_pc/cmake/Loader/CMakeLists.txt
+++ b/jp2_pc/cmake/Loader/CMakeLists.txt
@@ -23,6 +23,8 @@ list(APPEND Loader_Inc
     ${CMAKE_SOURCE_DIR}/source/Lib/Loader/TextureManager.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Loader/TexturePackSurface.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Groff/ValueTable.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Loader/SaveBuffer.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Groff/VTParse.hpp
 )
 
 list(APPEND Loader_Src

--- a/jp2_pc/cmake/Math/CMakeLists.txt
+++ b/jp2_pc/cmake/Math/CMakeLists.txt
@@ -19,6 +19,10 @@ list(APPEND Math_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/Transform/TransLinear.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Transform/Vector.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Transform/VectorRange.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Types/BigFixed.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Types/FixedP.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Types/P5/FixedPEx.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Math/FloatShort.hpp
 )
 
 list(APPEND Math_Src

--- a/jp2_pc/cmake/QuantizerTool/CMakeLists.txt
+++ b/jp2_pc/cmake/QuantizerTool/CMakeLists.txt
@@ -3,11 +3,14 @@ project(QuantizerTool)
 list(APPEND QuantizerTool_Src
     ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/QuantizerTool.cpp
     ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/QuantizerToolDlg.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/StdAfx.cpp
 )
 
 list(APPEND QuantizerTool_Inc
     ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/QuantizerTool.h
     ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/QuantizerToolDlg.h
+    ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/stdafx.h
+    ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/resource.h
 )
 
 list(APPEND QuantizerTool_Res
@@ -21,3 +24,5 @@ add_common_options()
 add_executable(${PROJECT_NAME} WIN32 ${QuantizerTool_Src} ${QuantizerTool_Inc} ${QuantizerTool_Res} )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Tools)
+
+target_precompile_headers(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR}/Source/Tools/QuantizerTool/stdafx.h)

--- a/jp2_pc/cmake/Render3D/CMakeLists.txt
+++ b/jp2_pc/cmake/Render3D/CMakeLists.txt
@@ -21,6 +21,13 @@ list(APPEND Render3D_Inc
     ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/Shadow.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/Sky.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/Texture.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/SkyPoly.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/ShapePresence.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/screenrenderauxd3dutilities.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/RenderDefs.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/Line2D.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/LineSide2DTest.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/Overlay.hpp
 )
 
 list(APPEND Render3D_Src

--- a/jp2_pc/cmake/ScreenRenderDWI/CMakeLists.txt
+++ b/jp2_pc/cmake/ScreenRenderDWI/CMakeLists.txt
@@ -18,6 +18,15 @@ list(APPEND ScreenRenderDWI_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/screenrenderdwi.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Walk.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/P6/WalkEx.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/RenderCacheInterface.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Renderer/RenderCacheLRUItem.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/ColLookupT.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/Edge.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/IndexPerspectiveT.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/LineBumpMake.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/MapT.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/ScanLine.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Renderer/Primitives/TransparencyT.hpp
 )
 
 list(APPEND ScreenRenderDWI_Src

--- a/jp2_pc/cmake/Std/CMakeLists.txt
+++ b/jp2_pc/cmake/Std/CMakeLists.txt
@@ -29,6 +29,10 @@ list(APPEND Std_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/Std/UAssert.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Std/UDefs.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Std/UTypes.hpp
+    ${CMAKE_SOURCE_DIR}/Source/GblInc/Warnings.hpp
+    ${CMAKE_SOURCE_DIR}/Source/GblInc/Version.hpp
+    ${CMAKE_SOURCE_DIR}/Source/GblInc/VerBones.hpp
+    ${CMAKE_SOURCE_DIR}/Source/GblInc/3DX.hpp
 )
 
 list(APPEND Std_Src

--- a/jp2_pc/cmake/System/CMakeLists.txt
+++ b/jp2_pc/cmake/System/CMakeLists.txt
@@ -26,6 +26,14 @@ list(APPEND System_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ThreadControl.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Sys/VirtualMem.hpp
     ${CMAKE_SOURCE_DIR}/Source/shell/winrendertools.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/Errors.h
+    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/WinAlias.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/WinInclude.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Timer.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ThreadActionBase.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FileEx.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/TextOut.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/P5/Msr.hpp
 )
 
 list(APPEND System_Src
@@ -57,6 +65,10 @@ list(APPEND System_Src
     ${CMAKE_SOURCE_DIR}/Source/Shell/WinRenderTools.cpp
 )
 
+list(APPEND System_Rsc
+    ${CMAKE_SOURCE_DIR}/Source/Lib/W95/Errors.rc
+)
+
 include_directories(
     ${CMAKE_SOURCE_DIR}/Source
     ${CMAKE_SOURCE_DIR}/Source/gblinc
@@ -64,6 +76,6 @@ include_directories(
 
 add_common_options()
 
-add_library(${PROJECT_NAME} STATIC ${System_Inc} ${System_Src} )
+add_library(${PROJECT_NAME} STATIC ${System_Inc} ${System_Src} ${System_Rsc} )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Lib/Util)

--- a/jp2_pc/cmake/View/CMakeLists.txt
+++ b/jp2_pc/cmake/View/CMakeLists.txt
@@ -25,6 +25,9 @@ list(APPEND View_Inc
     ${CMAKE_SOURCE_DIR}/source/Lib/View/RasterPool.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/View/RasterVid.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/View/Viewport.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/View/ColourT.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/View/Video.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/W95//Direct3DCards.hpp
 )
 
 list(APPEND View_Src

--- a/jp2_pc/cmake/WinShell/CMakeLists.txt
+++ b/jp2_pc/cmake/WinShell/CMakeLists.txt
@@ -4,6 +4,9 @@ list(APPEND WinShell_Inc
     ${CMAKE_SOURCE_DIR}/Source/Shell/AppEvent.hpp
     ${CMAKE_SOURCE_DIR}/Source/Shell/AppShell.hpp
     ${CMAKE_SOURCE_DIR}/Source/Shell/WinShell.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Shell/ShellResource.h
+    ${CMAKE_SOURCE_DIR}/Source/Shell/Resource.h
+    ${CMAKE_SOURCE_DIR}/Source/Shell/WinEvent.hpp
 )
 
 list(APPEND WinShell_Src

--- a/jp2_pc/cmake/trespass/CMakeLists.txt
+++ b/jp2_pc/cmake/trespass/CMakeLists.txt
@@ -19,6 +19,7 @@ ${CMAKE_SOURCE_DIR}/Source/Trespass/token.h
 ${CMAKE_SOURCE_DIR}/Source/Trespass/tpassglobals.h
 ${CMAKE_SOURCE_DIR}/Source/Trespass/uidlgs.h
 ${CMAKE_SOURCE_DIR}/Source/Trespass/uiwnd.h
+${CMAKE_SOURCE_DIR}/Source/Trespass/resource.h
 )
 
 list(APPEND trespass_Src    


### PR DESCRIPTION
A lot of code files in usage were not part of the project structure. Those files may not show up directly in the VS project structure, which makes them difficult to find and work with. At best they are listed under "external dependencies"... along with the entire Windows SDK.
Some of those files are added to the project. Mainly these heuristics were used:
- Files referenced in source files already in CMake are included
- Files named `X.h` or `X.hpp`, where a corresponding `X.cpp` file exists and is _not_ in CMake, are not included.
