### PR TITLE
CMake: exclude broken projects from default builds & .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ jp2_pc/Build/
 *.vcxproj
 *.filters
 *.user
+*.aps
 
 # OSX Hidden Files
 .DS_Store

--- a/jp2_pc/CMakeLists.txt
+++ b/jp2_pc/CMakeLists.txt
@@ -67,3 +67,25 @@ add_subdirectory(cmake/TweakTrespass)
 add_subdirectory(cmake/View)
 add_subdirectory(cmake/WaveTest)
 add_subdirectory(cmake/WinShell)
+
+
+
+set(DEACTIVATE_BROKEN_PROJECTS TRUE CACHE BOOL INTERNAL)
+
+if (DEACTIVATE_BROKEN_PROJECTS)
+    list(APPEND BROKEN_PROJECTS
+        Bugs
+        CollisionEditor
+        Examples
+        InitGUIApp
+        ProcessorDetect
+        PipelineTest
+        QuantizerToolCLI
+        TweakTrespass
+        WaveTest
+    )
+    foreach(broken ${BROKEN_PROJECTS})
+        set_target_properties(${broken} PROPERTIES EXCLUDE_FROM_ALL true)
+        set_target_properties(${broken} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD true)
+    endforeach()
+endif()

--- a/jp2_pc/CMakeLists.txt
+++ b/jp2_pc/CMakeLists.txt
@@ -84,8 +84,9 @@ if (DEACTIVATE_BROKEN_PROJECTS)
         TweakTrespass
         WaveTest
     )
+    
     foreach(broken ${BROKEN_PROJECTS})
-        set_target_properties(${broken} PROPERTIES EXCLUDE_FROM_ALL true)
-        set_target_properties(${broken} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD true)
+        set_target_properties(${broken} PROPERTIES EXCLUDE_FROM_ALL true)             #When building the ALL_BUILD project
+        set_target_properties(${broken} PROPERTIES EXCLUDE_FROM_DEFAULT_BUILD true)   #When building the entire solution
     endforeach()
 endif()


### PR DESCRIPTION
Some projects are broken in the sense that they do not build properly.
Those projects are now excluded when you try to build the entire solution or the CMake-autogenerated project `ALL_BUILD`. They still show up in the solution and can be built directly.
This behaviour can be disabled with a CMake variable.

In an unrelated change, APS files are added to `.gitignore`. Those files are sometimes generated by VS in the source directory when resource files are edited in VS.