### PR TITLE
VirtualMem: quick and dirty workaround

### DIFF
--- a/jp2_pc/Source/Lib/Sys/VirtualMem.cpp
+++ b/jp2_pc/Source/Lib/Sys/VirtualMem.cpp
@@ -154,7 +154,11 @@ CVirtualMem::CVirtualMem
 	AutoSetMemory();
 
 	// reserve a block of VM of the specified size
-	pu1AllocateBase = (uint8*)VirtualAlloc(NULL,u4_mem_pool,MEM_RESERVE,PAGE_READWRITE);
+	//pu1AllocateBase = (uint8*)VirtualAlloc(NULL,u4_mem_pool,MEM_RESERVE,PAGE_READWRITE);
+
+	//TODO using new[] is a quickfix until VirtualMem is repaired and VirtualAlloc can be used again
+	//TODO also see destructor below
+	pu1AllocateBase = new uint8[u4_mem_pool];
 	Assert(pu1AllocateBase != NULL);
 
 	MEMLOG_ADD_COUNTER(emlVirtualPool,u4_mem_pool);
@@ -223,7 +227,12 @@ CVirtualMem::~CVirtualMem
 	// remove any committed memory
 	if (pvBase)
 	{
-		Verify( VirtualFree(pvBase, u4Length, MEM_DECOMMIT) );
+		//Verify( VirtualFree(pvBase, u4Length, MEM_DECOMMIT) );
+
+		//TODO using delete[] is a quickfix until VirtualMem is repaired and VirtualFree can be used again
+		//TODO also see constructor above
+		delete[] static_cast<uint8*>(pvBase);
+		pvBase = nullptr;
 	}
 
 	// there is no commited memory any more, and the virtual pages require no memory


### PR DESCRIPTION
Something is wrong with Trespasser's usage of virtual memory, we get memory access violations when loading levels.
I want to propose a quickfix until the root cause problem is fully investigated and resolved: instead of virtual memory, we use C++-style memory management. For the record, my old branches ran very stable with this quickfix.