### PR TITLE
Resolve crouch bug

### DIFF
--- a/jp2_pc/Source/Lib/Physics/Pelvis.cpp
+++ b/jp2_pc/Source/Lib/Physics/Pelvis.cpp
@@ -230,7 +230,7 @@ extern bool		 bKontrol_Krouch[NUM_PELVISES];
 	
 				Pel[me][MOUTH][2] = CSPRING*(knees - Pel[me][MOUTH][0]) - CDAMP*Pel[me][MOUTH][1];
 	
-				if (Pel[me][MOUTH][0] < 0.09*(Pel_Data[me][14] - .2) ) {Pel[me][MOUTH][0] = .09*(Pel_Data[me][14] - .2); Pel[me][MOUTH][1] = 0;}
+				if (Pel[me][MOUTH][0] < 0.089*(Pel_Data[me][14] - .2) ) {Pel[me][MOUTH][0] = .09*(Pel_Data[me][14] - .2); Pel[me][MOUTH][1] = 0;}
 				if (Pel[me][MOUTH][0] > 1.1*(Pel_Data[me][14] - .2) ) {Pel[me][MOUTH][0] = 1.1*(Pel_Data[me][14] - .2); Pel[me][MOUTH][1] = 0;}
 
 				hat[0] *= Pel[me][MOUTH][0];


### PR DESCRIPTION
When you crouch to the maximum crouch level, you cannot stand up again. A slight tweak of a magic number resolves this problem.
This is an OpenTrespasser bug, it was not present in the original.