### PR TITLE
Fix level transition crash

### DIFF
--- a/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
@@ -2030,6 +2030,8 @@ CRenderDB*  ps_renderDB = 0;
 		// Release texture pointers.
 		EraseTextureMap();
 
+		// Reset the texture manager
+		gtxmTexMan.Reset();
 
 		//
 		// Reset the load heap


### PR DESCRIPTION
When transitioning to a new level the game would crash.
The cause is that the texture manager holds `rptrs` to `CTexture` objects,
But the memory where the `CTexture` objects are stored is invalidated before `reset()` is called on the texture manager, leaving those `rptrs` dangling. When `reset()` is finally called and the `rptrs` are destructed in the texture manager, this causes memory access violations.
To resolve this problem, a texture manager reset is performed before invalidating the load heap where the `CTexture` objects are stored. 