### PR TITLE
Fix memory leaks and LightBlend 

### DIFF
--- a/jp2_pc/Source/Lib/Renderer/LightBlend.cpp
+++ b/jp2_pc/Source/Lib/Renderer/LightBlend.cpp
@@ -985,12 +985,13 @@ public:
 	//*****************************************************************************************
 	CAlphaBlend::~CAlphaBlend()
 	{
-		delete u2ColorToAlpha;
+		delete[] u2ColorToAlpha;
 	}
 
 	//*****************************************************************************************
 	void CAlphaBlend::Setup(CRaster* pras)
 	{
+		delete[] u2ColorToAlpha;
 		u2ColorToAlpha = new uint16[4096];
 
 		AlwaysAssert(u2ColorToAlpha);

--- a/jp2_pc/Source/Lib/View/Clut.cpp
+++ b/jp2_pc/Source/Lib/View/Clut.cpp
@@ -686,7 +686,7 @@ const char* strClutFileCache = "BinData/Cluts";
 
 		// Create a new clut table of the appropriate size.
 		{
-			delete aTable;
+			delete[] aTable;
 			uint32 u4_clut_size = iNumEntries * iNumRampValues * iNumDepthValues * iSizeofPixel;
 			aTable = new char[u4_clut_size];
 		}

--- a/jp2_pc/Source/Lib/View/Clut.hpp
+++ b/jp2_pc/Source/Lib/View/Clut.hpp
@@ -354,8 +354,8 @@ class CClut: public CClu
 private:
 	static EClutState ecsClutState;	// The pixel output format of the clut.
 
-	void* aTable;			// The colour lookup table in screen format.
-	void* aTableD3DTrans;	// The colour lookup table in D3D transparent texture format.
+	char* aTable;			// The colour lookup table in screen format.
+	uint8* aTableD3DTrans;	// The colour lookup table in D3D transparent texture format.
 	int   iSizeofPixel;		// The number of bytes in the destination pixels.
 	int   iShiftRamp;		// The number of bits to shift the ramp value by to get an index
 							// into the table.
@@ -516,6 +516,9 @@ public:
 	//
 	//**********************************
 	{
+		delete[] aTable;
+		delete[] aTableD3DTrans;
+		delete[] ad3dtTable;
 		new(this) CClut(clu, ppalPalette, pxf_dest);
 	}
 


### PR DESCRIPTION
Some fixes for memory leaks observed when switching and loading levels. Especially the leaks in `CClut` could amount to a couple of megabytes per loading.