### PR TITLE
Remove mouse trail effect

### DIFF
--- a/jp2_pc/Source/Trespass/uiwnd.cpp
+++ b/jp2_pc/Source/Trespass/uiwnd.cpp
@@ -102,6 +102,8 @@ void CUIManager::Draw()
 
     rc = m_rcInvalid;
 
+    prasMainScreen->Clear(0);
+	
     DrawWindowChain(prasMainScreen.ptPtrRaw(), &rc);
 
     DrawMouse(prasMainScreen.ptPtrRaw(), &rc);


### PR DESCRIPTION
The bug with the mouse trail effect in the main menu screens, introduced in PR #87, is resolved by clearing the screen buffer before drawing the UI.