### PR TITLE
Resolve ValidateDiskSpace overflow bug

### DIFF
--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -27,7 +27,7 @@
 #include "gblinc/buildver.hpp"
 #include "Lib/W95/Direct3DCards.hpp"
 #include "Version.hpp"
-
+#include <filesystem>
 
 #if TARGET_PROCESSOR == PROCESSOR_PENTIUM
 	#pragma message("Target build processor : Intel Pentium")
@@ -344,55 +344,19 @@ void TrespassExceptionCleanup()
 
 bool ValidateDiskSpace(int iMB)
 {
-    bool                bRet;
-    char                szPath[_MAX_PATH];
-    char                szDrive[_MAX_PATH];
-    DWORD               dwSectorsPerCluster;
-    DWORD               dwBytesPerSector;
-    DWORD               dwFreeClusters;
-    DWORD               dwTotalClusters;
-    HANDLE              hFind;
-    WIN32_FIND_DATA     finddata;
-    DWORD               dwTotalSize;
-
+    char szPath[_MAX_PATH] = { '\0' };
     GetFileLoc(FA_INSTALLDIR, szPath, sizeof(szPath));
-    _splitpath(szPath, szDrive, NULL,NULL, NULL);
-    strcat(szDrive, "\\");
-    bRet = GetDiskFreeSpace(szDrive,
-                                  &dwSectorsPerCluster,
-                                  &dwBytesPerSector,
-                                  &dwFreeClusters,
-                                  &dwTotalClusters);
-    if (!bRet)
-    {
-        Trace(("ValidateDiskSpace() -- GetFreeDiskSpace error %i", 
-               GetLastError()));
-		return true;
-    }
 
-    dwTotalSize = 0;
-    hFind = FindFirstFile("*.swp", &finddata);
-    if (hFind != INVALID_HANDLE_VALUE)
-    {
-        do
-        {   
-            dwTotalSize += finddata.nFileSizeLow;
-        }
-        while (FindNextFile(hFind, &finddata));
+    const auto diskstat = std::filesystem::space(szPath);
 
-        FindClose(hFind);
-    }
+	//Existing swp files count as free space
+    std::uintmax_t swpFilesSize = 0;
+	for (const auto& entry : std::filesystem::directory_iterator("."))
+		if (entry.is_regular_file() && entry.path().extension() == ".swp")
+            swpFilesSize += entry.file_size();
 
-	Trace(("%s  %s\r\n%i %i %i %i\r\n%i", szDrive, szPath,
-		dwSectorsPerCluster, dwBytesPerSector, dwFreeClusters, dwTotalClusters, dwTotalSize));
-    // Check for enough free space for a save
-    if ((dwSectorsPerCluster * dwBytesPerSector * dwFreeClusters) + dwTotalSize < 
-        iMB * 1024 * 1024)
-    {
-        bRet = false;
-    }
-
-    return bRet;
+	const std::uintmax_t neededBytes = iMB * static_cast<std::uintmax_t>(1024 * 1024);
+    return diskstat.free + swpFilesSize > neededBytes;
 }
 
 

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -346,16 +346,16 @@ bool ValidateDiskSpace(int iMB)
 {
     char szPath[_MAX_PATH] = { '\0' };
     GetFileLoc(FA_INSTALLDIR, szPath, sizeof(szPath));
-
+    
     const auto diskstat = std::filesystem::space(szPath);
-
-	//Existing swp files count as free space
+    
+    //Existing swp files count as free space
     std::uintmax_t swpFilesSize = 0;
-	for (const auto& entry : std::filesystem::directory_iterator("."))
-		if (entry.is_regular_file() && entry.path().extension() == ".swp")
+    for (const auto& entry : std::filesystem::directory_iterator("."))
+        if (entry.is_regular_file() && entry.path().extension() == ".swp")
             swpFilesSize += entry.file_size();
-
-	const std::uintmax_t neededBytes = iMB * static_cast<std::uintmax_t>(1024 * 1024);
+    
+    const std::uintmax_t neededBytes = iMB * static_cast<std::uintmax_t>(1024 * 1024);
     return diskstat.free + swpFilesSize > neededBytes;
 }
 


### PR DESCRIPTION
The implementation of `ValidateDiskSpace` is prone to overflows of the 32bit `DWORD` variables. This causes occasional false positive user error messages about insufficient disk space. That is especially likely to happen with disks that have a couple of terabytes of capacity.
The function is rewritten using C++17 STL facilities.