### PR TITLE
CTPassGlobals array initialization

### DIFF
--- a/jp2_pc/Source/Trespass/tpassglobals.cpp
+++ b/jp2_pc/Source/Trespass/tpassglobals.cpp
@@ -115,9 +115,8 @@ BOOL GetNextAvailSaveName(LPSTR pszFileName, int icFileLen, int iBaseExt)
 
 
 CTPassGlobals::CTPassGlobals()
+	: m_apsamRandoms{ nullptr }
 {
-    int     i;
-
     m_prasBkgnd = NULL;
     m_prasMiniBkgnd = NULL;
 
@@ -126,11 +125,6 @@ CTPassGlobals::CTPassGlobals()
     m_psamButton = NULL;
 	bInGame = false;
 	bHardReset = false;
-
-    for (i = 0; i < 14; i++)
-    {
-        m_apsamRandoms[i] = NULL;
-    }
 }
 
 


### PR DESCRIPTION
The array  `m_apsamRandoms` was initialized like it has 15 elements, but it only has 13. The initialization of the array is restructured.