### PR TITLE
Jump bug workaround

### DIFF
--- a/jp2_pc/Source/Lib/Physics/InfoSkeleton.cpp
+++ b/jp2_pc/Source/Lib/Physics/InfoSkeleton.cpp
@@ -448,7 +448,7 @@ extern int	 iKontrol_Jump[NUM_PELVISES];
 			Pelvis_Jump[2] = 1;
 			Pelvis_Jump_Voluntary = true;
 		}
-		else
+		else if (!Pelvis_Jump_Voluntary) /* If-condition part of an incomplete workaround for the jump bug */
 		{
 			// Always stop jumping if no urgency.
 			Pelvis_Jump[0] = Pelvis_Jump[1] = Pelvis_Jump[2] = 0;

--- a/jp2_pc/Source/Lib/Physics/foot.cpp
+++ b/jp2_pc/Source/Lib/Physics/foot.cpp
@@ -1322,6 +1322,8 @@ extern bool	OKtoJUMP;
 					if (Pelvis_Jump_Voluntary)
 						NPhysImport::MakePlayerJumpNoise();
 					BioTag[pelvis][(RIGHT_FOOT+2)] = 0;
+
+					Pelvis_Jump_Voluntary = false; /* assignment part of an incomplete workaround for the jump bug */
 				}
 				else conPhysics << "JumpFailure: " << Xob[feetwet].Wz << " and slope: " << slohp << "\n";
 			}


### PR DESCRIPTION
A partial workaround for issue #13 is introduced. A jump request is not cancelled/overwritten until it has been processed.

The workaround is incomplete because a new problem is introduced: when a jump is requested while another jump is in progress, that new jump is performed immediately after touchdown from the old jump. Howevers, players using continuous jumping to move fast and outrun dinos will probably not notice a difference.