### PR TITLE
Physics freeze workaround

### DIFF
--- a/jp2_pc/Source/Lib/Physics/Pelvis.cpp
+++ b/jp2_pc/Source/Lib/Physics/Pelvis.cpp
@@ -1161,7 +1161,20 @@ int				count_dracula = 0;
 
 				while (1) 
 				{
-
+					if (!std::isfinite(L))
+					{
+						dout << "FINITY BAILOUT IN PELVIS FOR L: " << L << std::endl;
+						//This is an incomplete workaround
+						
+						//Set to valid, normalised vector
+						Pel[i][(index + 0)][0] = 0.25f;
+						Pel[i][(index + 1)][0] = 0.25f;
+						Pel[i][(index + 2)][0] = 0.25f;
+						Pel[i][(index + 3)][0] = 0.25f;
+						
+						break;
+					}
+					
 					if ( fabs(L) < lag_max ) break;
 					count_dracula++;
 

--- a/jp2_pc/Source/Lib/Physics/Xob_bc.cpp
+++ b/jp2_pc/Source/Lib/Physics/Xob_bc.cpp
@@ -11,6 +11,7 @@
 #include "Lib/Audio/SoundDefs.hpp"
 #include "Lib/Std/Set.hpp"
 #include "Lib/Sys/ConIO.hpp"
+#include "Lib/Sys/DebugConsole.hpp"
 
 #include <memory.h>
 #include <float.h>
@@ -3736,7 +3737,19 @@ const float		lag_mult = .1;
 const float		lag_max = .003;//.001;
 int count = 0;
 			while (1) {
-
+				if (!std::isfinite(L))
+				{
+					dout << "FINITY BAILOUT IN XOB_BC FOR L: " << L << std::endl;
+					//This is an incomplete workaround
+					
+					//Set to valid, normalised vector
+					State[3][0] = 0.25f;
+					State[4][0] = 0.25f;
+					State[5][0] = 0.25f;
+					State[6][0] = 0.25f;
+					
+					break;
+				}
 
 				if ( fabs(L) < lag_max ) break;
 


### PR DESCRIPTION
A partial workaround around for issue #84 is introduced.
In the vector normalisation loops, when the loop variant `L` becomes non-finite, (i.e. `NaN`), the loop is aborted.

To prevent a followup problem where the game badly misbehaves and softlocks after such a finity bailout, the vector of the normalisation is set to a valid value. The value chosen is arbitrary.

The workaround is incomplete because a new problem is introduced: when the inventory object is retrieved after a finity correction, it can misbehave a little: it can appear outside of the hand, be rotated wrong and in one instance it floated mid-air after dropping. However, this misbehavior usually disappears after dropping and repicking the item. 