### PR TITLE
Audiodaemon: avoid use after delete

### DIFF
--- a/jp2_pc/Source/Lib/Audio/AudioDaemon.cpp
+++ b/jp2_pc/Source/Lib/Audio/AudioDaemon.cpp
@@ -403,14 +403,14 @@ void CAudioDaemon::Process(const CMessageStep& msg_step)
 			// remove from the fade list just in case it is fading
 			CAudio::pcaAudio->StopFade(psamMusic);
 
-			delete psamMusic;
-
 			// If this was a 3D music stream (of any type) then it must have been attached to an
 			// instance.
 			if (psamMusic->u4CreateFlags & (AU_CREATE_PSEUDO_3D|AU_CREATE_SPATIAL_3D))
 			{
 				RemoveSoundAttachment(psamMusic);
 			}
+
+			delete psamMusic;
 
 			bMusic = false;
 			psamMusic = NULL;


### PR DESCRIPTION
In `CAudioDaemon::Process`, the object `psamMusic` is still used after being deleted. The deletion is deferred a little.
This spot only raises complaints when additional memory access validation (full page heap verification) is enabled.