### PR TITLE
TexturePackSurface: avoid use after delete

### DIFF
--- a/jp2_pc/Source/Lib/Loader/TexturePackSurface.cpp
+++ b/jp2_pc/Source/Lib/Loader/TexturePackSurface.cpp
@@ -1129,6 +1129,7 @@ void CPackedRaster::KillNode
 			if (b_delete)
 			{
 				MEMLOG_SUB_ADRSIZE(emlTextureManQuad,tqtPackQuadTree.anltFree[i_size].aptqn[u4]);
+				deletedNodes.insert(tqtPackQuadTree.anltFree[i_size].aptqn[u4]);
 				delete tqtPackQuadTree.anltFree[i_size].aptqn[u4];
 			}
 
@@ -1280,7 +1281,13 @@ bool CPackedRaster::bRemoveQuadNodeAndCompact
 			// the last node may point to the first node if it is a rectangle and the block
 			// for the first node may have been deleted and paged out when the last node
 			// references it.
-			if (ptqnDel)
+			if (deletedNodes.find(ptqnDel) != deletedNodes.end())
+			{
+				//Pointer is known to have been deleted, do not use
+				dout << "applied dead texture node link correction" << std::endl;
+				ptqnDel = nullptr;
+			}
+			else if (ptqnDel)
 			{
 				u1DelXPos = ptqnDel->u1XOrg;
 				u1DelYPos = ptqnDel->u1YOrg;

--- a/jp2_pc/Source/Lib/Loader/TexturePackSurface.hpp
+++ b/jp2_pc/Source/Lib/Loader/TexturePackSurface.hpp
@@ -63,6 +63,7 @@
 #define HEADER_TEXTUREPACKSURFACE_HPP
 
 #include "Lib/View/Raster.hpp"
+#include <unordered_set>
 
 #pragma pack(push,1)
 
@@ -264,6 +265,8 @@ protected:
 	uint32					u4SmallestAllocation;
 	uint8					u1DelXPos;
 	uint8					u1DelYPos;
+
+	std::unordered_set<STextureQuadNode*> deletedNodes;
 
 	//*****************************************************************************************
 	void InitQuadTree


### PR DESCRIPTION
`CPackedRaster` manages trees of `STextureQuadNode` objects. Those nodes are "linked" to each other via pointers. When a node is deleted, those link pointers are left dangling. When such a dangling pointer is dereferenced, this raises complaints when additional memory access validation (full page heap verification) is enabled.
As a quick workaround, the pointers of the deleted nodes are cached. The cache is checked to avoid dereferencing those dangling pointers.
A better solution, using either `std::weak_ptr` or automatic unlinking of nodes upon destruction, requires more research.