### PR TITLE
Repair ProcessorDetect

### DIFF
--- a/jp2_pc/CMakeLists.txt
+++ b/jp2_pc/CMakeLists.txt
@@ -101,7 +101,6 @@ if (DEACTIVATE_BROKEN_PROJECTS)
         FastBumpTest
         InitGUIApp
         PolyTest
-        ProcessorDetect
         PipelineTest
         QuantizerToolCLI
         TweakTrespass

--- a/jp2_pc/Source/Tools/Processor Detect/Detect.cpp
+++ b/jp2_pc/Source/Tools/Processor Detect/Detect.cpp
@@ -1084,8 +1084,8 @@ static uint32 u4CPUSpeed(int clocks)
           		
 			total = ( freq + freq2 + freq3 );
 				
-		} while (	(tries < 3 ) || (tries < 20) && ((abs(3 * freq -total) > 3*TOLERANCE ) ||
-			(abs(3 * freq2-total) > 3*TOLERANCE ) || (abs(3 * freq3-total) > 3*TOLERANCE )));
+		} while (	(tries < 3 ) || (tries < 20) && ((abs(3 * static_cast<int64>(freq) -total) > 3*TOLERANCE ) ||
+			(abs(3 * static_cast<int64>(freq2)-total) > 3*TOLERANCE ) || (abs(3 * static_cast<int64>(freq3)-total) > 3*TOLERANCE )));
 		
 		if ( total / 3  !=  ( total + 1 ) / 3 )
 		{

--- a/jp2_pc/cmake/ProcessorDetect/CMakeLists.txt
+++ b/jp2_pc/cmake/ProcessorDetect/CMakeLists.txt
@@ -17,4 +17,6 @@ add_common_options()
 
 add_library(${PROJECT_NAME} SHARED ${ProcessorDetect_Inc} ${ProcessorDetect_Src} )
 
+set_target_properties(${PROJECT_NAME} PROPERTIES OUTPUT_NAME "Processor")
+
 set_target_properties(${PROJECT_NAME} PROPERTIES FOLDER Lib/Other)


### PR DESCRIPTION
The subproject `ProcessorDetect` is repaired so that it compiles.
The problem is that the `abs` function is not defined for unsigned types. This is easily resolved with a typecast to a bigger signed type.
The output file name is changed `Processor.dll` to match the original release.