### PR TITLE
Fix DINOS/FPS cheat overlap

### DIFF
--- a/jp2_pc/Source/Trespass/gamewnd.cpp
+++ b/jp2_pc/Source/Trespass/gamewnd.cpp
@@ -248,6 +248,7 @@ bool ExecuteCheat(LPSTR pszCheat)
 				// Toggle the boring dino bit.
 				gaiSystem.bBoring = !gaiSystem.bBoring;
 			}
+            break;
 
         case CHEAT_FPS:
             g_bDisplayFPS = !g_bDisplayFPS;


### PR DESCRIPTION
The `DINOS` cheat also toggles the `FPS` cheat because of a missing `break` statement.