### PR TITLE
Tolerate missing backslashes in config paths

### DIFF
--- a/jp2_pc/Source/GUIApp/GUIAppDlg.cpp
+++ b/jp2_pc/Source/GUIApp/GUIAppDlg.cpp
@@ -926,9 +926,9 @@ LRESULT CGUIAppDlg::OnIdle(WPARAM wParam, LPARAM lParam)
 		// HACK: to get data drive location.
 		GetRegString(REG_KEY_DATA_DRIVE, szFile, sizeof(szFile), "");
 
-		// Add on data sub-directoy to path.
+		// Add on data sub-directory to path.
 		if (*szFile)
-			strcat(szFile, "data\\");
+			strcat(szFile, "\\data\\");
 
 		// Append file name.
 		strcat(szFile, strName.c_str());
@@ -1156,7 +1156,9 @@ int CGUIAppDlg::OnCreate
         strcpy(szInstalledDir, "C:\\program files\\DreamWorks Interactive\\Trespasser\\");
         SetRegString(REG_KEY_INSTALLED_DIR, szInstalledDir);
         CreateDirAlongPath(szInstalledDir);
-    }
+	}
+    else
+        strcat(szInstalledDir, "\\");
     
 
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
@@ -1226,7 +1226,7 @@ CRenderDB*  ps_renderDB = 0;
                                 if (pc_short_name &&
                                     GetRegString(REG_KEY_DATA_DRIVE, sz, sizeof(sz), "") > 0)
                                 {
-                                    strcat(sz, "data\\");
+                                    strcat(sz, "\\data\\");
                                     strcat(sz, pc_short_name);
 
                                     psz = sz;

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -108,7 +108,7 @@ void SetProperWorkingDir()
     char        szPath[_MAX_PATH];
 
 #if VER_TEST
-    GetRegString(REG_KEY_INSTALLED_DIR, szPath, sizeof(szPath), "");
+    GetFileLoc(FA_INSTALLDIR, szPath, sizeof(szPath));
 #else
     GetModulePath(g_hInst, szPath, sizeof(szPath));
 #endif

--- a/jp2_pc/Source/Trespass/mainwnd.cpp
+++ b/jp2_pc/Source/Trespass/mainwnd.cpp
@@ -61,8 +61,7 @@ BOOL CMainWnd::InitSurface()
 		SetupForSelfModifyingCode(g_hInst);
 	#endif
 
-    GetRegString("Data Drive", szSource, sizeof(szSource), "");
-    strcat(szSource, "data\\");
+    GetFileLoc(FA_DATADRIVE, szSource, sizeof(szSource));
 
     CAudioDaemon::SetDataPath(szSource);
 

--- a/jp2_pc/Source/Trespass/supportfn.cpp
+++ b/jp2_pc/Source/Trespass/supportfn.cpp
@@ -165,11 +165,12 @@ int GetFileLoc(FA_TYPE faFileLoc, char * psz, int icSize)
     {
         case FA_DATADRIVE:
             GetRegString(REG_KEY_DATA_DRIVE, psz, icSize, "");
-            strcat(psz, "data\\");
+    		strcat(psz, "\\data\\");
             break;
 
         case FA_INSTALLDIR:
             GetRegString(REG_KEY_INSTALLED_DIR, psz, icSize, "");
+            strcat(psz, "\\");
             break;
     }
 

--- a/jp2_pc/Source/Trespass/tpassglobals.cpp
+++ b/jp2_pc/Source/Trespass/tpassglobals.cpp
@@ -296,8 +296,7 @@ int CTPassGlobals::LoadLevel(LPCSTR pszName)
     char    szFile[_MAX_PATH];
 
     // BUGBUG:  Hack to get data drive location
-    GetRegString(REG_KEY_DATA_DRIVE, szFile, sizeof(szFile), "");
-    strcat(szFile, "data\\");
+    GetFileLoc(FA_DATADRIVE, szFile, sizeof(szFile));
     strcat(szFile, pszName);
 
     iRet = LoadScene(szFile, (LPSTR)pszName);

--- a/jp2_pc/Source/Trespass/tpassglobals.cpp
+++ b/jp2_pc/Source/Trespass/tpassglobals.cpp
@@ -295,7 +295,6 @@ int CTPassGlobals::LoadLevel(LPCSTR pszName)
     int     iRet;
     char    szFile[_MAX_PATH];
 
-    // BUGBUG:  Hack to get data drive location
     GetFileLoc(FA_DATADRIVE, szFile, sizeof(szFile));
     strcat(szFile, pszName);
 

--- a/jp2_pc/Source/Trespass/uidlgs.cpp
+++ b/jp2_pc/Source/Trespass/uidlgs.cpp
@@ -789,8 +789,7 @@ BOOL CDirectLoadWnd::OnCreate()
         return FALSE;
     }
 
-    GetRegString("Data Drive", szFile, sizeof(szFile), "");
-    strcat(szFile, "data\\");
+    GetFileLoc(FA_DATADRIVE, szFile, sizeof(szFile));
     strcat(szFile, "*.scn");
 
     puilist = (CUIListbox*)GetUICtrl(1002);
@@ -919,8 +918,8 @@ BOOL CNewGameWnd::OnCreate()
         return FALSE;
     }
 
-    GetRegString("Data Drive", szFile, sizeof(szFile), "");
-    strcat(szFile, "data\\menu\\ngi.ddf");
+    GetFileLoc(FA_DATADRIVE, szFile, sizeof(szFile));
+    strcat(szFile, "menu\\ngi.ddf");
 
     puilist = (CUIListbox*)GetUICtrl(1002);
 

--- a/jp2_pc/Source/Trespass/uiwnd.cpp
+++ b/jp2_pc/Source/Trespass/uiwnd.cpp
@@ -835,11 +835,7 @@ BOOL CUIWnd::LoadWindowInfo()
     GetWndFile(szWndName, sizeof(szWndName));
 
     //The Hack's hack to try and find the file first in the installed dir
-    GetRegString(REG_KEY_INSTALLED_DIR, szFile, sizeof(szFile), "");
-    if (szFile[strlen(szFile) - 1] != '\\')
-    {
-        strcat(szFile, "\\");
-    }
+    GetFileLoc(FA_INSTALLDIR, szFile, sizeof(szFile));
 
     strcat(szFile, "menu\\");
     strcat(szFile, szWndName);
@@ -857,14 +853,9 @@ BOOL CUIWnd::LoadWindowInfo()
                     "Unable to open file %s from Install Dir. Trying Data Dir.",
                     szFile));
 
-        // BUGBUG:  Hack to get data drive location
-        GetRegString(REG_KEY_DATA_DRIVE, szFile, sizeof(szFile), "");
-        if (szFile[strlen(szFile) - 1] != '\\')
-        {
-            strcat(szFile, "\\");
-        }
+        GetFileLoc(FA_DATADRIVE, szFile, sizeof(szFile));
 
-        strcat(szFile, "data\\menu\\");
+        strcat(szFile, "menu\\");
         strcat(szFile, szWndName);
 
         hFile = CreateFile(szFile,

--- a/jp2_pc/Source/Trespass/uiwnd.cpp
+++ b/jp2_pc/Source/Trespass/uiwnd.cpp
@@ -834,7 +834,6 @@ BOOL CUIWnd::LoadWindowInfo()
 
     GetWndFile(szWndName, sizeof(szWndName));
 
-    //The Hack's hack to try and find the file first in the installed dir
     GetFileLoc(FA_INSTALLDIR, szFile, sizeof(szFile));
 
     strcat(szFile, "menu\\");


### PR DESCRIPTION
With these changes it is ensured that the paths for the installation directory and the data directory can be specified in the configuration without a trailing backslash.
This is largely done by adjusting the `GetFileLoc` wrapper function and by using that function more often.
Possible double backslashes are not a problem.