### PR TITLE
trespass/main.cpp: use correct format specifier for pointer

### DIFF
--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -700,7 +700,7 @@ void DumpException(LPEXCEPTION_POINTERS pep_info)
 		fprintf(pfile, "----------------\n");
 		fprintf(pfile, "Code   : 0x%08X\n", pep_info->ExceptionRecord->ExceptionCode);
 		fprintf(pfile, "Flags  : 0x%08X\n", pep_info->ExceptionRecord->ExceptionFlags);
-		fprintf(pfile, "Address: 0x%08X\n", pep_info->ExceptionRecord->ExceptionAddress);
+		fprintf(pfile, "Address: 0x%08p\n", pep_info->ExceptionRecord->ExceptionAddress);
 		for (uint u = 0; u < pep_info->ExceptionRecord->NumberParameters && u < 16; ++u)
 			fprintf(pfile, "Info %2ld: 0x%08X\n", u, pep_info->ExceptionRecord->ExceptionInformation[u]);
 	}


### PR DESCRIPTION
A string format specifier is changed to fit the pointer type it is used with.