### PR TITLE
RegToIni: Missing key "MRU Num"

### DIFF
--- a/jp2_pc/Source/Lib/Sys/RegToIni.cpp
+++ b/jp2_pc/Source/Lib/Sys/RegToIni.cpp
@@ -75,7 +75,8 @@ bool RegToIniConverter::convert()
 		strHARDWARE_WATER			,
 		"SwapSpaceMb"				,
 		"NoCopyright"				,
-		"ShowProgressBar"
+		"ShowProgressBar"			,
+		"MRU Num"
 	};
 
 	if (regkey.Open(HKEY_LOCAL_MACHINE, "Software\\DreamWorks Interactive\\Trespasser", KEY_READ) != ERROR_SUCCESS)


### PR DESCRIPTION
Another registry key was forgotten for the Reg-To-Ini-conversion.