### PR TITLE
RasterVid.cpp: only skip RestoreDisplayMode in forced window mode

### DIFF
--- a/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
+++ b/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
@@ -1330,17 +1330,19 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 		// Release Direct3D before doing anything.
 		d3dDriver.Uninitialize();
 
-		if (!forceWindowMode && bFullScreen)
+		if (bFullScreen)
 		{
 			// Return to Windows screen if necessary.
 			if (DirectDraw::pdd4)
 			{
-				DirectDraw::err = DirectDraw::pdd4->RestoreDisplayMode();
+				if (!forceWindowMode)
+					DirectDraw::err = DirectDraw::pdd4->RestoreDisplayMode();
 				DirectDraw::err = DirectDraw::pdd4->SetCooperativeLevel(0, DDSCL_NORMAL);
 			}
 			else
 			{
-				DirectDraw::err = DirectDraw::pdd->RestoreDisplayMode();
+				if (!forceWindowMode)
+					DirectDraw::err = DirectDraw::pdd->RestoreDisplayMode();
 				DirectDraw::err = DirectDraw::pdd->SetCooperativeLevel(0, DDSCL_NORMAL);
 			}
 		}


### PR DESCRIPTION
When closing the app in a debug build while running in 16bit color depth mode, the call to `DestroyWindow()` in `trespass/main.cpp` line 597 can cause an exception. It looks like a use-after-free problem. The stack trace says that it happens during the release of DirectDraw surfaces in the 16bit color depth compatibility layer: 
```
apphelp.dll!DirectDrawSurface<struct IDirectDrawSurface *,struct _DDSURFACEDESC,struct _DDSCAPS,struct IDirect3DDevice2 *>::Release32BitTempOffScreen(void)
apphelp.dll!DirectDrawSurface<struct IDirectDrawSurface *,struct _DDSURFACEDESC,struct _DDSCAPS,struct IDirect3DDevice2 *>::ReleaseAllSurfaceData(void)
apphelp.dll!DirectDrawSurface<struct IDirectDrawSurface *,struct _DDSURFACEDESC,struct _DDSCAPS,struct IDirect3DDevice2 *>::ReleaseDirectDrawSurface(void)
apphelp.dll!DWM8And16Bit_DeleteDDrawExisting(class DirectDrawSurface<struct IDirectDrawSurface *,struct _DDSURFACEDESC,struct _DDSCAPS,struct IDirect3DDevice2 *> *)
apphelp.dll!DWM8And16Bit_DeleteDDrawExistingPrimary(void)
apphelp.dll!DWM8AND16BitHook_DestroyWindow()
OpenTrespasser.exe!DoWinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 597
OpenTrespasser.exe!WinMain(HINSTANCE__ * hInstance, HINSTANCE__ * hPrevInstance, char * lpCmdLine, int nCmdShow) Line 741
...
```
This problem is mitigated by ensuring that the cooperative level is restored when `CRasterWin` is destructed.