### PR TITLE
Check for write access to working directory

### DIFF
--- a/jp2_pc/Source/Lib/Sys/Permissions.cpp
+++ b/jp2_pc/Source/Lib/Sys/Permissions.cpp
@@ -1,0 +1,38 @@
+#include "Permissions.hpp"
+#include <atlbase.h>
+
+//Based on https://github.com/microsoftarchive/msdn-code-gallery-microsoft/tree/master/OneCodeTeam/UAC%20self-elevation%20(CppUACSelfElevation)/%5BC%2B%2B%5D-UAC%20self-elevation%20(CppUACSelfElevation)/C%2B%2B
+
+bool IsProcessElevated()
+{
+	ATL::CHandle hToken(INVALID_HANDLE_VALUE);
+
+	if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken.m_h))
+		return false;
+	if (hToken == nullptr || hToken == INVALID_HANDLE_VALUE)
+		return false;
+
+	TOKEN_ELEVATION elevation = { 0 };
+	DWORD dwSize = 0;
+	if (!GetTokenInformation(hToken, TokenElevation, &elevation,
+		sizeof(elevation), &dwSize))
+		return false;
+
+	return elevation.TokenIsElevated;
+}
+
+bool StartAsElevated(HWND wnd, HINSTANCE inst)
+{
+	TCHAR name[_MAX_PATH] = { '\0' };
+	if (!GetModuleFileName(inst, name, sizeof(name)))
+		return false;
+
+	SHELLEXECUTEINFO sei = { 0 };
+	sei.cbSize = sizeof(SHELLEXECUTEINFO);
+	sei.lpVerb = _T("runas");
+	sei.lpFile = name;
+	sei.hwnd = wnd;
+	sei.nShow = SW_NORMAL;
+
+	return ShellExecuteEx(&sei);
+}

--- a/jp2_pc/Source/Lib/Sys/Permissions.hpp
+++ b/jp2_pc/Source/Lib/Sys/Permissions.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "Windows.h"
+
+bool IsProcessElevated();
+bool StartAsElevated(HWND hwnd, HINSTANCE hinst);

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -22,6 +22,8 @@
 #include "main.h"
 #include "..\Lib\Sys\reg.h"
 #include "..\lib\sys\reginit.hpp"
+#include "Lib/Sys/Permissions.hpp"
+#include "Lib/Sys/FileEx.hpp"
 #include "supportfn.hpp"
 #include "tpassglobals.h"
 #include "gblinc/buildver.hpp"
@@ -306,7 +308,6 @@ bool ValidateDiskSpace(int iMB)
 
 
 
-
 //+--------------------------------------------------------------------------
 //
 //  Function:   DoWinMain
@@ -348,6 +349,13 @@ int DoWinMain(HINSTANCE hInstance,
 
     SetProperWorkingDir();
 
+    if (!bCanCreateFile("permissiontestfile.txt") && !IsProcessElevated()) {
+        if (!StartAsElevated(g_hwnd, hInstance));
+			dout << "Start with elevated permissions failed or declined by user" << std::endl;
+    	//New process started (or not), exit current one
+        goto Cleanup;
+    }
+	
     InitCommonControls();
 
     g_uiRegMsg = RegisterWindowMessage("DWI Trespasser FINDER");

--- a/jp2_pc/cmake/System/CMakeLists.txt
+++ b/jp2_pc/cmake/System/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND System_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/P5/Msr.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/IniFile.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/RegToIni.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Permissions.hpp
 )
 
 list(APPEND System_Src
@@ -66,6 +67,7 @@ list(APPEND System_Src
     ${CMAKE_SOURCE_DIR}/Source/Shell/WinRenderTools.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/IniFile.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/RegToIni.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Permissions.cpp
 )
 
 list(APPEND System_Rsc


### PR DESCRIPTION
When the installation directory is in `C:\Program Files (x86)\...`, then the game needs elevated permissions to write files there.
Early during startup, after the working directory is determined, that directory is checked for write permissions. If the check fails and the process is not elevated already, it is restarted with elevated permissions. 
Requesting these elevated permissions usually triggers a permission request dialog for the user, the famous UAC dialog.