### PR TITLE
Drop DirectDraw2 layer

### DIFF
--- a/jp2_pc/Source/Lib/View/RasterD3D.cpp
+++ b/jp2_pc/Source/Lib/View/RasterD3D.cpp
@@ -673,7 +673,7 @@ public:
 		// Set the correct dimensions.
 		d3dDriver.SetTextureMinMax(iWidth, iHeight, false);
 
-		Assert(DirectDraw::pdd);
+		Assert(DirectDraw::pdd4);
 
 		iPixelBits       = 16;
 		iLinePixels      = iWidth;

--- a/jp2_pc/Source/Lib/View/RasterVid.hpp
+++ b/jp2_pc/Source/Lib/View/RasterVid.hpp
@@ -274,7 +274,6 @@ class CRasterVid: public CRaster
 //**************************************
 {
 public:
-	CCom<IDirectDrawSurface>	pddsDraw;	// The DD object that manages the surface.
 	CCom<IDirectDrawSurface4>	pddsDraw4;	// The DD object that manages the surface.
 	uint32						u4DDSFlags;	// DD Surface flags.
 	bool						bVideoMem;	// Surface is in videomemory.
@@ -450,8 +449,6 @@ protected:
 	//
 	// Additional DirectDraw structures needed for implementation.
 	//
-	CCom<IDirectDrawSurface>	pddsPrimary;	// The front surface, if double-buffered.
-												// If not, it's equal to pddsDraw.
 	CCom<IDirectDrawSurface4>	pddsPrimary4;	// The front surface, if double-buffered.
 	CCom<IDirectDrawClipper>	pddclip;		// Clipping object if windowed.
 
@@ -588,9 +585,9 @@ public:
 
 	//******************************************************************************************
 	//
-    IDirectDrawSurface * GetPrimarySurface()
+    IDirectDrawSurface4 * GetPrimarySurface()
     {
-        return pddsPrimary;
+        return pddsPrimary4;
     }
 	//
 	// Returns a pointer to the primary surface.  This is necessary for Videos.

--- a/jp2_pc/Source/Lib/View/W95/Video.cpp
+++ b/jp2_pc/Source/Lib/View/W95/Video.cpp
@@ -123,7 +123,7 @@ namespace Video
 	//
 	static HRESULT CALLBACK EnumDisplayModesCallback
 	(
-		DDSURFACEDESC* pddsd,			// Surface descriptor for a screen mode.
+		DDSURFACEDESC2* pddsd,			// Surface descriptor for a screen mode.
 		void*							// Ignored.
 	)
 	// 
@@ -197,12 +197,12 @@ namespace Video
 		EVideoCard evc;
 
 		// Get the video card type.
-		AlwaysAssert(DirectDraw::pdd);
+		AlwaysAssert(DirectDraw::pdd4);
 		if (DirectDraw::pdd4)
 			evc = evcGetCard(DirectDraw::pdd4);
 		else
-			evc = evcGetCard(DirectDraw::pdd);
-
+			return;
+		
 		// Suppress resolutions based on the video card type.
 		bSuppress512x384 = false;
 		switch (evc)
@@ -213,14 +213,14 @@ namespace Video
 		}
 
 		// Find out the total video memory for this hardware.
-		DirectDraw::err = DirectDraw::pdd->GetCaps(&ddcaps_hw, &ddcaps_sw);
+		DirectDraw::err = DirectDraw::pdd4->GetCaps(&ddcaps_hw, &ddcaps_sw);
 
 		// Bug: the following is always 0.
 		iTotalVideoMemory = ddcaps_hw.dwVidMemTotal;
 
 		// Use DirectDraw and our callback functions to list the available screen modes.
 		iModes = 0;
-		DirectDraw::err = DirectDraw::pdd->EnumDisplayModes(DDEDM_REFRESHRATES, 0, 0, EnumDisplayModesCallback);
+		DirectDraw::err = DirectDraw::pdd4->EnumDisplayModes(DDEDM_REFRESHRATES, 0, 0, EnumDisplayModesCallback);
 
 		qsort(ascrmdList, iModes, sizeof(*ascrmdList), CompareModes);
 	}

--- a/jp2_pc/Source/Lib/W95/DD.hpp
+++ b/jp2_pc/Source/Lib/W95/DD.hpp
@@ -153,13 +153,12 @@ public:
 namespace DirectDraw
 //
 // Encapsulation of some IDirectDraw items.
-// Contains the IDirectDraw2* pointer, and an error variable used to handle errors.
+// Contains the IDirectDraw4* pointer, and an error variable used to handle errors.
 //
 // These items are automatically initialised by CInitDD below.
 //
 //**************************************
 {
-	extern CCom<IDirectDraw2>	pdd;		// The pointer through which all functions are accessed.
 	extern CCom<IDirectDraw4>	pdd4;		// The pointer through which all functions are accessed.
 
 	//**********************************************************************************************

--- a/jp2_pc/Source/Lib/W95/Direct3D.cpp
+++ b/jp2_pc/Source/Lib/W95/Direct3D.cpp
@@ -864,7 +864,7 @@ public:
 	bool CDirect3D::bD3DCapable()
 	{
 		bool b_vid_raster = true;
-		if (prasMainScreen && prasMainScreen->pddsDraw)
+		if (prasMainScreen && prasMainScreen->pddsDraw4)
 		{
 			CDDSize<DDSURFACEDESC2> sd;
 

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -557,9 +557,9 @@ DoRestartWithRenderDlg:
 
 Cleanup:
 
-    if (DirectDraw::pdd)
+    if (DirectDraw::pdd4)
     {
-    	DirectDraw::err = DirectDraw::pdd->SetCooperativeLevel(g_hwnd, DDSCL_NORMAL);
+    	DirectDraw::err = DirectDraw::pdd4->SetCooperativeLevel(g_hwnd, DDSCL_NORMAL);
     }
 
 	// Release everything really well.

--- a/jp2_pc/Source/Trespass/supportfn.cpp
+++ b/jp2_pc/Source/Trespass/supportfn.cpp
@@ -1120,7 +1120,7 @@ void ScreenCapture()
     int                     i;
     int                     j;
     char                    szFile[_MAX_PATH];
-    IDirectDrawSurface *    pSurface;
+    IDirectDrawSurface4 *   pSurface;
     HRESULT                 hr;
 
     pras24 = new CRasterDC(g_hwnd, 
@@ -1188,7 +1188,7 @@ void MiddleMessage(UINT uiIDS)
 {
     char                    sz[50];
     HDC                     hdcSrc;
-    IDirectDrawSurface *    pSurface;
+    IDirectDrawSurface4 *   pSurface;
     HRESULT                 hr;
     RECT                    rc;
     COLORREF                cr;

--- a/jp2_pc/Source/Trespass/tpassglobals.cpp
+++ b/jp2_pc/Source/Trespass/tpassglobals.cpp
@@ -136,7 +136,7 @@ CTPassGlobals::~CTPassGlobals()
 
 void CTPassGlobals::SetupBackground()
 {
-    IDirectDrawSurface *    pSurface;
+    IDirectDrawSurface4 *   pSurface;
     HRESULT                 hr;
     HDC                     hdc;
 
@@ -176,12 +176,12 @@ void CTPassGlobals::CaptureBackground(bool bBackbuffer /* = false */)
     HDC     hdcDst;
     HDC     hdcMini;
 
-    IDirectDrawSurface *    pSurface;
+    IDirectDrawSurface4 *   pSurface;
     HRESULT                 hr;
 
     if (bBackbuffer)
     {
-        pSurface = prasMainScreen->pddsDraw;
+        pSurface = prasMainScreen->pddsDraw4;
     }
     else
     {

--- a/jp2_pc/Source/Trespass/uidlgs.cpp
+++ b/jp2_pc/Source/Trespass/uidlgs.cpp
@@ -495,7 +495,7 @@ void CLoaderWnd::OnTimer(UINT uiID)
 
 void CLoaderWnd::InnerWindowLoop(bool bPaint)
 {
-    IDirectDrawSurface *    pSurface;
+    IDirectDrawSurface4 *   pSurface;
     HRESULT                 hr;
     CUIWnd *                puiwnd;
     DDBLTFX                 ddfx;
@@ -522,7 +522,7 @@ void CLoaderWnd::InnerWindowLoop(bool bPaint)
         // Now draw everthing from the back buffer to the front buffer
         pSurface = prasMainScreen->GetPrimarySurface();
         hr = pSurface->Blt(&m_pUIMgr->m_rcInvalid,
-                           prasMainScreen->pddsDraw,
+                           prasMainScreen->pddsDraw4,
                            &m_pUIMgr->m_rcInvalid,
                            DDBLT_WAIT | DDBLT_ROP,
                            &ddfx);

--- a/jp2_pc/Source/Trespass/video.cpp
+++ b/jp2_pc/Source/Trespass/video.cpp
@@ -53,7 +53,7 @@ CVideoWnd::~CVideoWnd()
 
 void CVideoWnd::NextDirect()
 {
-    IDirectDrawSurface *    pSurface;
+    IDirectDrawSurface4 *   pSurface;
     HDC                     hdc;
     HRESULT                 hr;
 
@@ -102,8 +102,8 @@ void CVideoWnd::NextNonDirect()
     LPBYTE      pbSrc;
     LPBYTE      pbDst;
     int         iSurface;
-    IDirectDrawSurface *    pSurface;
-    DDSURFACEDESC           dds;
+    IDirectDrawSurface4 *   pSurface;
+    DDSURFACEDESC2          dds;
     HRESULT                 hr;
 
 
@@ -176,7 +176,7 @@ void CVideoWnd::NextNonDirect()
     }
 
     m_pBuff->Unlock();
-    pSurface->Unlock(dds.lpSurface);
+    pSurface->Unlock(nullptr);
 }
 
 
@@ -285,8 +285,8 @@ BOOL CVideoWnd::Play(LPCSTR pszFile)
     //
 
     {
-        IDirectDrawSurface *    pSurface;
-        DDSURFACEDESC           dds;
+        IDirectDrawSurface4 *   pSurface;
+        DDSURFACEDESC2          dds;
         HRESULT                 hr;
 
         pSurface = prasMainScreen->GetPrimarySurface();
@@ -313,7 +313,7 @@ BOOL CVideoWnd::Play(LPCSTR pszFile)
             m_fDirect = FALSE;
         }
 
-        pSurface->Unlock(dds.lpSurface);
+        pSurface->Unlock(nullptr);
     }
 
     POINT screenSize = GetCurrentClientSize();


### PR DESCRIPTION
The code uses both DirectDraw 2 and DirectDraw 4 at the same time. (DirectDraw 4 is needed for Direct3D 3.) To simplify the code, the DirectDraw 2 layer is dropped and everything is switched over to DirectDraw 4.