### PR TITLE
Configurable window mode

### DIFF
--- a/jp2_pc/Source/Lib/View/DisplayMode.cpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.cpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "DisplayMode.hpp"
+#include "Lib/Sys/RegInit.hpp"
+#include "Lib/Sys/reg.h"
+
+WindowMode GetWindowModeConfigured()
+{
+	int selection = GetRegValue("WindowMode", 0);
+	if (selection > static_cast<int>(WindowMode::EXCLUSIVE))
+		selection = 0;
+	return static_cast<WindowMode>(selection);
+}
+
+WindowMode GetWindowModeActual()
+{
+	if (GetRegValue(strFLAG_D3D, DEFAULT_D3D))
+		return WindowMode::EXCLUSIVE;
+	else
+		return GetWindowModeConfigured();
+}

--- a/jp2_pc/Source/Lib/View/DisplayMode.cpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.cpp
@@ -7,7 +7,7 @@
 WindowMode GetWindowModeConfigured()
 {
 	int selection = GetRegValue("WindowMode", 0);
-	if (selection > static_cast<int>(WindowMode::EXCLUSIVE))
+	if (selection < 0 || selection > static_cast<int>(WindowMode::EXCLUSIVE))
 		selection = 0;
 	return static_cast<WindowMode>(selection);
 }

--- a/jp2_pc/Source/Lib/View/DisplayMode.hpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+enum class WindowMode {
+	UNDEFINED = 0,
+	FRAMED = 1,
+	BORDERLESS = 2,
+	EXCLUSIVE = 3
+};
+
+WindowMode GetWindowModeConfigured();
+
+WindowMode GetWindowModeActual();

--- a/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
+++ b/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
@@ -75,6 +75,7 @@
 #include "Lib/Std/PrivSelf.hpp"
 #include "Lib/Renderer/ScreenRenderAuxD3D.hpp"
 #include "Lib/W95/Direct3DCards.hpp"
+#include "Lib/View/DisplayMode.hpp"
 
 //
 // D3D inclusion is needed in order to set certain flags on structures.
@@ -100,8 +101,6 @@
 #define u4BORDER_COLOUR		0x00000000
 
 extern  bool bIsTrespasser;
-
-constexpr bool forceWindowMode = true; //Fullscreen is currently broken TODO repair
 
 //**********************************************************************************************
 //
@@ -321,7 +320,7 @@ private:
 		iWidthFront  = i_width;
 		iHeightFront = i_height;
 
-		if (i_bits && !forceWindowMode)
+		if (i_bits && GetWindowModeActual() == WindowMode::EXCLUSIVE)
 		{		
 			// Go fullscreen.  We need to call 2 DD functions to do this.
 			DirectDraw::err = DirectDraw::pdd4->SetCooperativeLevel(hwnd, 
@@ -1301,7 +1300,7 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 			// Return to Windows screen if necessary.
 			if (DirectDraw::pdd4)
 			{
-				if (!forceWindowMode)
+				if (GetWindowModeActual() == WindowMode::EXCLUSIVE)
 					DirectDraw::err = DirectDraw::pdd4->RestoreDisplayMode();
 				DirectDraw::err = DirectDraw::pdd4->SetCooperativeLevel(0, DDSCL_NORMAL);
 			}
@@ -1728,7 +1727,7 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 		CDDSize<DDSURFACEDESC2> sd;
 		HRESULT hres;
 
-		DWORD dw_flags = forceWindowMode ? DDSCL_NORMAL : DDSCL_FULLSCREEN | DDSCL_EXCLUSIVE;
+		DWORD dw_flags = GetWindowModeActual() != WindowMode::EXCLUSIVE ? DDSCL_NORMAL : DDSCL_FULLSCREEN | DDSCL_EXCLUSIVE;
 		DDDEVICEIDENTIFIER dddevid;
 		bool b_identifier_found = true;
 

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -26,6 +26,7 @@
 #include "Lib/Sys/Permissions.hpp"
 #include "Lib/Sys/FileEx.hpp"
 #include "supportfn.hpp"
+#include "Lib/View/DisplayMode.hpp"
 #include "tpassglobals.h"
 #include "gblinc/buildver.hpp"
 #include "Lib/W95/Direct3DCards.hpp"
@@ -897,10 +898,14 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
     int windowHeight = 480;
     bGetDimensions(windowWidth, windowHeight);
 
+    DWORD style = WS_VISIBLE | WS_POPUP | WS_SYSMENU;
+    if (GetWindowModeActual() == WindowMode::FRAMED)
+        style |= WS_OVERLAPPEDWINDOW;
+	
     if (!CreateWindowEx(0,
                     g_szAppName,
                     sz,
-                    WS_VISIBLE | WS_POPUP | WS_SYSMENU,
+                    style,
                     0,
                     0,
                     windowWidth,

--- a/jp2_pc/Source/Trespass/supportfn.cpp
+++ b/jp2_pc/Source/Trespass/supportfn.cpp
@@ -936,14 +936,13 @@ CCamera* pcamGetCamera()
 
 void SetupGameScreen()
 {
-    POINT clientSize = GetCurrentClientSize();
-	
-    int             iWidth = clientSize.x;
-    int             iHeight = clientSize.y;
+    int             iWidth;
+    int             iHeight;
     BOOL            bSystemMem;
     RECT            rc;
     int             iGore;
 
+    bGetDimensions(iWidth, iHeight);
 	
     bSystemMem = bGetSystemMem();
 

--- a/jp2_pc/cmake/View/CMakeLists.txt
+++ b/jp2_pc/cmake/View/CMakeLists.txt
@@ -28,6 +28,7 @@ list(APPEND View_Inc
     ${CMAKE_SOURCE_DIR}/Source/Lib/View/ColourT.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/View/Video.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/W95//Direct3DCards.hpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/View/DisplayMode.hpp
 )
 
 list(APPEND View_Src
@@ -56,6 +57,7 @@ list(APPEND View_Src
     ${CMAKE_SOURCE_DIR}/Source/Lib/View/W95/RasterVid.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/View/W95/Video.cpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/View/Viewport.cpp
+    ${CMAKE_SOURCE_DIR}/Source/Lib/View/DisplayMode.cpp
 )
 
 include_directories(


### PR DESCRIPTION
An option to set the window mode via the INI file is introduced. Three modes are supported:
- bordered window
- borderless window
- exclusive fullscreen

The D3D renderer currently only works in exclusive full screen mode, so that is enforced when the D3D renderer is enabled.