### PR TITLE
Modernize GlobalMemoryStatus

### DIFF
--- a/jp2_pc/Source/Lib/Std/Mem.cpp
+++ b/jp2_pc/Source/Lib/Std/Mem.cpp
@@ -56,60 +56,52 @@ uint32 gu4SystemPageSize = 4096;
 	//******************************************************************************************
 	// Return the amount of physical memory in the machine
 	//
-	uint32 u4TotalPhysicalMemory()
+	uint64 u4TotalPhysicalMemory()
 	{
-		MEMORYSTATUS	ms;
-		ms.dwLength = sizeof(MEMORYSTATUS);
-		GlobalMemoryStatus(&ms);
+		MEMORYSTATUSEX	ms = {0};
+		ms.dwLength = sizeof(MEMORYSTATUSEX);
+		GlobalMemoryStatusEx(&ms);
 
-		MEMLOG_SET_COUNTER(emlTotalPhysical,ms.dwTotalPhys);
-
-		return ms.dwTotalPhys;
+		return ms.ullTotalPhys;
 	}
 
 
 	//******************************************************************************************
 	// Return the amount free of physical memory in the machine
 	//
-	uint32 u4FreePhysicalMemory()
+	uint64 u4FreePhysicalMemory()
 	{
-		MEMORYSTATUS	ms;
-		ms.dwLength = sizeof(MEMORYSTATUS);
-		GlobalMemoryStatus(&ms);
+		MEMORYSTATUSEX	ms = {0};
+		ms.dwLength = sizeof(MEMORYSTATUSEX);
+		GlobalMemoryStatusEx(&ms);
 
-		MEMLOG_SET_COUNTER(emlFreePhysical,ms.dwAvailPhys);
-
-		return ms.dwAvailPhys;
+		return ms.ullAvailPhys;
 	}
 
 
 	//******************************************************************************************
 	// Return the amount space of memory in the page file
 	//
-	uint32 u4FreePagefileMemory()
+	uint64 u4FreePagefileMemory()
 	{
-		MEMORYSTATUS	ms;
-		ms.dwLength = sizeof(MEMORYSTATUS);
-		GlobalMemoryStatus(&ms);
+		MEMORYSTATUSEX	ms = {0};
+		ms.dwLength = sizeof(MEMORYSTATUSEX);
+		GlobalMemoryStatusEx(&ms);
 
-		MEMLOG_SET_COUNTER(emlFreePage,ms.dwAvailPageFile);
-
-		return ms.dwAvailPageFile;
+		return ms.ullAvailPageFile;
 	}
 
 
 	//******************************************************************************************
 	// Return the amount of free (un-commited and un-reserved) virtual address space
 	//
-	uint32 u4FreeVirtualMemory()
+	uint64 u4FreeVirtualMemory()
 	{
-		MEMORYSTATUS	ms;
-		ms.dwLength = sizeof(MEMORYSTATUS);
-		GlobalMemoryStatus(&ms);
+		MEMORYSTATUSEX	ms = {0};
+		ms.dwLength = sizeof(MEMORYSTATUSEX);
+		GlobalMemoryStatusEx(&ms);
 
-		MEMLOG_SET_COUNTER(emlFreeVirtual,ms.dwAvailVirtual);
-
-		return ms.dwAvailVirtual;
+		return ms.ullAvailVirtual;
 	}
 
 

--- a/jp2_pc/Source/Lib/Std/MemLimits.hpp
+++ b/jp2_pc/Source/Lib/Std/MemLimits.hpp
@@ -66,7 +66,7 @@ inline uint32 u4SystemPageSize
 
 //**********************************************************************************************
 //
-uint32 u4TotalPhysicalMemory();
+uint64 u4TotalPhysicalMemory();
 //
 // Returns the total amount of physical memory (RAM) in the machine
 //
@@ -76,7 +76,7 @@ uint32 u4TotalPhysicalMemory();
 
 //**********************************************************************************************
 //
-uint32 u4FreePhysicalMemory();
+uint64 u4FreePhysicalMemory();
 //
 // Returns the total amount of free (usable) physical memory (RAM) in the machine
 //
@@ -86,7 +86,7 @@ uint32 u4FreePhysicalMemory();
 
 //**********************************************************************************************
 //
-uint32 u4FreePagefileMemory();
+uint64 u4FreePagefileMemory();
 //
 // Returns the amount of free space in the system page file
 //
@@ -96,7 +96,7 @@ uint32 u4FreePagefileMemory();
 
 //**********************************************************************************************
 //
-uint32 u4FreeVirtualMemory();
+uint64 u4FreeVirtualMemory();
 //
 // Returns the amount of free space in the apps virtual address space (2GB to start with)
 //

--- a/jp2_pc/Source/Test/BumpBuild/IOStuff.cpp
+++ b/jp2_pc/Source/Test/BumpBuild/IOStuff.cpp
@@ -27,14 +27,15 @@ BOOL  DoFileOutput;
 
 void DisplayMemory()
 {
-	MEMORYSTATUS MemStatus;
+	MEMORYSTATUSEX MemStatus = {0};
+	MemStatus.dwLength = sizeof(MEMORYSTATUSEX);
 
-	GlobalMemoryStatus(&MemStatus);
+	GlobalMemoryStatusEx(&MemStatus);
 	
 	print("");
-    print("Available Physical Memory (kb)", MemStatus.dwAvailPhys >> 10);     // DWORD free physical memory bytes 
-    print("Available Page File (Mb)",       MemStatus.dwAvailPageFile >> 20); // DWORD free bytes of paging file 
-    print("Available Virtual (Mb)",         MemStatus.dwAvailVirtual >> 20);  // DWORD free user bytes 
+    print("Available Physical Memory (kb)", MemStatus.ullAvailPhys >> 10);     // DWORD free physical memory bytes 
+    print("Available Page File (Mb)",       MemStatus.ullAvailPageFile >> 20); // DWORD free bytes of paging file 
+    print("Available Virtual (Mb)",         MemStatus.ullAvailVirtual >> 20);  // DWORD free user bytes 
 
 }
 
@@ -156,7 +157,8 @@ void DisplaySystemInfo()
 {
 	LPVOID       lpv = NULL;
 	SYSTEM_INFO  SysInfo;
-	MEMORYSTATUS MemStatus;
+	MEMORYSTATUSEX MemStatus = { 0 };
+	MemStatus.dwLength = sizeof(MEMORYSTATUSEX);
 
 	GetSystemInfo(&SysInfo);
 
@@ -172,16 +174,16 @@ void DisplaySystemInfo()
 	print("wProcessorLevel",             SysInfo.wProcessorLevel);
 	print("wProcessorRevision",          SysInfo.wProcessorRevision);
 
-	GlobalMemoryStatus(&MemStatus);
+	GlobalMemoryStatusEx(&MemStatus);
 	
 	print("");
     print("Memory Load %",                  MemStatus.dwMemoryLoad);    // DWORD percent of memory in use 
-    print("Total Physical Memory (kb)",     MemStatus.dwTotalPhys >> 10);     // DWORD bytes of physical memory 
-    print("Available Physical Memory (kb)", MemStatus.dwAvailPhys >> 10);     // DWORD free physical memory bytes 
-    print("Total Page File (Mb)",           MemStatus.dwTotalPageFile >> 20); // DWORD bytes of paging file 
-    print("Available Page File (Mb)",       MemStatus.dwAvailPageFile >> 20); // DWORD free bytes of paging file 
-    print("Total Virtual (Mb)",             MemStatus.dwTotalVirtual >> 20);  // DWORD user bytes of address space 
-    print("Available Virtual (Mb)",         MemStatus.dwAvailVirtual >> 20);  // DWORD free user bytes 
+    print("Total Physical Memory (kb)",     MemStatus.ullTotalPhys >> 10);     // DWORD bytes of physical memory 
+    print("Available Physical Memory (kb)", MemStatus.ullAvailPhys >> 10);     // DWORD free physical memory bytes 
+    print("Total Page File (Mb)",           MemStatus.ullTotalPageFile >> 20); // DWORD bytes of paging file 
+    print("Available Page File (Mb)",       MemStatus.ullAvailPageFile >> 20); // DWORD free bytes of paging file 
+    print("Total Virtual (Mb)",             MemStatus.ullTotalVirtual >> 20);  // DWORD user bytes of address space 
+    print("Available Virtual (Mb)",         MemStatus.ullAvailVirtual >> 20);  // DWORD free user bytes 
 
 }
 

--- a/jp2_pc/Source/Test/BumpBuild/IOStuff.cpp
+++ b/jp2_pc/Source/Test/BumpBuild/IOStuff.cpp
@@ -33,9 +33,9 @@ void DisplayMemory()
 	GlobalMemoryStatusEx(&MemStatus);
 	
 	print("");
-    print("Available Physical Memory (kb)", MemStatus.ullAvailPhys >> 10);     // DWORD free physical memory bytes 
-    print("Available Page File (Mb)",       MemStatus.ullAvailPageFile >> 20); // DWORD free bytes of paging file 
-    print("Available Virtual (Mb)",         MemStatus.ullAvailVirtual >> 20);  // DWORD free user bytes 
+    print("Available Physical Memory (kb)", MemStatus.ullAvailPhys >> 10);     // free physical memory bytes 
+    print("Available Page File (Mb)",       MemStatus.ullAvailPageFile >> 20); // free bytes of paging file 
+    print("Available Virtual (Mb)",         MemStatus.ullAvailVirtual >> 20);  // free user bytes 
 
 }
 
@@ -177,13 +177,13 @@ void DisplaySystemInfo()
 	GlobalMemoryStatusEx(&MemStatus);
 	
 	print("");
-    print("Memory Load %",                  MemStatus.dwMemoryLoad);    // DWORD percent of memory in use 
-    print("Total Physical Memory (kb)",     MemStatus.ullTotalPhys >> 10);     // DWORD bytes of physical memory 
-    print("Available Physical Memory (kb)", MemStatus.ullAvailPhys >> 10);     // DWORD free physical memory bytes 
-    print("Total Page File (Mb)",           MemStatus.ullTotalPageFile >> 20); // DWORD bytes of paging file 
-    print("Available Page File (Mb)",       MemStatus.ullAvailPageFile >> 20); // DWORD free bytes of paging file 
-    print("Total Virtual (Mb)",             MemStatus.ullTotalVirtual >> 20);  // DWORD user bytes of address space 
-    print("Available Virtual (Mb)",         MemStatus.ullAvailVirtual >> 20);  // DWORD free user bytes 
+    print("Memory Load %",                  MemStatus.dwMemoryLoad);    // percent of memory in use 
+    print("Total Physical Memory (kb)",     MemStatus.ullTotalPhys >> 10);     // bytes of physical memory 
+    print("Available Physical Memory (kb)", MemStatus.ullAvailPhys >> 10);     // free physical memory bytes 
+    print("Total Page File (Mb)",           MemStatus.ullTotalPageFile >> 20); // bytes of paging file 
+    print("Available Page File (Mb)",       MemStatus.ullAvailPageFile >> 20); // free bytes of paging file 
+    print("Total Virtual (Mb)",             MemStatus.ullTotalVirtual >> 20);  // user bytes of address space 
+    print("Available Virtual (Mb)",         MemStatus.ullAvailVirtual >> 20);  // free user bytes 
 
 }
 


### PR DESCRIPTION
`GlobalMemoryStatus` is deprecated because its data structure only supports 32bit values, and gives incorrect results on systems withs more than 4GB of RAM. Its replacement `GlobalMemoryStatusEx` supports 64bit values.
All usages of `GlobalMemoryStatus` are modernized.