### PR TITLE
Aspect ratio fix

### DIFF
--- a/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/WorldDBase.cpp
@@ -421,8 +421,7 @@ CRenderDB*  ps_renderDB = 0;
 			camprop.vpViewport.SetSize(prasMainScreen->iWidth, prasMainScreen->iHeight);
 
 			// Set the physical aspect ratio to the product of the raster and pixel aspect ratios.
-			camprop.fAspectRatio = float(prasMainScreen->iWidth) / prasMainScreen->iHeight /
-									prasMainScreen->fAspectRatio;
+			camprop.fAspectRatio = prasMainScreen->GetAspectRatio();
 
 			pcam->SetProperties(camprop);
 		}

--- a/jp2_pc/Source/Lib/Sys/W95/Render.cpp
+++ b/jp2_pc/Source/Lib/Sys/W95/Render.cpp
@@ -274,8 +274,7 @@ int iGetScreenBitdepth();
 		camprop.vpViewport.SetSize(prasMainScreen->iWidth, prasMainScreen->iHeight);
 
 		// Set the physical aspect ratio to the product of the raster and pixel aspect ratios.
-		camprop.fAspectRatio = float(prasMainScreen->iWidth) / prasMainScreen->iHeight /
-								prasMainScreen->fAspectRatio;
+		camprop.fAspectRatio = prasMainScreen->GetAspectRatio();
 
 		pcam->SetProperties(camprop);
 
@@ -542,8 +541,7 @@ int iGetScreenBitdepth();
 		camprop.vpViewport.SetSize(prasMainScreen->iWidth, prasMainScreen->iHeight);
 
 		// Set the new renderer aspect ratio.
-		camprop.fAspectRatio = float(prasMainScreen->iWidth) / float(prasMainScreen->iHeight) /
-			                   prasMainScreen->fAspectRatio;
+		camprop.fAspectRatio = prasMainScreen->GetAspectRatio();
 
 		// Set the main camera's properties.
 		pcam->SetProperties(camprop);

--- a/jp2_pc/Source/Lib/View/RasterVid.hpp
+++ b/jp2_pc/Source/Lib/View/RasterVid.hpp
@@ -436,7 +436,6 @@ class CRasterWin: public CRasterVid
 public:
 	bool   bFullScreen;		// True if in full-screen mode, else a window.
 	int    iBuffers;		// The number of buffers in the raster.
-	float  fAspectRatio;	// Ratio of pixel x size to y size.
 	uint32 u4DDSFlagsFront;
 	int    iWidthFront;		// True surface dimensions. May be different than the reported
 	int    iHeightFront;	// surface.
@@ -663,6 +662,11 @@ public:
 	//
 	//**********************************
 
+	float GetAspectRatio()
+	{
+		return fWidth / fHeight;
+	}
+	
 protected:
 
 	CRasterWin()

--- a/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
+++ b/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
@@ -1130,9 +1130,6 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 // Globals for CRasterWin.
 //
 
-	// Assume a standard monitor aspect ratio (width/height).
-	const float fMONITOR_ASPECT = 4.0f / 3.0f;
-
 	//************************************************************************
 	//
 	static void ClientToScreen
@@ -1250,7 +1247,6 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 		//
 		DirectDraw::err = pddsPrimary4->GetSurfaceDesc(&sd);
 		u4DDSFlagsFront = sd.ddsCaps.dwCaps;
-		fAspectRatio = (float)sd.dwWidth / sd.dwHeight / fMONITOR_ASPECT ;
 		
 		eClearMethod  = ecmTEST;
 		i4ClearTiming = 0;


### PR DESCRIPTION
`CRasterVid` has an `fAspectRatio` property.
The way that property is calculated is a little strange: `width / height / (4/3)`. For 4:3 resolutions, this always gives a result of 1. For different aspect ratios, it would give a result larger than 1 and the game looks a little squished. Adjusting for different aspect ratios would mean that `fAspectRatio` is always 1, which makes it redundant, especially since it is only ever used as a divisor.

`fAspectRatio` is dropped. Its usages are replaced by a function that divides width by height.

4:3 reference
![TPass021](https://user-images.githubusercontent.com/5839584/83361306-2af80b00-a388-11ea-8125-751c7f012074.png)
16:9 with fix
![TPass022](https://user-images.githubusercontent.com/5839584/83361308-2c293800-a388-11ea-95a0-44cc130af5e7.png)
16:9 without fix
![TPass023](https://user-images.githubusercontent.com/5839584/83361309-2cc1ce80-a388-11ea-8375-979184863d56.png)
Pay close attention to the free-standing pillar in the middle.