### PR TITLE
Clone/checkout instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ A git-based fork of the Jurassic Park: Trespasser source code.
 </p>
 <p align="center">Link: https://discord.gg/5EngSvu</p>
 
+## Cloning/Checkout instructions
+**This is a complex repository using Git Submodules and Git LFS.**
+
+After cloning, please run the script `gitsyncscript.sh` to also checkout the externals and download the LFS data. Use this command (on Windows, use Git Bash): `sh gitsyncscript.sh`
+
+If you are using TortoiseGit to clone this repository, please check the boxes "Recursive" and "LFS" in the cloning dialog.
+
+
 ## Solution Overview
 | Projects          | Generates                         | Notes:                                                                                                                                                                                                                 |
 | :---------------- | :-------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/gitsyncscript.sh
+++ b/gitsyncscript.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+git submodule update --init
+pushd jp2_pc/BuildTools/CMake
+git-lfs fetch
+popd


### PR DESCRIPTION
A little script and instructions are provided for how to clone/checkout this repo. Because of submodules and LFS, a simple `git clone` is insufficient.