### PR TITLE
Support for D3D in windowed mode

### DIFF
--- a/jp2_pc/Source/Lib/View/DisplayMode.cpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.cpp
@@ -14,8 +14,6 @@ WindowMode GetWindowModeConfigured()
 
 WindowMode GetWindowModeActual()
 {
-	if (GetRegValue(strFLAG_D3D, DEFAULT_D3D))
-		return WindowMode::EXCLUSIVE;
-	else
-		return GetWindowModeConfigured();
+	//In some situations it can be helpful to override the configured mode
+	return GetWindowModeConfigured();
 }

--- a/jp2_pc/Source/Lib/View/DisplayMode.cpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.cpp
@@ -14,6 +14,13 @@ WindowMode GetWindowModeConfigured()
 
 WindowMode GetWindowModeActual()
 {
-	//In some situations it can be helpful to override the configured mode
+	//In some situations it can be helpful to override the configured mode.
+	//For example, during some development stages it is possible that not
+	//all combinations of window modes and renderers work together. In such
+	//a situation an enforcement of a specific window mode is needed.
+	//
+	//At the same time it should remain possible to query the configured window mode.
+	//A possible use case is displaying the value in a settings menu.
+
 	return GetWindowModeConfigured();
 }

--- a/jp2_pc/Source/Lib/View/DisplayMode.cpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.cpp
@@ -11,16 +11,3 @@ WindowMode GetWindowModeConfigured()
 		selection = 0;
 	return static_cast<WindowMode>(selection);
 }
-
-WindowMode GetWindowModeActual()
-{
-	//In some situations it can be helpful to override the configured mode.
-	//For example, during some development stages it is possible that not
-	//all combinations of window modes and renderers work together. In such
-	//a situation an enforcement of a specific window mode is needed.
-	//
-	//At the same time it should remain possible to query the configured window mode.
-	//A possible use case is displaying the value in a settings menu.
-
-	return GetWindowModeConfigured();
-}

--- a/jp2_pc/Source/Lib/View/DisplayMode.hpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.hpp
@@ -8,5 +8,3 @@ enum class WindowMode {
 };
 
 WindowMode GetWindowModeConfigured();
-
-WindowMode GetWindowModeActual();

--- a/jp2_pc/Source/Lib/View/RasterVid.hpp
+++ b/jp2_pc/Source/Lib/View/RasterVid.hpp
@@ -668,6 +668,7 @@ public:
 	}
 	
 protected:
+	void ConstructClipper(HWND hwnd);
 
 	CRasterWin()
 	{

--- a/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
+++ b/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
@@ -320,7 +320,7 @@ private:
 		iWidthFront  = i_width;
 		iHeightFront = i_height;
 
-		if (i_bits && GetWindowModeActual() == WindowMode::EXCLUSIVE)
+		if (i_bits && GetWindowModeConfigured() == WindowMode::EXCLUSIVE)
 		{		
 			// Go fullscreen.  We need to call 2 DD functions to do this.
 			DirectDraw::err = DirectDraw::pdd4->SetCooperativeLevel(hwnd, 
@@ -1302,7 +1302,7 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 			// Return to Windows screen if necessary.
 			if (DirectDraw::pdd4)
 			{
-				if (GetWindowModeActual() == WindowMode::EXCLUSIVE)
+				if (GetWindowModeConfigured() == WindowMode::EXCLUSIVE)
 					DirectDraw::err = DirectDraw::pdd4->RestoreDisplayMode();
 				DirectDraw::err = DirectDraw::pdd4->SetCooperativeLevel(0, DDSCL_NORMAL);
 			}
@@ -1716,7 +1716,7 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 	//******************************************************************************************
 	bool CRasterWin::CPriv::bConstructD3D(HWND hwnd, int i_width, int i_height, int i_bits)
 	{
-		if (GetWindowModeActual() == WindowMode::EXCLUSIVE)
+		if (GetWindowModeConfigured() == WindowMode::EXCLUSIVE)
 			return bConstructD3DExclusive(hwnd, i_width, i_height, i_bits);
 		else
 			return bConstructD3DWindowed(hwnd, i_width, i_height, i_bits);

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -906,7 +906,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
     bGetDimensions(windowWidth, windowHeight);
 
     DWORD style = WS_VISIBLE | WS_POPUP | WS_SYSMENU;
-    if (GetWindowModeActual() == WindowMode::FRAMED)
+    if (GetWindowModeConfigured() == WindowMode::FRAMED)
         style |= WS_OVERLAPPEDWINDOW;
 	
     if (!CreateWindowEx(0,


### PR DESCRIPTION
Support for Direct3D in windowed mode is introduced.
To achieve this, the DirectDraw surfaces have to be created in a different way than in fullscreen mode. The key difference is that we cannot directly create a primary surface with a backbuffer, but have to create the backbuffer manually.

On a side note, the performance (FPS) of the D3D renderer is much higher in windowed mode than in exclusive fullscreen.