### PR TITLE
Deduplicate CDDSize and use it where applicable

### DIFF
--- a/jp2_pc/Source/GUIApp/GUIAppDlg.cpp
+++ b/jp2_pc/Source/GUIApp/GUIAppDlg.cpp
@@ -202,6 +202,7 @@
 #include "Lib/sys/Reg.h"
 #include "lib/sys/reginit.hpp"
 #include "lib/loader/LoadTexture.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 
 
 #include <stdio.h>
@@ -6142,9 +6143,8 @@ void CGUIAppDlg::ToggleTextureWire()
 bool CGUIAppDlg::bDetectJoystick(EControlMethod ecm_stick)
 {
 	// ecm_joystick is ignored at the moment
-	JOYINFOEX	ji_stick;
+	CDDSize<JOYINFOEX> ji_stick;
 
-	ji_stick.dwSize=sizeof(JOYINFOEX);
 	ji_stick.dwFlags=0;
 	if (joyGetPosEx(JOYSTICKID1,&ji_stick)==JOYERR_NOERROR)
 		return(TRUE);

--- a/jp2_pc/Source/Lib/Audio/Audio.cpp
+++ b/jp2_pc/Source/Lib/Audio/Audio.cpp
@@ -247,6 +247,7 @@
 
 #include "Lib/Sys/DebugConsole.hpp"
 #include "lib/sys/memorylog.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 #include "eax.h"			// Creative environmental audio
 
 
@@ -951,7 +952,7 @@ void CAudio::CreateAudio
 //**************************************
 {
 	HRESULT					hr;
-	CDSSize<DSBUFFERDESC>	dsbd;
+	CDDSize<DSBUFFERDESC>	dsbd;
 
 	// clear out all of the pseudo 3d sample pointers
 	uint32 u4_p_count;
@@ -1063,7 +1064,7 @@ void CAudio::CreateAudio
 	bSoundEnabled = false;
 
 	// Get the DS caps
-	CDSSize<DSCAPS>	dscaps;
+	CDDSize<DSCAPS>	dscaps;
 
 	if (pDSInterface->GetCaps(&dscaps) == DS_OK)
 	{
@@ -1382,7 +1383,7 @@ void CAudio::EnableEnvironmentalAudio
 //	
 //**************************************
 {
-	CDSSize<DSBUFFERDESC>	dsbd;
+	CDDSize<DSBUFFERDESC>	dsbd;
 	HRESULT					hr;
 	WAVEFORMATEX			format;
 
@@ -1928,7 +1929,7 @@ LPDIRECTSOUNDBUFFER	CAudio::CreateDSBuffer
 //**************************************
 {
 	LPDIRECTSOUNDBUFFER		psbuffer;
-	CDSSize<DSBUFFERDESC>	dsbd;
+	CDDSize<DSBUFFERDESC>	dsbd;
 	HRESULT					hr;
 	WAVEFORMATEX			format;
 

--- a/jp2_pc/Source/Lib/Audio/Audio.hpp
+++ b/jp2_pc/Source/Lib/Audio/Audio.hpp
@@ -334,33 +334,6 @@ struct SStreamedSample
 
 
 //**********************************************************************************************
-//
-template<class T> class CDSSize: public T 
-//	
-//	Handy template class for setting the size of structures
-//
-//	Example: instead of saying:
-//
-//		DSBUFFERDESC	sd;
-//		memset(&sd, 0, sizeof(sd));
-//		sd.dwSize = sizeof(sd);
-//
-//	Say:
-//
-//		CDSSize<DSBUFFERDESC>	sd;
-//
-//**************************************
-{
-public:
-	// Constructor just sets everything to 0, then sets the correct dwSize field.
-	CDSSize() 
-	{
-		memset(this, 0, sizeof(*this));
-		dwSize = sizeof(*this);
-	}
-};
-
-//**********************************************************************************************
 #define u4SEMAPHORE_COUNT	2
 
 //**********************************************************************************************

--- a/jp2_pc/Source/Lib/Control/Control.cpp
+++ b/jp2_pc/Source/Lib/Control/Control.cpp
@@ -78,6 +78,8 @@
 
 #include <mmsystem.h>
 
+#include "Lib/Sys/DWSizeStruct.hpp"
+
 #ifdef USE_DIRECTINPUT
 #include <DirectX/DInput.h>
 #endif //#ifdef USE_DIRECTINPUT
@@ -382,13 +384,12 @@ CInput::~CInput()
 //
 SInput& CInput::tinReadStandardJoystickControls()
 {
-	JOYINFOEX	ji_stick;
+	CDDSize<JOYINFOEX> ji_stick;
 
 	// Clear keys to off.
 	tin_Input.u4ButtonState = 0;
 	tin_Input.u4ButtonHit = 0;
 
-	ji_stick.dwSize=sizeof(JOYINFOEX);
 	ji_stick.dwFlags=JOY_RETURNX|JOY_RETURNY|JOY_RETURNBUTTONS|JOY_USEDEADZONE|JOY_RETURNCENTERED;
 	joyGetPosEx(JOYSTICKID1,&ji_stick);
 
@@ -853,9 +854,8 @@ bool bReadJoystickSimple(float& rf_x, float& rf_y, float& rf_z, bool& rb_trigger
 	rf_z = 0.0f;
 	rb_trigger = false;
 	rb_thumb   = false;
-	JOYINFOEX ji;
+	CDDSize<JOYINFOEX> ji;
 
-	ji.dwSize=sizeof(ji);
 	ji.dwFlags=JOY_RETURNX|JOY_RETURNY|JOY_RETURNR|JOY_RETURNBUTTONS|JOY_USEDEADZONE|JOY_RETURNCENTERED;
 	if (joyGetPosEx(0, &ji)!=JOYERR_NOERROR)
 		return false;

--- a/jp2_pc/Source/Lib/Sys/DWSizeStruct.hpp
+++ b/jp2_pc/Source/Lib/Sys/DWSizeStruct.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <type_traits>
+#include <cstring>
+
+template<class T> class CDDSize : public T
+//	
+//	Handy template class for all those DD structs that require a dwSize field to be set properly.
+//
+//	Example: instead of saying:
+//
+//		DDSURFACEDESC2	sd;
+//		memset(&sd, 0, sizeof(sd));
+//		sd.dwSize = sizeof(sd);
+//
+//	Say:
+//
+//		CDDSize<DDSURFACEDESC2>	sd;
+//
+//**************************************
+{
+public:
+	// Constructor just sets everything to 0, then sets the correct dwSize field.
+	CDDSize()
+	{
+		InitStruct(*this);
+		
+		static_assert(sizeof(*this) == sizeof(T)); //Ensure compatibility of types
+		static_assert(std::is_trivially_copyable_v<CDDSize<T>>);
+	}
+
+	static void InitStruct(T& structdata)
+	{
+		std::memset(&structdata, 0, sizeof(structdata));
+		structdata.dwSize = sizeof(structdata);
+
+		static_assert(std::is_trivially_copyable_v<T>); //Ensure memset is harmless
+	}
+};

--- a/jp2_pc/Source/Lib/View/RasterD3D.cpp
+++ b/jp2_pc/Source/Lib/View/RasterD3D.cpp
@@ -212,6 +212,7 @@
 #include "Lib/View/Direct3DRenderState.hpp"
 #include "Lib/Renderer/ScreenRenderAuxD3D.hpp"
 #include "Lib/View/AGPTextureMemManager.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 
 #include <memory.h>
 
@@ -337,35 +338,7 @@ static CProfileStat psLockTexture("Lock Tex.", &proHardware.psHardware);
 // Local functions.
 //
 
-//**********************************************************************************************
-//
-template<class T> void InitDXStruct
-(
-	T& t
-)
-//
-// Initializes and DirectX structure.
-//
-//**************************************
-{
-	Clear(t);
-	t.dwSize = sizeof(t);
-}
 
-//**********************************************************************************************
-//
-template<class T> T& Clear
-(
-	T& t
-)
-//
-// Clears any structure.
-//
-//**************************************
-{
-	memset(&t, 0, sizeof(t));
-	return t;
-}
 
 //**********************************************************************************************
 //
@@ -1131,7 +1104,7 @@ public:
 
 		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_TEXTURE;
 
-		InitDXStruct(ddsd.ddpfPixelFormat);
+		CDDSize<DDPIXELFORMAT>::InitStruct(ddsd.ddpfPixelFormat);
 
 		// Set the pixel format.
 		if (d3dDriver.bUseD3D())
@@ -1143,7 +1116,7 @@ public:
 		{
 			// Use the screen format.
 			CDDSize<DDSURFACEDESC2> ddsd_screen;
-			InitDXStruct(ddsd_screen.ddpfPixelFormat);
+			CDDSize<DDPIXELFORMAT>::InitStruct(ddsd_screen.ddpfPixelFormat);
 
 			prasMainScreen->pddsDraw4->GetSurfaceDesc(&ddsd_screen);
 			ddsd.ddpfPixelFormat = ddsd_screen.ddpfPixelFormat;
@@ -1170,7 +1143,7 @@ public:
 
 		ddsd.ddsCaps.dwCaps = DDSCAPS_SYSTEMMEMORY | DDSCAPS_TEXTURE;
 
-		InitDXStruct(ddsd.ddpfPixelFormat);
+		CDDSize<DDPIXELFORMAT>::InitStruct(ddsd.ddpfPixelFormat);
 
 		// Set the pixel format.
 		if (d3dDriver.bUseD3D())
@@ -1191,7 +1164,7 @@ public:
 		{
 			// Use the screen format.
 			CDDSize<DDSURFACEDESC2> ddsd_screen;
-			InitDXStruct(ddsd_screen.ddpfPixelFormat);
+			CDDSize<DDPIXELFORMAT>::InitStruct(ddsd_screen.ddpfPixelFormat);
 
 			prasMainScreen->pddsDraw4->GetSurfaceDesc(&ddsd_screen);
 

--- a/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
+++ b/jp2_pc/Source/Lib/View/W95/RasterVid.cpp
@@ -71,6 +71,7 @@
 #include "Lib/Sys/debugConsole.hpp"
 #include "Lib/Sys/W95/Render.hpp"
 #include "Lib/Sys/RegInit.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 #include "Lib/W95/Direct3D.hpp"
 #include "Lib/Std/PrivSelf.hpp"
 #include "Lib/Renderer/ScreenRenderAuxD3D.hpp"
@@ -1215,10 +1216,7 @@ rptr<CRaster> prasReadBMP(const char* str_bitmap_name, bool b_vid)
 			if (evc_type != evcPermedia2)
 			{
 				// Check for primary gamma capability.
-				DDCAPS  ddcaps;
-
-				memset(&ddcaps, 0, sizeof(ddcaps));
-				ddcaps.dwSize = sizeof(ddcaps);
+				CDDSize<DDCAPS> ddcaps;
 
 				HRESULT ddrval = DirectDraw::pdd4->GetCaps(&ddcaps, NULL);
 

--- a/jp2_pc/Source/Lib/View/W95/Video.cpp
+++ b/jp2_pc/Source/Lib/View/W95/Video.cpp
@@ -62,6 +62,7 @@
 #include "Common.hpp"
 #include "Lib/W95/DD.hpp"
 #include "../Video.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 #include "Lib/W95/Direct3DCards.hpp"
 
 

--- a/jp2_pc/Source/Lib/W95/DD.cpp
+++ b/jp2_pc/Source/Lib/W95/DD.cpp
@@ -41,6 +41,7 @@
 #include "Lib/Sys/RegInit.hpp"
 #include "Lib/W95/Direct3D.hpp"
 #include "Lib/Sys/DebugConsole.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 
 //**********************************************************************************************
 //
@@ -222,16 +223,13 @@ void CInitDD::ReleaseAll()
 
 bool CInitDD::IsCertified()
 {
-    DDCAPS  ddcaps;
+    CDDSize<DDCAPS> ddcaps;
     HRESULT ddrval;
 
     if (BaseInit() < 0)
     {
         return false;
     }
-
-    memset(&ddcaps, 0, sizeof(ddcaps));
-    ddcaps.dwSize = sizeof(ddcaps);
 
     ddrval = DirectDraw::pdd4->GetCaps(&ddcaps, NULL);
     if (ddrval != DD_OK)
@@ -250,16 +248,13 @@ bool CInitDD::IsCertified()
 
 bool CInitDD::IsHardwareSupported()
 {
-    DDCAPS  ddcaps;
+    CDDSize<DDCAPS> ddcaps;
     HRESULT ddrval;
 
     if (BaseInit() < 0)
     {
         return false;
     }
-
-    memset(&ddcaps, 0, sizeof(ddcaps));
-    ddcaps.dwSize = sizeof(ddcaps);
 
     ddrval = DirectDraw::pdd4->GetCaps(&ddcaps, NULL);
     if (ddrval != DD_OK)

--- a/jp2_pc/Source/Lib/W95/DD.hpp
+++ b/jp2_pc/Source/Lib/W95/DD.hpp
@@ -109,47 +109,6 @@
 
 //**********************************************************************************************
 //
-template<class T> class CDDSize: public T 
-//	
-//	Handy template class for all those DD structs that require a dwSize field to be set properly.
-//
-//	Example: instead of saying:
-//
-//		DDSURFACEDESC2	sd;
-//		memset(&sd, 0, sizeof(sd));
-//		sd.dwSize = sizeof(sd);
-//
-//	Say:
-//
-//		CDDSize<DDSURFACEDESC2>	sd;
-//
-//**************************************
-{
-public:
-	// Constructor just sets everything to 0, then sets the correct dwSize field.
-	CDDSize() 
-	{
-		memset(this, 0, sizeof(*this));
-		dwSize = sizeof(*this);
-	}
-};
-
-
-#ifndef __MWERKS__
-#if _MSC_VER <= 1020
-	//
-	// Stupid compiler requires this external declaration, otherwise it will not be able to find
-	// the struct 'IDirectDraw2.'
-	//
-	extern CCom<IDirectDraw2>	pdd;		// The pointer through which all functions are accessed.
-	extern CCom<IDirectDraw4>	pdd4;		// The pointer through which all functions are accessed.
-	#error Bullcrap needed for 4.2. Remove this error message to get 4.2 to compile.
-#endif
-#endif	// MWERKS
-
-
-//**********************************************************************************************
-//
 namespace DirectDraw
 //
 // Encapsulation of some IDirectDraw items.

--- a/jp2_pc/Source/Lib/W95/Direct3D.cpp
+++ b/jp2_pc/Source/Lib/W95/Direct3D.cpp
@@ -96,7 +96,7 @@
 #include "Lib/Sys/Profile.hpp"
 #include "Lib/View/ColourBase.hpp"
 #include "Lib/View/RasterConvertD3D.hpp"
-
+#include "Lib/Sys/DWSizeStruct.hpp"
 #include "Lib/Sys/DebugConsole.hpp"
 
 
@@ -1352,8 +1352,7 @@ public:
 		iViewportHeight = int(sd.dwHeight);
 
 		// Intialize viewport values.
-		D3DVIEWPORT2 d3d_viewport;	// Viewport information..
-		d3d_viewport.dwSize       = sizeof(d3d_viewport);
+		CDDSize<D3DVIEWPORT2> d3d_viewport;	// Viewport information..
 		d3d_viewport.dwX          = 0;
 		d3d_viewport.dwY          = 0;
 		d3d_viewport.dwWidth      = iViewportWidth;

--- a/jp2_pc/Source/Lib/W95/Direct3DQuery.cpp
+++ b/jp2_pc/Source/Lib/W95/Direct3DQuery.cpp
@@ -151,6 +151,7 @@
 #include "Lib/W95/Direct3D.hpp"
 #include "Lib/Sys/W95/Render.hpp"
 #include "Lib/Renderer/ScreenRenderAuxD3D.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 
 
 //

--- a/jp2_pc/Source/Trespass/uidlgs.cpp
+++ b/jp2_pc/Source/Trespass/uidlgs.cpp
@@ -30,6 +30,7 @@
 #include "..\Lib\Sys\reg.h"
 #include "..\lib\sys\reginit.hpp"
 #include "keyremap.h"
+#include "Lib/Sys/DWSizeStruct.hpp"
 
 
 #define FIRST_LEVEL_NAME "BE.SCN"
@@ -498,7 +499,7 @@ void CLoaderWnd::InnerWindowLoop(bool bPaint)
     IDirectDrawSurface4 *   pSurface;
     HRESULT                 hr;
     CUIWnd *                puiwnd;
-    DDBLTFX                 ddfx;
+    CDDSize<DDBLTFX>        ddfx;
 
     PreLoopCall();
 
@@ -512,9 +513,6 @@ void CLoaderWnd::InnerWindowLoop(bool bPaint)
         // Draw everything to the back buffer
         puiwnd = m_pUIMgr->GetActiveUIWnd();
         puiwnd->DrawIntoSurface(prasMainScreen.ptPtrRaw(), &m_pUIMgr->m_rcInvalid);
-
-        memset(&ddfx, 0, sizeof(ddfx));
-        ddfx.dwSize = sizeof(ddfx);
 
         ddfx.dwROP = SRCCOPY;
         ddfx.dwDDFX = DDBLTFX_NOTEARING;

--- a/jp2_pc/Source/Trespass/video.cpp
+++ b/jp2_pc/Source/Trespass/video.cpp
@@ -24,6 +24,7 @@
 #include "video.h"
 #include "..\Lib\Sys\reg.h"
 #include "..\lib\sys\reginit.hpp"
+#include "Lib/Sys/DWSizeStruct.hpp"
 
 
 extern HINSTANCE    g_hInst;
@@ -103,12 +104,8 @@ void CVideoWnd::NextNonDirect()
     LPBYTE      pbDst;
     int         iSurface;
     IDirectDrawSurface4 *   pSurface;
-    DDSURFACEDESC2          dds;
+    CDDSize<DDSURFACEDESC2> dds;
     HRESULT                 hr;
-
-
-    memset(&dds, 0, sizeof(dds));
-    dds.dwSize = sizeof(dds);
 
     pSurface = prasMainScreen->GetPrimarySurface();
     do
@@ -286,13 +283,11 @@ BOOL CVideoWnd::Play(LPCSTR pszFile)
 
     {
         IDirectDrawSurface4 *   pSurface;
-        DDSURFACEDESC2          dds;
+        CDDSize<DDSURFACEDESC2> dds;
         HRESULT                 hr;
 
         pSurface = prasMainScreen->GetPrimarySurface();
-		memset(&dds, 0, sizeof(dds));
-		dds.dwSize = sizeof(dds);
-
+		
 		do
 		{
 			hr = pSurface->Lock(NULL, 

--- a/jp2_pc/cmake/System/CMakeLists.txt
+++ b/jp2_pc/cmake/System/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND System_Inc
     ${CMAKE_SOURCE_DIR}/source/lib/control/Control.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Control/KeyMapping.hpp
     ${CMAKE_SOURCE_DIR}/source/Lib/Sys/DebugConsole.hpp
+    ${CMAKE_SOURCE_DIR}/source/Lib/Sys/DWSizeStruct.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/Errors.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/ExePageModify.hpp
     ${CMAKE_SOURCE_DIR}/Source/Lib/Sys/FastHeap.hpp


### PR DESCRIPTION
Certain DirectX structs have a `dwSize` member. When creating such a struct, you are supposed to assign `dwSize` to `sizeof(ThatStruct)`.
Trespasser has _three_ wrappers to automate this: `CDDSize`, `CDSSize` (a copypaste of `CDDSize`) and `InitDXStruct`. They all do the same thing: `memset` the struct to 0 and then assign `dwSize`.

`CDDSize` is extracted into its own header file and augmented with a few compile-time safety checks. All usages of `CDSSize` and `InitDXStruct` are replaced with `CDDSize`. Furthermore, `CDDSize` is now used wherever applicable.