### PR TITLE
No min/max macros

### DIFF
--- a/jp2_pc/Inc/maxsdk/box2.h
+++ b/jp2_pc/Inc/maxsdk/box2.h
@@ -19,6 +19,7 @@
 #include "point2.h"
 #include <windef.h>
 
+#define min(x,y) (((x) < (y)) ? (x) : (y))
 
 class Box2: public RECT {
 	public:
@@ -64,5 +65,7 @@ struct FBox2 {
 	DllExport FBox2& operator+=(const FBox2& b);
 	DllExport int Contains(const Point2& p) const;  // is point in this box?
 	};
+
+#undef min
 
 #endif

--- a/jp2_pc/Source/Lib/File/Image.cpp
+++ b/jp2_pc/Source/Lib/File/Image.cpp
@@ -332,7 +332,7 @@ CSymbolTable::SSymbol::SSymbol(const SSymbol& symbol)
 CSymbolTable::SSymbol::SSymbol(const SSymbolEntry& sym_entry, const char* sym_name)
 {
 	handle = sym_entry.handle;
-	unused_handle = max(unused_handle, handle)+1;
+	unused_handle = std::max(unused_handle, handle)+1;
 	
 	if (sym_name && sym_name[0])
 	{

--- a/jp2_pc/Source/Lib/File/Section.cpp
+++ b/jp2_pc/Source/Lib/File/Section.cpp
@@ -488,7 +488,7 @@ char* CArea::SAreaMemory::reserve(int size)
 {
 	if (size > off_end - off_free)
 	{
-		int new_size = max(DEF_AREA_SIZE, size);
+		int new_size = std::max(DEF_AREA_SIZE, size);
 		pstart = (char*)realloc(pstart, new_size);
 		off_end += new_size;
 	}

--- a/jp2_pc/Source/Lib/File/Section.hpp
+++ b/jp2_pc/Source/Lib/File/Section.hpp
@@ -28,10 +28,6 @@
 #include "Image.hpp"
 #include "Section.hpp"
 
-#ifndef __MWERKS__
- #include <minmax.h>
-#endif
-
 #include <assert.h>
 #include <vector>
 

--- a/jp2_pc/cmake/CMakeCommon.cmake
+++ b/jp2_pc/cmake/CMakeCommon.cmake
@@ -12,6 +12,10 @@ add_compile_definitions(
     $<$<CONFIG:Debug>:TARGET_PROCESSOR=PROCESSOR_PENTIUM>
     $<$<CONFIG:Release>:TARGET_PROCESSOR=PROCESSOR_PENTIUMPRO>
     $<$<CONFIG:Final>:TARGET_PROCESSOR=PROCESSOR_PENTIUMPRO>
+    
+    $<$<CONFIG:Debug>:NOMINMAX>
+    $<$<CONFIG:Release>:NOMINMAX>
+    $<$<CONFIG:Final>:NOMINMAX>
 )
 
 #In CMake, the regular Release configuration has no debug info


### PR DESCRIPTION
The macro versions of `min`/`max` have two problems:
1. They are not typesafe. Arguments of completely different types might be compared (like `signed`/`unsigned`), leading to unexpected behavior. 
2. If an argument is an expression with side effects like `x++`, it might be evaluated twice, which may cause unintended behavior.

The Trespasser code already avoids those macros for the most part and undefines them in some strategic places.

The few remaining usages of the `min`/`max` macros are removed. The macro definitions from `Windows.h` are avoided by global definitions of the `NOMINMAX` macro and not using the `minmax.h` header.
An exemption is made for `box2.h` from the 3DS Max SDK, it gets a "scoped" definition of the `min` macro. 