### PR TITLE
CVideoWnd: missing cleanup

### DIFF
--- a/jp2_pc/Source/Trespass/uiwnd.cpp
+++ b/jp2_pc/Source/Trespass/uiwnd.cpp
@@ -293,7 +293,7 @@ CUIWnd::CUIWnd(CUIManager * pUIMgr)
 CUIWnd::~CUIWnd()
 {
     if (m_pUIMgr)
-        Assert(!m_pUIMgr->Detach(this)) //Detach should have happened before this point
+        Verify(!m_pUIMgr->Detach(this)); //Detach should have happened before this point
 
     delete m_pRaster;
 }

--- a/jp2_pc/Source/Trespass/video.cpp
+++ b/jp2_pc/Source/Trespass/video.cpp
@@ -259,7 +259,8 @@ BOOL CVideoWnd::Play(LPCSTR pszFile)
 #ifdef _DEBUG
         dprintf("CVideoWnd::Play() -- Unable to load/find %s", sz);
 #endif
-        return FALSE;
+        m_pUIMgr->Detach(this);
+    	return FALSE;
     }
 
     m_pSmack = SmackOpen((char *)hfile, 
@@ -267,6 +268,8 @@ BOOL CVideoWnd::Play(LPCSTR pszFile)
                          SMACKAUTOEXTRA);
     if (!m_pSmack)
     {
+        m_pUIMgr->Detach(this);
+        CloseHandle(hfile);
         return FALSE;
     }
 


### PR DESCRIPTION
The `CVideoWnd::Play` function attaches the `CVideoWnd` instance to the UI manager early on, but forgets to detach from it before early `return` statements. This later causes use-after-free errors in the UI manager.

This becomes a problem when reaching the end of the demo: the game tries to play the outro video and the credits video, but because it cannot find the video files, `CVideoWnd::Play` returns early without sufficient cleanup. The use-after-free error then causes a crash.

The missing cleanup before the `return` statements is added.

The sentinel in the `CUIWnd` destructor (from PR #136) caught this problem only in `Debug` builds because an `Assert` instead of a `Verify` was used. That oversight is rectified.