### PR TITLE
Add .idea directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ jp2_pc/Build/
 
 #OpenTrespasser
 jp2_pc/Build/*
+
+#CLion project files
+jp2_pc/.idea/*


### PR DESCRIPTION
To accommodate users of the CLion C++ IDE, the directory `.idea` is added to the Git ignore list. It would contain various files generated by CLion after a CMake import.
It is named `.idea` because CLion is based on IntelliJ IDEA, a Java IDE.