### PR TITLE
32bit color depth support

### DIFF
--- a/jp2_pc/README.md
+++ b/jp2_pc/README.md
@@ -40,9 +40,10 @@ Depending on your system configuration, a program running in the Trespasser dire
 
 ### 16bit color depth mode
 
-The renderer only supports 16bit color depth. Adding 32bit support is an open issue.
+The game works in both 16bit and 32bit color depth. 
+An exception applies to D3D rendering together with exclusive fullscreen mode: this combination only works with 16bit color depth. 
 
-Running the game with 32bit color depth is possible, but the graphics are faulty and it will inevitably crash after a few minutes. Some apps like GUIApp completely refuse to start in 32bit color depth mode.
+Additional tools like GUIApp have not yet been tested in 32bit color depth and might completely refuse to start in that configuration.
 
 We do not know how to make VS start a program in 16bit color depth mode. Perhaps it can be done by starting VS with 16bit color depth, but that would be very inconvenient.
 

--- a/jp2_pc/Source/Lib/View/DisplayMode.cpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.cpp
@@ -11,3 +11,24 @@ WindowMode GetWindowModeConfigured()
 		selection = 0;
 	return static_cast<WindowMode>(selection);
 }
+
+int GetSystemBitDepth(HWND wnd)
+{
+	return GetSystemBitDepth(GetDC(wnd));
+}
+
+int GetSystemBitDepth(HDC dc)
+{
+	//Gives 16bit when program is set to 16bit color depth compatibility mode
+	return GetDeviceCaps(dc, BITSPIXEL);
+}
+
+bool IsDisplayConfigurationValid(int colorDepth, bool d3dEnabled, WindowMode mode)
+{
+	if (mode == WindowMode::UNDEFINED)
+		return false;
+	if (mode == WindowMode::EXCLUSIVE && d3dEnabled && colorDepth != 16)
+		return false;
+
+	return true;
+}

--- a/jp2_pc/Source/Lib/View/DisplayMode.hpp
+++ b/jp2_pc/Source/Lib/View/DisplayMode.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <Windows.h>
+
 enum class WindowMode {
 	UNDEFINED = 0,
 	FRAMED = 1,
@@ -8,3 +10,8 @@ enum class WindowMode {
 };
 
 WindowMode GetWindowModeConfigured();
+
+int GetSystemBitDepth(HWND wnd);
+int GetSystemBitDepth(HDC dc);
+
+bool IsDisplayConfigurationValid(int colorDepth, bool d3dEnabled, WindowMode mode);

--- a/jp2_pc/Source/Lib/View/RasterVid.hpp
+++ b/jp2_pc/Source/Lib/View/RasterVid.hpp
@@ -595,14 +595,14 @@ public:
 
 	//******************************************************************************************
 	//
-    IDirectDrawSurface4 * GetPrimarySurface4()
+    IDirectDrawSurface4 * GetRenderTargetSurface()
     {
-        return pddsPrimary4;
+        return pddsDraw4;
     }
 	//
-	// Returns a pointer to the primary surface.  This is necessary for Videos.
-	//
-	//**********************************
+    // Returns a pointer to the backbuffer, which generally should be the rendering target.
+    //
+    //**********************************
 
 
 	//******************************************************************************************

--- a/jp2_pc/Source/Lib/W95/Direct3D.cpp
+++ b/jp2_pc/Source/Lib/W95/Direct3D.cpp
@@ -856,7 +856,7 @@ public:
 			return false;
 		}
 		LPDIRECTDRAWSURFACE4 pdds_back  = prasMainScreen->pddsDraw4;
-		LPDIRECTDRAWSURFACE4 pdds_front = prasMainScreen->GetPrimarySurface4();
+		LPDIRECTDRAWSURFACE4 pdds_front = prasMainScreen->GetPrimarySurface();
 		return bInitialize(pdds_back, pdds_front);
 	}
 	

--- a/jp2_pc/Source/Trespass/gamewnd.cpp
+++ b/jp2_pc/Source/Trespass/gamewnd.cpp
@@ -419,6 +419,9 @@ void CGameWnd::SetupGameStoppage()
     // Stop the simulation
     msg.Dispatch();
 
+    //Repaint in case we have a cleared framebuffer right now
+    this->OnPaint(g_hwnd);
+
     m_bPaused = TRUE;
     m_pUIMgr->m_bDrawMouse = TRUE;
 
@@ -434,7 +437,7 @@ void CGameWnd::SetupGameStoppage()
     SetCursorPos(prasMainScreen->iWidth / 2, 
                  prasMainScreen->iHeight / 2);
 
-    g_CTPassGlobals.CaptureBackground();
+    g_CTPassGlobals.CaptureBackground(true);
 	g_CTPassGlobals.bHardReset = false;
 }
 

--- a/jp2_pc/Source/Trespass/main.cpp
+++ b/jp2_pc/Source/Trespass/main.cpp
@@ -455,6 +455,15 @@ int DoWinMain(HINSTANCE hInstance,
         return -1;
     }
 
+    if ( !IsDisplayConfigurationValid( GetSystemBitDepth(g_hwnd), bGetD3D(), GetWindowModeConfigured()))
+    {
+        if (MsgDlg(g_hwnd,
+            MB_YESNOCANCEL | MB_SETFOREGROUND,
+            IDS_ERROR_TITLE,
+            IDS_ERR_INVALID_DISPLAY_CONFIGURATION) != IDYES)
+            goto Cleanup;
+    }
+
     //
     // Check To see if the installed registry flag is set.  If it has not been
     // set then we haven't been installed.

--- a/jp2_pc/Source/Trespass/mainwnd.cpp
+++ b/jp2_pc/Source/Trespass/mainwnd.cpp
@@ -174,6 +174,8 @@ void CMainWnd::OnKey(HWND hwnd, UINT vk, BOOL fDown, int cRepeat, UINT flags)
 
     if (vk == VK_SNAPSHOT)
     {
+        //Repaint in case we have a cleared framebuffer right now
+        this->OnPaint(hwnd);
         ScreenCapture();
         return;
     }

--- a/jp2_pc/Source/Trespass/resource.h
+++ b/jp2_pc/Source/Trespass/resource.h
@@ -44,6 +44,7 @@
 #define IDS_ERR_PDETECT_FAILED          40
 #define IDS_ERR_NO_ACCELERATORS         41
 #define IDS_ERR_DISPLAY_README          42
+#define IDS_ERR_INVALID_DISPLAY_CONFIGURATION 43
 #define IDI_APP                         101
 #define IDTIMER_MAINRANDOM              101
 #define IDB_DEF_PAL                     102

--- a/jp2_pc/Source/Trespass/supportfn.cpp
+++ b/jp2_pc/Source/Trespass/supportfn.cpp
@@ -1147,7 +1147,7 @@ void ScreenCapture()
 
 	// Save out a blank bitmap if a real one cannot be found.
 
-    pSurface = prasMainScreen->GetPrimarySurface();
+    pSurface = prasMainScreen->GetRenderTargetSurface();
     hr = pSurface->GetDC(&hdcSrc);
 
 	SetStretchBltMode(hdcDst, COLORONCOLOR);

--- a/jp2_pc/Source/Trespass/tpassglobals.cpp
+++ b/jp2_pc/Source/Trespass/tpassglobals.cpp
@@ -181,7 +181,7 @@ void CTPassGlobals::CaptureBackground(bool bBackbuffer /* = false */)
 
     if (bBackbuffer)
     {
-        pSurface = prasMainScreen->pddsDraw4;
+        pSurface = prasMainScreen->GetRenderTargetSurface();
     }
     else
     {
@@ -193,7 +193,8 @@ void CTPassGlobals::CaptureBackground(bool bBackbuffer /* = false */)
     hdcDst = m_prasBkgnd->hdcGet();
 
     POINT basepoint = { 0,0 };
-    ClientToScreen(g_hwnd, &basepoint);
+    //Enable this if the background is shifted in windowed mode
+    //ClientToScreen(g_hwnd, &basepoint);
 	
     BitBlt(hdcDst, 
            0, 

--- a/jp2_pc/Source/Trespass/trespass.rc
+++ b/jp2_pc/Source/Trespass/trespass.rc
@@ -208,6 +208,8 @@ BEGIN
     IDS_ERR_PDETECT_FAILED  "Failed to detect local processor. Do you want to continue?"
     IDS_ERR_NO_ACCELERATORS "No hardware accelerators compatible with Trespasser have been found.\r\nConsult the 'Readme.txt' file for more information on supported\r\nhardware accelerators."
     IDS_ERR_DISPLAY_README  "Unable to display the 'Readme.txt' file. Please open the file\nmanually from the 'Setup' directory on your distribution CD-ROM\nusing a program like Notepad or Wordpad."
+    IDS_ERR_INVALID_DISPLAY_CONFIGURATION
+                            "The current combination of display settings is invalid. This error involves a combination of these settings:\r\n\r\n- 16bit color depth compatibility mode\r\n- Window Mode\r\n- D3D enabled\r\n\r\nIf you continue, then the game will have visual errors and not run stable.\r\nDo you want to continue?"
 END
 
 #endif    // English (U.S.) resources

--- a/jp2_pc/Source/Trespass/video.cpp
+++ b/jp2_pc/Source/Trespass/video.cpp
@@ -107,7 +107,7 @@ void CVideoWnd::NextNonDirect()
     CDDSize<DDSURFACEDESC2> dds;
     HRESULT                 hr;
 
-    pSurface = prasMainScreen->GetPrimarySurface();
+    pSurface = prasMainScreen->GetRenderTargetSurface();
     do
     {
         hr = pSurface->Lock(NULL, 
@@ -179,6 +179,10 @@ void CVideoWnd::NextNonDirect()
 
 void CVideoWnd::NextSmackerFrame()
 {
+    CDDSize<DDBLTFX> fx;
+    fx.dwFillColor = 0;
+    HRESULT blt = prasMainScreen->GetRenderTargetSurface()->Blt(nullptr, nullptr, nullptr, DDBLT_WAIT | DDBLT_COLORFILL, &fx);
+
     if (m_fDirect)
     {
         NextDirect();
@@ -187,6 +191,9 @@ void CVideoWnd::NextSmackerFrame()
     {
         NextNonDirect();
     }
+
+    prasMainScreen->Flip();
+
 
     if (m_pSmack->FrameNum == m_pSmack->Frames - 1)
     {


### PR DESCRIPTION
Support for 32bit color depth is introduced. (See issue #10). This makes it possible to run the game without forcing it into the 16bit color depth compatibility mode. However, support for 16bit remains active at this stage.
The change required is surprisingly simple. If we are in 32bit mode, then we force that the backbuffer is created with 16bit. When the buffers are flipped, DirectDraw's blitting automatically takes care of the color conversion.

The only configuration where this trick does not work is D3D mode combined with exclusive fullscreen mode, because here the backbuffer(s) are created indirectly. In this configuration, a warning message is displayed to the player at startup.

This adjustment breaks FMV rendering, screenshots and the pause menu background in certain configurations (usually 32bit + D3D), but all that is easily fixed.