### PR TITLE
Use override keyword

### DIFF
--- a/jp2_pc/Source/GUIApp/AI Dialogs2Dlg.h
+++ b/jp2_pc/Source/GUIApp/AI Dialogs2Dlg.h
@@ -26,7 +26,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAIDialogs2Dlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -35,11 +35,11 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CAIDialogs2Dlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnAll();
 	afx_msg void OnNone();
 	afx_msg void OnDblclkActivities();

--- a/jp2_pc/Source/GUIApp/Background.hpp
+++ b/jp2_pc/Source/GUIApp/Background.hpp
@@ -66,7 +66,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CBackground)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);
+	virtual void DoDataExchange(CDataExchange* pDX) override;
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/CameraProperties.hpp
+++ b/jp2_pc/Source/GUIApp/CameraProperties.hpp
@@ -60,7 +60,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CCameraProperties)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogAlphaColour.hpp
+++ b/jp2_pc/Source/GUIApp/DialogAlphaColour.hpp
@@ -57,7 +57,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogAlphaColour)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogBumpPack.hpp
+++ b/jp2_pc/Source/GUIApp/DialogBumpPack.hpp
@@ -85,7 +85,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogBumpPack)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 	int32		i4PageSelect;		// current selected bump map page or -1

--- a/jp2_pc/Source/GUIApp/DialogCulling.hpp
+++ b/jp2_pc/Source/GUIApp/DialogCulling.hpp
@@ -63,7 +63,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogCulling)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogDepthSort.hpp
+++ b/jp2_pc/Source/GUIApp/DialogDepthSort.hpp
@@ -78,7 +78,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogDepthSort)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogFog.hpp
+++ b/jp2_pc/Source/GUIApp/DialogFog.hpp
@@ -57,7 +57,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogFog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogGamma.hpp
+++ b/jp2_pc/Source/GUIApp/DialogGamma.hpp
@@ -23,7 +23,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogGamma)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -40,7 +40,7 @@ protected:
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg void OnClose();
-	virtual void OnOK();
+	virtual void OnOK() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/jp2_pc/Source/GUIApp/DialogGore.hpp
+++ b/jp2_pc/Source/GUIApp/DialogGore.hpp
@@ -22,7 +22,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogGore)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogGun.hpp
+++ b/jp2_pc/Source/GUIApp/DialogGun.hpp
@@ -62,7 +62,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogGun)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogMagnet.h
+++ b/jp2_pc/Source/GUIApp/DialogMagnet.h
@@ -50,8 +50,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogMagnet)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
-	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam);
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
+	virtual BOOL OnCommand(WPARAM wParam, LPARAM lParam) override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogMaterial.h
+++ b/jp2_pc/Source/GUIApp/DialogMaterial.h
@@ -53,7 +53,7 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void SetVal(T val)
+	virtual void SetVal(T val) override
 	//
 	// Converts the angle (in degrees) to a cosine.
 	//
@@ -62,7 +62,7 @@ protected:
 	}
 
 	//******************************************************************************************
-	virtual T tGetVal() const
+	virtual T tGetVal() const override
 	//
 	// Converts the cosine to an angle (in degrees).
 	//
@@ -109,7 +109,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogMaterial)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -134,7 +134,7 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void Update(CController& ctrl);
+	virtual void Update(CController& ctrl) override;
 };
 
 

--- a/jp2_pc/Source/GUIApp/DialogMemLog.hpp
+++ b/jp2_pc/Source/GUIApp/DialogMemLog.hpp
@@ -59,7 +59,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogTexturePack)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogMipmap.hpp
+++ b/jp2_pc/Source/GUIApp/DialogMipmap.hpp
@@ -21,7 +21,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogMipmap)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogObject.h
+++ b/jp2_pc/Source/GUIApp/DialogObject.h
@@ -72,7 +72,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogObject)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogOcclusion.hpp
+++ b/jp2_pc/Source/GUIApp/DialogOcclusion.hpp
@@ -45,7 +45,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogOcclusion)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogPartition.hpp
+++ b/jp2_pc/Source/GUIApp/DialogPartition.hpp
@@ -50,7 +50,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogPartition)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogPhysics.cpp
+++ b/jp2_pc/Source/GUIApp/DialogPhysics.cpp
@@ -143,14 +143,14 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual float fGet() const
+	virtual float fGet() const override
 	{
 		Assert(pfVar);
 		return *pfVar;
 	}
 
 	//******************************************************************************************
-	virtual void Set(float f)
+	virtual void Set(float f) override
 	{
 		Assert(pfVar);
 		*pfVar = f;
@@ -175,14 +175,14 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual float fGet() const
+	virtual float fGet() const override
 	{
 		Assert(pfVar);
 		return pphibBox ? pphibBox->*pfVar : 0.0;
 	}
 
 	//******************************************************************************************
-	virtual void Set(float f)
+	virtual void Set(float f) override
 	{
 		Assert(pfVar);
 		if (pphibBox)
@@ -207,7 +207,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual float fGet() const
+	virtual float fGet() const override
 	{
 		// Return calculated value.
 		if (CItemFloatBox::pphibBox)
@@ -220,7 +220,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual void Set(float f)
+	virtual void Set(float f) override
 	{
 		if (CItemFloatBox::pphibBox)
 		{

--- a/jp2_pc/Source/GUIApp/DialogPhysics.hpp
+++ b/jp2_pc/Source/GUIApp/DialogPhysics.hpp
@@ -113,7 +113,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogPhysics)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:
@@ -137,9 +137,9 @@ protected:
 	//{{AFX_MSG(CDialogPhysics)
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
-	virtual void OnOK();
+	virtual void OnOK() override;
 	afx_msg void OnReset();
-	virtual void OnCancel();
+	virtual void OnCancel() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/jp2_pc/Source/GUIApp/DialogPlayer.h
+++ b/jp2_pc/Source/GUIApp/DialogPlayer.h
@@ -101,7 +101,7 @@ public:
 	protected:
 	//}}AFX_VIRTUAL
 
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 
 // Implementation
 protected:

--- a/jp2_pc/Source/GUIApp/DialogRenderCache.hpp
+++ b/jp2_pc/Source/GUIApp/DialogRenderCache.hpp
@@ -38,7 +38,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogRenderCache)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogScheduler.hpp
+++ b/jp2_pc/Source/GUIApp/DialogScheduler.hpp
@@ -23,7 +23,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogScheduler)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogScrollbars.hpp
+++ b/jp2_pc/Source/GUIApp/DialogScrollbars.hpp
@@ -213,7 +213,7 @@ public:
 		int   i_steps = 100,	// Number of discrete steps the scrollbar uses.
 		int	  i_text_id = 0,	// Associated static text control for display.
 		CWnd* pwnd_dialog = 0	// Containing dialog.
-	)
+	) override
 	//
 	// Sets the scrollbar's internal values.
 	//
@@ -244,7 +244,7 @@ public:
 	(
 		float f_current_value,	// Current value of the parameter.
 		CWnd* pwnd_dialog = 0	// Containing dialog.
-	)
+	) override
 	//
 	// Sets the scrollbar to the specified value.
 	//
@@ -266,7 +266,7 @@ public:
 	virtual float fGet
 	(
 		CWnd* pwnd_dialog = 0			// Containing dialog.
-	)
+	) override
 	//
 	// Gets the value specified by the scrollbar.
 	//

--- a/jp2_pc/Source/GUIApp/DialogSky.hpp
+++ b/jp2_pc/Source/GUIApp/DialogSky.hpp
@@ -79,7 +79,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogSky)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogSoundMaterial.hpp
+++ b/jp2_pc/Source/GUIApp/DialogSoundMaterial.hpp
@@ -166,7 +166,7 @@ public:
 	void TestPlay(TSoundHandle sndhnd, bool b_loop);
 
 	//*****************************************************************************************
-	virtual void OnOK();
+	virtual void OnOK() override;
 
 	//*****************************************************************************************
 	//
@@ -224,7 +224,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogSoundMaterial)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 	//*****************************************************************************************

--- a/jp2_pc/Source/GUIApp/DialogString.hpp
+++ b/jp2_pc/Source/GUIApp/DialogString.hpp
@@ -60,7 +60,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogString)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogTeleport.h
+++ b/jp2_pc/Source/GUIApp/DialogTeleport.h
@@ -32,9 +32,9 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogTeleport)
 	public:
-	virtual BOOL Create(LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext = NULL);
+	virtual BOOL Create(LPCTSTR lpszClassName, LPCTSTR lpszWindowName, DWORD dwStyle, const RECT& rect, CWnd* pParentWnd, UINT nID, CCreateContext* pContext = NULL) override;
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -42,7 +42,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CDialogTeleport)
-	virtual void OnOK();
+	virtual void OnOK() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/jp2_pc/Source/GUIApp/DialogTerrain.hpp
+++ b/jp2_pc/Source/GUIApp/DialogTerrain.hpp
@@ -94,7 +94,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogTerrain)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/DialogTexturePack.hpp
+++ b/jp2_pc/Source/GUIApp/DialogTexturePack.hpp
@@ -62,7 +62,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogTexturePack)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogTexturePackOptions.hpp
+++ b/jp2_pc/Source/GUIApp/DialogTexturePackOptions.hpp
@@ -56,7 +56,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogTexturePackOptions)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogVM.hpp
+++ b/jp2_pc/Source/GUIApp/DialogVM.hpp
@@ -63,7 +63,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogVM)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/DialogWater.hpp
+++ b/jp2_pc/Source/GUIApp/DialogWater.hpp
@@ -52,7 +52,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogWater)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/GUIApp.cpp
+++ b/jp2_pc/Source/GUIApp/GUIApp.cpp
@@ -435,7 +435,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	BOOL OnInitDialog()
+	BOOL OnInitDialog() override
 	//
 	// Set the version and date strings.
 	//

--- a/jp2_pc/Source/GUIApp/GUIApp.h
+++ b/jp2_pc/Source/GUIApp/GUIApp.h
@@ -69,8 +69,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CGUIAppApp)
 	public:
-	virtual BOOL InitInstance();
-	virtual int ExitInstance();
+	virtual BOOL InitInstance() override;
+	virtual int ExitInstance() override;
 	//}}AFX_VIRTUAL
 
 	//{{AFX_MSG(CGUIAppApp)

--- a/jp2_pc/Source/GUIApp/GUIAppDlg.h
+++ b/jp2_pc/Source/GUIApp/GUIAppDlg.h
@@ -620,7 +620,7 @@ public:
 	void Process
 	(
 		const CMessageNewRaster& msgnewr
-	);
+	) override;
 	//
 	// Processes CMessageNewRaster messages.
 	//
@@ -738,12 +738,12 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CGUIAppDlg)
 	public:
-	virtual BOOL OnCmdMsg(UINT nID, int nCode, void* pExtra, AFX_CMDHANDLERINFO* pHandlerInfo);
-	virtual BOOL PreTranslateMessage(MSG* pMsg);
-	virtual BOOL DestroyWindow();
+	virtual BOOL OnCmdMsg(UINT nID, int nCode, void* pExtra, AFX_CMDHANDLERINFO* pHandlerInfo) override;
+	virtual BOOL PreTranslateMessage(MSG* pMsg) override;
+	virtual BOOL DestroyWindow() override;
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
-	virtual LRESULT DefWindowProc(UINT message, WPARAM wParam, LPARAM lParam);
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
+	virtual LRESULT DefWindowProc(UINT message, WPARAM wParam, LPARAM lParam) override;
 	//}}AFX_VIRTUAL
 
 
@@ -816,10 +816,10 @@ protected:
 
 	// Overridden from CInstance...
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char* pcLoad(const char* pc_buffer);
+	virtual const char* pcLoad(const char* pc_buffer) override;
 
 
 
@@ -852,7 +852,7 @@ protected:
 public:
 
 	//{{AFX_MSG(CGUIAppDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();
 	afx_msg int OnCreate(LPCREATESTRUCT lpCreateStruct);

--- a/jp2_pc/Source/GUIApp/GUIControls.hpp
+++ b/jp2_pc/Source/GUIApp/GUIControls.hpp
@@ -189,7 +189,7 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DDX(CDataExchange* pDX)
+	virtual void DDX(CDataExchange* pDX) override
 	{
 		::DDX_Control(pDX, iID, *this);
 		Display();
@@ -204,7 +204,7 @@ protected:
 	}
  */
 	//******************************************************************************************
-	virtual BOOL OnChildNotify( UINT message, WPARAM wParam, LPARAM lParam, LRESULT* pLResult )
+	virtual BOOL OnChildNotify( UINT message, WPARAM wParam, LPARAM lParam, LRESULT* pLResult ) override
 	{
 		// Dispatch messages.
 		if (message == WM_NOTIFY)
@@ -230,7 +230,7 @@ protected:
 
 	//******************************************************************************************
 	//
-	virtual void Display() const
+	virtual void Display() const override
 	//
 	// Display the current value.
 	//
@@ -298,7 +298,7 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual BOOL OnDeltaPos( NM_UPDOWN* pNMUpDown )
+	virtual BOOL OnDeltaPos( NM_UPDOWN* pNMUpDown ) override
 	{
 		//
 		// Handle spinner control.
@@ -353,7 +353,7 @@ protected:
 	}
 
 	//******************************************************************************************
-	virtual void Format(char str_text[]) const;
+	virtual void Format(char str_text[]) const override;
 };
 
 	//******************************************************************************************
@@ -404,7 +404,7 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual BOOL OnDeltaPos( NM_UPDOWN* pNMUpDown )
+	virtual BOOL OnDeltaPos( NM_UPDOWN* pNMUpDown ) override
 	{
 		if (MinMax == emmMIN)
 			tMin = *ptVarClamp * tDisplayFactor;

--- a/jp2_pc/Source/GUIApp/LightProperties.hpp
+++ b/jp2_pc/Source/GUIApp/LightProperties.hpp
@@ -83,7 +83,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CLightProperties)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/ParameterDlg.h
+++ b/jp2_pc/Source/GUIApp/ParameterDlg.h
@@ -45,7 +45,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CParameterDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 
@@ -54,9 +54,9 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CParameterDlg)
-	virtual BOOL OnInitDialog();
-	virtual void OnOK();
-	virtual void OnCancel();
+	virtual BOOL OnInitDialog() override;
+	virtual void OnOK() override;
+	virtual void OnCancel() override;
 	afx_msg void OnPaint();
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg void OnChangeEditParameter();

--- a/jp2_pc/Source/GUIApp/PerspectiveSubdivideDialog.hpp
+++ b/jp2_pc/Source/GUIApp/PerspectiveSubdivideDialog.hpp
@@ -63,7 +63,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CPerspectiveSubdivideDialog)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/GUIApp/QualityDialog.hpp
+++ b/jp2_pc/Source/GUIApp/QualityDialog.hpp
@@ -52,7 +52,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogQuality)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/SoundPropertiesDlg.hpp
+++ b/jp2_pc/Source/GUIApp/SoundPropertiesDlg.hpp
@@ -96,7 +96,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogSoundProp)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/GUIApp/TerrainTest.hpp
+++ b/jp2_pc/Source/GUIApp/TerrainTest.hpp
@@ -253,8 +253,8 @@ private:
 	// Overrides.
 	//
 
-	void Process(const CMessageStep&);
-	void Process(const CMessagePaint& msgpaint);
+	void Process(const CMessageStep&) override;
+	void Process(const CMessagePaint& msgpaint) override;
 };
 
 

--- a/jp2_pc/Source/GUIApp/Toolbar.hpp
+++ b/jp2_pc/Source/GUIApp/Toolbar.hpp
@@ -77,7 +77,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CTool)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 protected:

--- a/jp2_pc/Source/Game/AI/AIGraph.hpp
+++ b/jp2_pc/Source/Game/AI/AIGraph.hpp
@@ -201,7 +201,7 @@ public:
 		(
 			int i_parent,
 			int i_successor_maybe
-		);
+		) override;
 		//
 		//	Returns true if the second arg is a successor of the first.
 		//
@@ -749,7 +749,7 @@ public:
 	//
 
 		//*********************************************************************************
-		virtual void RemoveNode(int i_node_index);
+		virtual void RemoveNode(int i_node_index) override;
 
 		//*********************************************************************************
 		//
@@ -757,7 +757,7 @@ public:
 		(
 			int i_parent,
 			int i_successor_maybe
-		);
+		) override;
 		//
 		//	Returns true if the second arg is a successor of the first.
 		//
@@ -770,7 +770,7 @@ public:
 		virtual void AddNode
 		(
 			CAIGraphNode& node
-		);
+		) override;
 		//
 		//	Adds a node to the graph.
 		//

--- a/jp2_pc/Source/Game/AI/AIMain.hpp
+++ b/jp2_pc/Source/Game/AI/AIMain.hpp
@@ -654,7 +654,7 @@ public:
 		virtual void Process
 		(
 			const CMessageStep& ms
-		);
+		) override;
 		//
 		//	Runs the AI system for one cycle.
 		//
@@ -672,7 +672,7 @@ public:
 
 		//*********************************************************************************************
 		//
-		virtual void Process(const CMessagePaint& msgpaint);
+		virtual void Process(const CMessagePaint& msgpaint) override;
 		//
 		//	Draws any AI debugging info.
 		//
@@ -680,10 +680,10 @@ public:
 
 
 		//*****************************************************************************************
-		virtual char * pcSave(char *  pc_buffer) const;
+		virtual char * pcSave(char *  pc_buffer) const override;
 
 		//*****************************************************************************************
-		virtual const char * pcLoad(const char *  pc_buffer);
+		virtual const char * pcLoad(const char *  pc_buffer) override;
 
 
 

--- a/jp2_pc/Source/Game/AI/Activity.hpp
+++ b/jp2_pc/Source/Game/AI/Activity.hpp
@@ -1045,13 +1045,13 @@ public:
 	(
 		const CFeeling&	feel,		// The feeling used to evaluate the action.
 		CInfluence*		pinf		// The direct object of the action.
-	);
+	) override;
 	//
 	//******************************
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/Game/AI/ActivityAttack.hpp
+++ b/jp2_pc/Source/Game/AI/ActivityAttack.hpp
@@ -152,7 +152,7 @@ public:
 		(
 			const CFeeling&	feel,		// The feeling used to evaluate the action.
 			CInfluence*		pinf		// The direct object of the action.
-		);
+		) override;
 		//
 		//******************************
 		
@@ -162,7 +162,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Bite the influence.
 		//
@@ -170,7 +170,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 };
@@ -213,7 +213,7 @@ public:
 		(
 			const CFeeling&	feel,		// The feeling used to evaluate the action.
 			CInfluence*		pinf		// The direct object of the action.
-		);
+		) override;
 		//
 		//******************************
 		
@@ -223,7 +223,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Claw the influence.
 		//
@@ -231,7 +231,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 };
@@ -267,14 +267,14 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf);
+		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf) override;
 
 		//*****************************************************************************************
-		virtual void MaybeSetTargetLock(CInfluence *pinf);
+		virtual void MaybeSetTargetLock(CInfluence *pinf) override;
 	
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 };
@@ -318,7 +318,7 @@ public:
 		(
 			const CFeeling&	feel,		// The feeling used to evaluate the action.
 			CInfluence*		pinf		// The direct object of the action.
-		);
+		) override;
 		//
 		//******************************
 		
@@ -328,7 +328,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Ram.
 		//
@@ -349,7 +349,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 };
@@ -392,27 +392,27 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf);
+		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf) override;
 
 		//*************************************************************************************
-		virtual void Start(CInfluence* pinf);
+		virtual void Start(CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseOne(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseOne(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseTwo(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseTwo(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseThree(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseThree(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseFour(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseFour(CRating rt_importance,	CInfluence*	pinf) override;
 
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -455,30 +455,30 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf);
+		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf) override;
 
 		//*************************************************************************************
-		virtual void Start(CInfluence* pinf);
+		virtual void Start(CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual void Stop(CInfluence* pinf);
+		virtual void Stop(CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseOne(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseOne(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseTwo(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseTwo(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseThree(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseThree(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseFour(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseFour(CRating rt_importance,	CInfluence*	pinf) override;
 
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 };
@@ -530,7 +530,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Jump at foe and bite them as you get near.
 		//
@@ -538,7 +538,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 };
@@ -589,7 +589,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Jump on foe and stomp/claw them.
 		//
@@ -597,7 +597,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -627,7 +627,7 @@ public:
 
 		
 		//*********************************************************************************
-		virtual void SetHeadPoint(CInfluence*		pinf);
+		virtual void SetHeadPoint(CInfluence*		pinf) override;
 
 	//*****************************************************************************************
 	//
@@ -636,7 +636,7 @@ public:
 	
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -673,26 +673,26 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf);
+		virtual CRating rtRate(const CFeeling&	feel,	CInfluence*		pinf) override;
 
 		//*************************************************************************************
 		virtual void Start();
 
 		//*************************************************************************************
-		virtual void DoPhaseOne(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseOne(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseTwo(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseTwo(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseThree(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseThree(CRating rt_importance,	CInfluence*	pinf) override;
 
 		//*************************************************************************************
-		virtual void DoPhaseFour(CRating rt_importance,	CInfluence*	pinf);
+		virtual void DoPhaseFour(CRating rt_importance,	CInfluence*	pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -740,7 +740,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Grab target with mouth.
 		//
@@ -748,7 +748,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -797,7 +797,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Only works when Grabbing-  throw thing held in your mouth.
 		//
@@ -805,7 +805,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -853,7 +853,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 		//
 		//	Shake the thing held in your mouth, much as a dog does.
 		//
@@ -861,7 +861,7 @@ public:
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/Game/AI/ActivityCompound.hpp
+++ b/jp2_pc/Source/Game/AI/ActivityCompound.hpp
@@ -158,7 +158,7 @@ public:
 		(
 			CRating,			//rt_importance,	// The importance of the activity.
 			CInfluence*		//pinf			// The direct object of the action.
-		)
+		) override
 		//
 		//	
 		//	Notes:  
@@ -202,7 +202,7 @@ public:
 		//
 		virtual void ResetTempFlags
 		(
-		);
+		) override;
 		//
 		//******************************
 
@@ -212,7 +212,7 @@ public:
 		(
 			const CFeeling&	feel,		// The feeling used to evaluate the action.
 			CInfluence*		pinf		// The direct object of the action.
-		);
+		) override;
 		//
 		//	Rates and Registers the activity with the synthesizer.
 		//
@@ -228,7 +228,7 @@ public:
 		(
 			const CFeeling&	feel,		// The emotional state used to evaluate the action.
 			CInfluenceList*	pinfl		// All influences known.
-		);
+		) override;
 		//
 		//	Rates and Registers the activity with the synthesizer.
 		//
@@ -292,7 +292,7 @@ public:
 		(
 			const CFeeling&	feel_self,		// How the animal feels inside.
 			CInfluence*		pinf			// What influence we are analyzing.
-		);
+		) override;
 		//
 		//	Notes:
 		//		The CActivityDOSubBrain performs a bunch of internal processing on the 
@@ -309,7 +309,7 @@ public:
 		(
 			const CFeeling&	feel_self,		// How the animal feels inside.
 			CInfluence*		pinf			// What influence we are analyzing.
-		);
+		) override;
 		//
 		//	Notes:
 		//		Uses an adjusted feeling to determine the sub-activities ratings.
@@ -393,7 +393,7 @@ public:
 		(
 			const CFeeling&	feel,		// The feeling used to evaluate the action.
 			CInfluence*		pinf		// The direct object of the action.
-		);
+		) override;
 		//
 		//******************************
 
@@ -403,7 +403,7 @@ public:
 		(
 			const CFeeling&	feel,		// The emotional state used to evaluate the action.
 			CInfluenceList*	pinfl		// All influences known.
-		);
+		) override;
 		//
 		//******************************
 };
@@ -473,7 +473,7 @@ public:
 		(
 			const CFeeling&	feel,		// The feeling used to evaluate the action.
 			CInfluence*		pinf		// The direct object of the action.
-		);
+		) override;
 		//
 		//******************************
 
@@ -483,7 +483,7 @@ public:
 		(
 			const CFeeling&	feel,		// The emotional state used to evaluate the action.
 			CInfluenceList*	pinfl		// All influences known.
-		);
+		) override;
 		//
 		//******************************
 };

--- a/jp2_pc/Source/Game/AI/ActivityPhased.hpp
+++ b/jp2_pc/Source/Game/AI/ActivityPhased.hpp
@@ -153,7 +153,7 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance,	CInfluence*	pinf);
+		virtual void Act(CRating rt_importance,	CInfluence*	pinf) override;
 
 };
 

--- a/jp2_pc/Source/Game/AI/ActivityVocal.hpp
+++ b/jp2_pc/Source/Game/AI/ActivityVocal.hpp
@@ -122,14 +122,14 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 		
 		//*********************************************************************************
-		virtual void Act(CRating	rt_importance, CInfluence* pinf);
+		virtual void Act(CRating	rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -166,10 +166,10 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating	rt_importance, CInfluence* pinf);
+		virtual void Act(CRating	rt_importance, CInfluence* pinf) override;
 
 };
 
@@ -211,7 +211,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 };
 
@@ -248,10 +248,10 @@ public:
 	
 		
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating	rt_importance, CInfluence* pinf);
+		virtual void Act(CRating	rt_importance, CInfluence* pinf) override;
 
 };
 
@@ -287,10 +287,10 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence*	pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence*	pinf) override;
 		
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence*	pinf);
+		virtual void Act(CRating rt_importance, CInfluence*	pinf) override;
 
 };
 
@@ -329,7 +329,7 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 };
 
@@ -368,14 +368,14 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 		//*************************************************************************************
 		virtual CRating rtRate
 		(
 			const CFeeling&	feel,		// The feeling used to evaluate the action.
 			CInfluence*		pinf		// The direct object of the action.
-		);
+		) override;
 };
 
 

--- a/jp2_pc/Source/Game/AI/EmotionActivities.hpp
+++ b/jp2_pc/Source/Game/AI/EmotionActivities.hpp
@@ -69,11 +69,11 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -109,14 +109,14 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating	rt_importance, CInfluence* pinf);
+		virtual void Act(CRating	rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -150,11 +150,11 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -189,14 +189,14 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -229,11 +229,11 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -266,11 +266,11 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -303,11 +303,11 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -340,11 +340,11 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -377,14 +377,14 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/Game/AI/HeadActivities.hpp
+++ b/jp2_pc/Source/Game/AI/HeadActivities.hpp
@@ -100,11 +100,11 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -142,11 +142,11 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -183,11 +183,11 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -222,11 +222,11 @@ public:
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -257,18 +257,18 @@ public:
 	//
 	
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 		
 		//*********************************************************************************
 		virtual void Act
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -304,18 +304,18 @@ public:
 	
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 		
 		//*********************************************************************************
 		virtual void Act
 		(
 			CRating			rt_importance,
 			CInfluence*		pinf
-		);
+		) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -350,14 +350,14 @@ public:
 	//
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating	rt_importance, CInfluence* pinf);
+		virtual void Act(CRating	rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/Game/AI/Influence.hpp
+++ b/jp2_pc/Source/Game/AI/Influence.hpp
@@ -277,7 +277,7 @@ public:
 		virtual int iAddToGraph
 		(
 			CBrain* pbr	// Brain to which this influence belongs.
-		);
+		) override;
 		//
 		//	Adds nodes to the pathfinding graph based on shape of the target.
 		//
@@ -317,7 +317,7 @@ public:
 		//
 		virtual void CalculateNodeSuitability
 		(
-		);
+		) override;
 		//
 		//	Decides how important the influence is for node construction (pathfinding).
 		//
@@ -327,7 +327,7 @@ public:
 		//
 		virtual TReal rRateNodeSuitability
 		(
-		) const;
+		) const override;
 		//
 		//	Decided how important the influence is right now (based on rNodeSuitability).
 		//
@@ -352,7 +352,7 @@ public:
 		//
 		void ResetTemporaryFlags
 		(
-		);
+		) override;
 		//
 		//	Resets the flags which are short-lived.
 		//

--- a/jp2_pc/Source/Game/AI/MoveActivities.hpp
+++ b/jp2_pc/Source/Game/AI/MoveActivities.hpp
@@ -97,14 +97,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -143,14 +143,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -186,14 +186,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -234,14 +234,14 @@ public:
 	//
 
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -277,11 +277,11 @@ public:
 	//
 
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -313,14 +313,14 @@ public:
 	//
 
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -356,14 +356,14 @@ public:
 	//
 
 		//*********************************************************************************
-		virtual CRating rtRate(	const CFeeling&	feel,CInfluence*		pinf);
+		virtual CRating rtRate(	const CFeeling&	feel,CInfluence*		pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating			rt_importance,	CInfluence*		pinf);
+		virtual void Act(CRating			rt_importance,	CInfluence*		pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -403,20 +403,20 @@ public:
 	//
 
 		//*********************************************************************************
-		virtual CRating rtRate(	const CFeeling&	feel,CInfluence*		pinf);
+		virtual CRating rtRate(	const CFeeling&	feel,CInfluence*		pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating			rt_importance,	CInfluence*		pinf);
+		virtual void Act(CRating			rt_importance,	CInfluence*		pinf) override;
 
 		//*****************************************************************************************
-		virtual char * pcSave(char *  pc_buffer) const;
+		virtual char * pcSave(char *  pc_buffer) const override;
 
 		//*****************************************************************************************
-		virtual const char * pcLoad(const char *  pc_buffer);
+		virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -456,20 +456,20 @@ public:
 	//
 
 		//*********************************************************************************
-		virtual CRating rtRate(	const CFeeling&	feel,CInfluence*		pinf);
+		virtual CRating rtRate(	const CFeeling&	feel,CInfluence*		pinf) override;
 
 		//*********************************************************************************
-		virtual void Act(CRating			rt_importance,	CInfluence*		pinf);
+		virtual void Act(CRating			rt_importance,	CInfluence*		pinf) override;
 
 		//*****************************************************************************************
-		virtual char * pcSave(char *  pc_buffer) const;
+		virtual char * pcSave(char *  pc_buffer) const override;
 
 		//*****************************************************************************************
-		virtual const char * pcLoad(const char *  pc_buffer);
+		virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -505,14 +505,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -548,14 +548,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -596,14 +596,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -641,14 +641,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -684,14 +684,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -729,14 +729,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -772,14 +772,14 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -826,17 +826,17 @@ public:
 	//
 	
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence* pinf);
+		virtual void Act(CRating rt_importance, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf);
+		virtual CRating rtRate(const CFeeling&	feel, CInfluence* pinf) override;
 
 		//*************************************************************************************
-		virtual void Activate(bool b_active_state);
+		virtual void Activate(bool b_active_state) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/Game/AI/NodeHistory.hpp
+++ b/jp2_pc/Source/Game/AI/NodeHistory.hpp
@@ -276,7 +276,7 @@ public:
 	(
 		CAIGraph*,	//paig,			// The graph the node is in.
 		int			//i_node_index	// The index of the node.
-	)
+	) override
 	//
 	//******************************
 	{
@@ -289,7 +289,7 @@ public:
 	(
 		CAIGraphNode*,	//paig,		// The node to update.
 		TSec			//s_when_used // The time the node was used.
-	)
+	) override
 	//
 	//******************************
 	{
@@ -298,7 +298,7 @@ public:
 //
 //  Cast functions.
 //
-	virtual CNHStart*			pCastNHStart()			{ return this; };
+	virtual CNHStart*			pCastNHStart() override { return this; };
 };
 
 //*********************************************************************************************
@@ -333,7 +333,7 @@ public:
 	(
 		CAIGraph*,	//paig,			// The graph the node is in.
 		int			//i_node_index	// The index of the node.
-	)
+	) override
 	//
 	//	Examines aign to determine its importance.
 	//
@@ -352,7 +352,7 @@ public:
 	(
 		CAIGraphNode*,	//paig,		// The node to update.
 		TSec			//s_when_used // The time the node was used.
-	)
+	) override
 	//
 	//******************************
 	{
@@ -362,7 +362,7 @@ public:
 //  Cast functions.
 //
 
-	virtual CNHStop*			pCastNHStop()			{ return this; };
+	virtual CNHStop*			pCastNHStop() override { return this; };
 
 };
 
@@ -402,7 +402,7 @@ public:
 	(
 		CAIGraph*,	//paig,			// The graph the node is in.
 		int			//i_node_index	// The index of the node.
-	);
+	) override;
 	//******************************
 
 	//*************************************************************************************
@@ -411,7 +411,7 @@ public:
 	(
 		CAIGraph*	paig,			// The graph the node is in.
 		int			i_node_index	// The index of the node.
-	);
+	) override;
 	//******************************
 
 	//*************************************************************************************
@@ -420,16 +420,16 @@ public:
 	(
 		CAIGraphNode*	paig,		// The node to update.
 		TSec			s_when_used // The time the node was used.
-	);
+	) override;
 	//******************************
 
 	//*************************************************************************************
-	virtual CNodeSource* pnsReferences();
+	virtual CNodeSource* pnsReferences() override;
 
 //
 //  Cast functions.
 //
-	virtual CNHNodeSource*		pCastNHNodeSource()		{ return this; };
+	virtual CNHNodeSource*		pCastNHNodeSource() override { return this; };
 };
 
 #ifdef TRACK_OLD_NODES
@@ -532,7 +532,7 @@ public:
 	(
 		CAIGraph*,	//paig,			// The graph the node is in.
 		int			//i_node_index	// The index of the node.
-	);
+	) override;
 	//******************************
 
 	//*************************************************************************************
@@ -541,7 +541,7 @@ public:
 	(
 		CAIGraph*	paig,			// The graph the node is in.
 		int			i_node_index	// The index of the node.
-	);
+	) override;
 	//******************************
 
 	//*************************************************************************************
@@ -550,7 +550,7 @@ public:
 	(
 		CAIGraphNode*	paig,		// The node to update.
 		TSec			s_when_used // The time the node was used.
-	);
+	) override;
 	//******************************
 
 	//*************************************************************************************
@@ -558,15 +558,15 @@ public:
 	virtual bool bReferences
 	(
 		const CInstance*	pins
-	) const;
+	) const override;
 	//******************************
 
 	//*************************************************************************************
-	virtual CNodeSource* pnsReferences();
+	virtual CNodeSource* pnsReferences() override;
 //
 //  Cast functions.
 //
-	virtual CNHInfluence*		pCastNHInfluence()		{ return this; };
+	virtual CNHInfluence*		pCastNHInfluence() override { return this; };
 };
 
 #ifdef TRACK_OLD_NODES
@@ -676,7 +676,7 @@ public:
 	(
 		CAIGraph*,	//paig,			// The graph the node is in.
 		int			//i_node_index	// The index of the node.
-	);
+	) override;
 	//******************************
 
 	//*************************************************************************************
@@ -685,10 +685,10 @@ public:
 	(
 		CAIGraph*	paig,			// The graph the node is in.
 		int			i_node_index	// The index of the node.
-	);
+	) override;
 	//******************************
 
-	virtual CNHInfluenceSurface*pCastNHInfluenceSurface()	{ return this; };
+	virtual CNHInfluenceSurface*pCastNHInfluenceSurface() override { return this; };
 
 };
 
@@ -719,15 +719,15 @@ public:
 //
 
 	//*************************************************************************************
-	virtual float fRate(CAIGraph*	paig, int i_node_index);
+	virtual float fRate(CAIGraph*	paig, int i_node_index) override;
 
 	//*************************************************************************************
-	virtual void Delete(CAIGraph*	paig, int i_node_index);
+	virtual void Delete(CAIGraph*	paig, int i_node_index) override;
 
 //
 //  Cast functions.
 //
-	virtual CNHRandom*			pCastNHRandom()			{ return this; };
+	virtual CNHRandom*			pCastNHRandom() override { return this; };
 };
 
 //*********************************************************************************************
@@ -762,7 +762,7 @@ public:
 	(
 		CAIGraph*	paig,			// The graph the node is in.
 		int			i_node_index	// The index of the node.
-	)
+	) override
 	//
 	//	Examines aign to determine its importance.
 	//
@@ -784,7 +784,7 @@ public:
 	(
 		CAIGraph*	paig,			// The graph the node is in.
 		int			i_node_index	// The index of the node.
-	);
+	) override;
 	//
 	//	Updates any external data structs that need it when a node is deleted.
 	//
@@ -795,7 +795,7 @@ public:
 //
 //  Cast functions.
 //
-	virtual CNHDesigner*		pCastNHDesigner()		{ return this; };
+	virtual CNHDesigner*		pCastNHDesigner() override { return this; };
 };
 
 //*********************************************************************************************
@@ -826,14 +826,14 @@ public:
 	(
 		CAIGraph*,	//paig,			// The graph the node is in.
 		int			//i_node_index	// The index of the node.
-	);
+	) override;
 	//******************************
 
 //
 //  Cast functions.
 //
 	
-	virtual CNHUnknown*			pCastNHUnknown()		{ return this; };
+	virtual CNHUnknown*			pCastNHUnknown() override { return this; };
 };
 
 //*********************************************************************************************
@@ -866,7 +866,7 @@ public:
 //  Cast functions.
 //
 	
-	virtual CNHInvalid*			pCastNHInvalid()		{ return this; };
+	virtual CNHInvalid*			pCastNHInvalid() override { return this; };
 };
 
 #define ENTRY(type, name) char name [sizeof(type)]

--- a/jp2_pc/Source/Game/AI/PathAStar.hpp
+++ b/jp2_pc/Source/Game/AI/PathAStar.hpp
@@ -108,7 +108,7 @@ public:
 			CPath*				ppath,
 			CRating				rt_solidity, // The max solidity through which the dino will go
 			TReal				r_close_enough	// Accept a path bringing you this close to destination
-		);
+		) override;
 		//
 		//	Notes:
 		//		Assumes that the influence list is up to date, including target distaces,
@@ -128,7 +128,7 @@ public:
 			CVector2<>			v2_direction,	// Direction of travel.
 			CPath*				ppath,			// The path to be filled by the pathfinder.
 			CRating				rt_solidity // The max solidity through which the dino will go
-		);
+		) override;
 		//
 		//	Fills "ppath" with a path leading in the general direction "v2_direction".
 		//

--- a/jp2_pc/Source/Game/AI/TestActivities.hpp
+++ b/jp2_pc/Source/Game/AI/TestActivities.hpp
@@ -81,7 +81,7 @@ public:
 
 #if VER_TEST			
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 };
@@ -123,11 +123,11 @@ public:
 	//
 		
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance, CInfluence*		pinf);
+		virtual void Act(CRating rt_importance, CInfluence*		pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -163,11 +163,11 @@ public:
 	//
 		
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance,	CInfluence*	pinf);
+		virtual void Act(CRating rt_importance,	CInfluence*	pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -201,11 +201,11 @@ public:
 	//
 		
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance,	CInfluence*	pinf);
+		virtual void Act(CRating rt_importance,	CInfluence*	pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -243,11 +243,11 @@ public:
 	//
 		
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance,	CInfluence*	pinf);
+		virtual void Act(CRating rt_importance,	CInfluence*	pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 
@@ -284,11 +284,11 @@ public:
 	//
 		
 		//*********************************************************************************
-		virtual void Act(CRating rt_importance,	CInfluence*	pinf);
+		virtual void Act(CRating rt_importance,	CInfluence*	pinf) override;
 
 #if VER_TEST
 		//*****************************************************************************************
-		virtual int iGetDescription(char *buffer, int i_buffer_length);
+		virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/Game/DesignDaemon/BloodSplat.hpp
+++ b/jp2_pc/Source/Game/DesignDaemon/BloodSplat.hpp
@@ -122,13 +122,13 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Process(const CMessageSystem& ms);
+	virtual void Process(const CMessageSystem& ms) override;
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 };
 
 // Single global instance.

--- a/jp2_pc/Source/Game/DesignDaemon/Daemon.hpp
+++ b/jp2_pc/Source/Game/DesignDaemon/Daemon.hpp
@@ -178,7 +178,7 @@ public:
 	// Overrides.
 	//
 
-	void Process(const CMessagePaint& msgpaint);
+	void Process(const CMessagePaint& msgpaint) override;
 };
 
 // Single global instance.

--- a/jp2_pc/Source/Game/DesignDaemon/Gun.hpp
+++ b/jp2_pc/Source/Game/DesignDaemon/Gun.hpp
@@ -158,36 +158,36 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual bool bUse(bool b_repeat);
+	virtual bool bUse(bool b_repeat) override;
 
 	//*****************************************************************************************
-	virtual void PickedUp();
+	virtual void PickedUp() override;
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageMove& msg);
+	virtual void Process(const CMessageMove& msg) override;
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageStep& msg);
+	virtual void Process(const CMessageStep& msg) override;
 
 	//*****************************************************************************************
-	virtual CInstance* pinsCopy() const;
+	virtual CInstance* pinsCopy() const override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
-	virtual void Cast(CGun** ppgun)
+	virtual void Cast(CGun** ppgun) override
 	{
 		*ppgun = this;
 	}
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 	//*****************************************************************************************
 	// Return true if all referenced names are loaded, otherwise return false to prevent the
@@ -236,7 +236,7 @@ public:
 	static void ResetMuzzleFlash();
 
 	//*****************************************************************************************
-	virtual bool bCanHaveChildren();
+	virtual bool bCanHaveChildren() override;
 
 //	CInstance* pinsCopy() const;
 

--- a/jp2_pc/Source/Game/DesignDaemon/Player.cpp
+++ b/jp2_pc/Source/Game/DesignDaemon/Player.cpp
@@ -1246,7 +1246,7 @@ private:
 		const CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
-	)
+	) override
 	{
 		// Woo.  Hellish.
 		Assert(!pinfo);
@@ -1371,7 +1371,7 @@ private:
 		const CHandle&			h_object,	// handle of object in value table.
 		CValueTable*			pvtable,	// Value Table.
 		const CInfo*			pinfo		// The info to copy.  Create a new one if 0.
-	)
+	) override
 	{
 
 #define PARSE_SAMPLE_SET(ss)\
@@ -1593,13 +1593,13 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual CInstance* pinsHeldObject() const
+	virtual CInstance* pinsHeldObject() const override
 	{
 		return bWithin(eHandHolding, ehhHOLDING, ehhDROPPING) ? pinsHeld : 0;
 	}
 	
 	//*****************************************************************************************
-	virtual bool bHandInteract(const CInstance* pins) const
+	virtual bool bHandInteract(const CInstance* pins) const override
 	{
 		if (eHandActivity == ehaINACTIVE && eHandHolding < ehhHOLDING)
 			// Hand is inactive, and thus interacts with NOTHING, do you hear?
@@ -1614,7 +1614,7 @@ private:
 	}
 	
 	//*****************************************************************************************
-	virtual void MaybeTalkAboutAmmo(int i_current, int i_max)
+	virtual void MaybeTalkAboutAmmo(int i_current, int i_max) override
   	{
 		// Bad, Bad, Bad, No negative ammo counts please.
 		if (i_current < 0)
@@ -1641,7 +1641,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void TalkAboutApproximateAmmo(int i_sample)
+	virtual void TalkAboutApproximateAmmo(int i_sample) override
   	{
 		// ALWAYS say approximates, because they happen so rarely.
 
@@ -1670,7 +1670,7 @@ private:
 		int i_current, 
 		int i_maximum, 
 		bool b_approximate
-	)
+	) override
 	{
 		// Bad, Bad, Bad, No negative ammo counts please.
 		if (i_current < 0)
@@ -1731,7 +1731,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual bool bCanTalk()
+	virtual bool bCanTalk() override
 	{
 	    // Is Anne already speaking?
 		Assert(padAudioDaemon);
@@ -1746,7 +1746,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void StopTalking()
+	virtual void StopTalking() override
 	{
 		// Kill all voiceovers and music.
 		AlwaysAssert(padAudioDaemon);
@@ -1764,13 +1764,13 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void JumpSound()
+	virtual void JumpSound() override
 	{
 		Say(&ssJump);
 	}
 
 	//*****************************************************************************************
-	virtual void Pickup(CInstance* pins_obj)
+	virtual void Pickup(CInstance* pins_obj) override
 	{
 		// If there is a preference, set the hand mesh.
 		// Must be done before magneting, so new hand box takes effect.
@@ -1814,7 +1814,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Drop(CVector3<> v3_throw = v3Zero)
+	virtual void Drop(CVector3<> v3_throw = v3Zero) override
 	{
 		// See if we're holding.
 		if (!bWithin(eHandHolding, ehhHOLDING, ehhDROPPING))
@@ -1883,7 +1883,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void CheckForDrop()
+	virtual void CheckForDrop() override
 	{
 		// See if we're holding.
 		if (!PlayerSettings.bAllowDrop)
@@ -1926,7 +1926,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void DrawPhysics(CDraw& draw, CCamera& cam) const
+	virtual void DrawPhysics(CDraw& draw, CCamera& cam) const override
 	{
 #if bVER_BONES()
 		CTransform3<> tf3_screen = cam.tf3ToHomogeneousScreen();
@@ -1972,13 +1972,13 @@ private:
 	//
 
 	//*****************************************************************************************
-	virtual bool bIncludeInBuildPart() const
+	virtual bool bIncludeInBuildPart() const override
 	{
 		return false;
 	}
 
 	//*****************************************************************************************
-	virtual void HandleDamage(float f_damage, const CInstance* pins_aggressor, const CInstance* pins_me)
+	virtual void HandleDamage(float f_damage, const CInstance* pins_aggressor, const CInstance* pins_me) override
 	{
 		// What were my hit points before?
 		Assert(fMaxHitPoints > 0.0f);
@@ -2086,7 +2086,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual float fWieldDamage(const CInstance* pins_weapon, float f_coll_damage) const
+	virtual float fWieldDamage(const CInstance* pins_weapon, float f_coll_damage) const override
 	{
 		if (iSwinging == 2)
 			f_coll_damage *= PlayerSettings.fSwingDamageMul;
@@ -2094,7 +2094,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Substitute(int i_sub)
+	virtual void Substitute(int i_sub) override
 	{
 		// Save our requested substitution.
 		// Actually perform the substitution next control message.
@@ -2107,7 +2107,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3HeadPlacement() const
+	virtual CPlacement3<> p3HeadPlacement() const override
 	{
 		return p3Head;
 	}
@@ -2118,7 +2118,7 @@ private:
 	//
 
 	//******************************************************************************************
-	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender)
+	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender) override
 	{
 		if (pet_sender == pphSystem)
 		{
@@ -2223,7 +2223,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageSystem& msgsys)
+	virtual void Process(const CMessageSystem& msgsys) override
 	{
 		if (msgsys.escCode == escSTOP_SIM)
 		{
@@ -2240,7 +2240,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageStep& msgstep)
+	virtual void Process(const CMessageStep& msgstep) override
 	{
 		// Invoke base class message handling.
 		CAnimate::Process(msgstep);
@@ -2334,7 +2334,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageControl& msgc)
+	virtual void Process(const CMessageControl& msgc) override
 	{
 		bool b_use = false;
 
@@ -3108,7 +3108,7 @@ private:
 	}
 
 	//******************************************************************************************
-	virtual void Process(const CMessageCollision& msgcoll)
+	virtual void Process(const CMessageCollision& msgcoll) override
 	{
 		CTimeBlock tmb(&psCollisionMsgPlayer);
 
@@ -3197,7 +3197,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Process(const CMessagePhysicsReq& msgpr)
+	virtual void Process(const CMessagePhysicsReq& msgpr) override
 	{
 		if (!bPhysics)
 			return;
@@ -3237,7 +3237,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageMove& msgmv)
+	virtual void Process(const CMessageMove& msgmv) override
 	{
 		CTimeBlock tmb(&psMoveMsgPlayer);
 
@@ -3269,7 +3269,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual char* pcSave(char* pc) const
+	virtual char* pcSave(char* pc) const override
 	{
 		// Save the instance location data.
 		pc = CAnimate::pcSave(pc);
@@ -3316,7 +3316,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual const char* pcLoad(const char* pc)
+	virtual const char* pcLoad(const char* pc) override
 	{
 		pc = CAnimate::pcLoad(pc);
 
@@ -3388,7 +3388,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void Cast(CPlayer** ppplay)
+	virtual void Cast(CPlayer** ppplay) override
 	{
 		*ppplay = this;
 	}
@@ -3397,7 +3397,7 @@ private:
 	//
 	virtual const char* strPartType
 	(
-	) const
+	) const override
 	//
 	// Returns a partition type string.
 	//
@@ -3407,7 +3407,7 @@ private:
 	}
 
 	//*****************************************************************************************
-	virtual void InitializeDataStatic()
+	virtual void InitializeDataStatic() override
 	{
 		SetFlagHardwareAble(true);
 		CPartition::InitializeDataStatic();

--- a/jp2_pc/Source/Game/DesignDaemon/Socket.hpp
+++ b/jp2_pc/Source/Game/DesignDaemon/Socket.hpp
@@ -85,16 +85,16 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual bool bUse(bool b_repeat);
+	virtual bool bUse(bool b_repeat) override;
 
 	//*****************************************************************************************
-	virtual void PickedUp();
+	virtual void PickedUp() override;
 
 	//*****************************************************************************************
-	virtual CInstance* pinsCopy() const;
+	virtual CInstance* pinsCopy() const override;
 
 	//*****************************************************************************************
-	virtual void Cast(CSocket** psock)
+	virtual void Cast(CSocket** psock) override
 	{
 		*psock = this;
 	}
@@ -102,7 +102,7 @@ public:
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/GroffBuild/dialogs.h
+++ b/jp2_pc/Source/GroffBuild/dialogs.h
@@ -62,7 +62,7 @@ public:
     virtual ~CMultiWnd() {;}
 
 protected:
-    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) override;
 };
 
 
@@ -83,10 +83,10 @@ public:
     virtual void    OnOK();
 
 protected:
-    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) override;
 
-    virtual void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify);
-    virtual BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam);
+    virtual void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify) override;
+    virtual BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam) override;
 };
 
 

--- a/jp2_pc/Source/GroffBuild/main.h
+++ b/jp2_pc/Source/GroffBuild/main.h
@@ -63,13 +63,13 @@ public:
     HWND        m_hwndList;
 
 protected:
-    void OnClose(HWND hwnd);
-    void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify);
-    void OnDestroy(HWND hwnd);
-    BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam);
-    LRESULT OnNotify(HWND hwnd, int idCtrl, LPNMHDR pnmhdr);
-    void OnParentNotify(HWND hwnd, UINT msg, HWND hwndChild, int idChild);
-    void OnDropFiles(HWND hwnd, HDROP hdrop);
+    void OnClose(HWND hwnd) override;
+    void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify) override;
+    void OnDestroy(HWND hwnd) override;
+    BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam) override;
+    LRESULT OnNotify(HWND hwnd, int idCtrl, LPNMHDR pnmhdr) override;
+    void OnParentNotify(HWND hwnd, UINT msg, HWND hwndChild, int idChild) override;
+    void OnDropFiles(HWND hwnd, HDROP hdrop) override;
 };
 
 
@@ -85,8 +85,8 @@ public:
     std::vector<GBUILD>  m_vGBuild;
 
 protected:
-    void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify);
-    BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam);
+    void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify) override;
+    BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam) override;
 };
 
 

--- a/jp2_pc/Source/InitGUIApp/InitGUIApp.h
+++ b/jp2_pc/Source/InitGUIApp/InitGUIApp.h
@@ -21,7 +21,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CInitGUIAppApp)
 	public:
-	virtual BOOL InitInstance();
+	virtual BOOL InitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/InitGUIApp/InitGUIAppDlg.cpp
+++ b/jp2_pc/Source/InitGUIApp/InitGUIAppDlg.cpp
@@ -40,7 +40,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/InitGUIApp/InitGUIAppDlg.h
+++ b/jp2_pc/Source/InitGUIApp/InitGUIAppDlg.h
@@ -25,7 +25,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CInitGUIAppDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -39,11 +39,11 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CInitGUIAppDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();
-	virtual void OnOK();
+	virtual void OnOK() override;
 	afx_msg void OnSelchangeComboVideoguid();
 	afx_msg void OnSelchangeComboD3d();
 	afx_msg void OnSelchangeListCard();

--- a/jp2_pc/Source/InitGUIApp2/InitGUIApp2.h
+++ b/jp2_pc/Source/InitGUIApp2/InitGUIApp2.h
@@ -21,7 +21,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CInitGUIApp2App)
 	public:
-	virtual BOOL InitInstance();
+	virtual BOOL InitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/InitGUIApp2/InitGUIApp2Dlg.h
+++ b/jp2_pc/Source/InitGUIApp2/InitGUIApp2Dlg.h
@@ -20,7 +20,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CInitGUIApp2Dlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -29,10 +29,10 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CInitGUIApp2Dlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();
-	virtual void OnOK();
+	virtual void OnOK() override;
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
 	afx_msg void OnCheckStuffChildren();

--- a/jp2_pc/Source/Lib/Audio/AudioADPCM.hpp
+++ b/jp2_pc/Source/Lib/Audio/AudioADPCM.hpp
@@ -103,37 +103,37 @@ protected:
 	//
 	// Output Mono 8 Bit data, the u4_byte count will be a multiple of 1
 	//
-	virtual uint32 u4DecompressMono8bit(uint8* pu1_dst, uint32 u4_byte_count);
+	virtual uint32 u4DecompressMono8bit(uint8* pu1_dst, uint32 u4_byte_count) override;
 
 
 	//******************************************************************************************
 	// Output Mono 16 Bit data, the u4_byte count will be a multiple of 2
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual uint32 u4DecompressMono16bit(uint8* pu1_dst, uint32 u4_byte_count);
+	virtual uint32 u4DecompressMono16bit(uint8* pu1_dst, uint32 u4_byte_count) override;
 
 	//******************************************************************************************
 	// Output Stereo 8 Bit data, the u4_byte count will be a multiple of 2
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual uint32 u4DecompressStereo8bit(uint8* pu1_dst, uint32 u4_byte_count);
+	virtual uint32 u4DecompressStereo8bit(uint8* pu1_dst, uint32 u4_byte_count) override;
 
 	//******************************************************************************************
 	// Output Stereo 16 Bit data, the u4_byte count will be a multiple of 4
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual uint32 u4DecompressStereo16bit(uint8* pu1_dst, uint32 u4_byte_count);
+	virtual uint32 u4DecompressStereo16bit(uint8* pu1_dst, uint32 u4_byte_count) override;
 
 	//******************************************************************************************
 	// Set the base address and size of the current block that is avaliable for decompressing
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual void SetSampleSource(uint8* pu1_src, uint32 u4_src_len);
+	virtual void SetSampleSource(uint8* pu1_src, uint32 u4_src_len) override;
 
 	//******************************************************************************************
 	// get the number of bytes remaining in the current block, or 0 if none.
 	//
-	virtual uint32 u4GetRemainingData();
+	virtual uint32 u4GetRemainingData() override;
 };
 
 

--- a/jp2_pc/Source/Lib/Audio/AudioDaemon.hpp
+++ b/jp2_pc/Source/Lib/Audio/AudioDaemon.hpp
@@ -361,17 +361,17 @@ public:
 	//******************************************************************************************
 	// The messages that we respond to.
 	//
-	void Process(const CMessageStep& msg_step);
-	void Process(const CMessageMove& msg);
-	void Process(const CMessageCollision& msg);
-	void Process(const CMessageAudio& msg_audio);
-	void Process(const CMessageSystem& msg);
+	void Process(const CMessageStep& msg_step) override;
+	void Process(const CMessageMove& msg) override;
+	void Process(const CMessageCollision& msg) override;
+	void Process(const CMessageAudio& msg_audio) override;
+	void Process(const CMessageSystem& msg) override;
 
 	//*****************************************************************************************
-	char* pcSave(char*  pc) const;
+	char* pcSave(char*  pc) const override;
 
 	//*****************************************************************************************
-	const char* pcLoad(const char*  pc);
+	const char* pcLoad(const char*  pc) override;
 
 	//*****************************************************************************************
 	char *pcSaveSample
@@ -390,7 +390,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	void SaveDefaults();
+	void SaveDefaults() override;
 	//
 	// Save the default values of the user modifiable settings.
 	//
@@ -398,7 +398,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	void RestoreDefaults();
+	void RestoreDefaults() override;
 	//
 	// Restore the default values of the user modifiable settings.
 	//

--- a/jp2_pc/Source/Lib/Audio/AudioPCM.hpp
+++ b/jp2_pc/Source/Lib/Audio/AudioPCM.hpp
@@ -90,7 +90,7 @@ protected:
 	//
 	// Output Mono 8 Bit data, the u4_byte count will be a multiple of 1
 	//
-	virtual uint32 u4DecompressMono8bit(uint8* pu1_dst, uint32 u4_byte_count)
+	virtual uint32 u4DecompressMono8bit(uint8* pu1_dst, uint32 u4_byte_count) override
 	{
 		uint32	u4_bytes;
 
@@ -109,7 +109,7 @@ protected:
 	// Output Mono 16 Bit data, the u4_byte count will be a multiple of 2
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual uint32 u4DecompressMono16bit(uint8* pu1_dst, uint32 u4_byte_count)
+	virtual uint32 u4DecompressMono16bit(uint8* pu1_dst, uint32 u4_byte_count) override
 	{
 		uint32	u4_bytes;
 
@@ -128,7 +128,7 @@ protected:
 	// Output Stereo 8 Bit data, the u4_byte count will be a multiple of 2
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual uint32 u4DecompressStereo8bit(uint8* pu1_dst, uint32 u4_byte_count)
+	virtual uint32 u4DecompressStereo8bit(uint8* pu1_dst, uint32 u4_byte_count) override
 	{
 		uint32	u4_bytes;
 
@@ -147,7 +147,7 @@ protected:
 	// Output Stereo 16 Bit data, the u4_byte count will be a multiple of 4
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual uint32 u4DecompressStereo16bit(uint8* pu1_dst, uint32 u4_byte_count)
+	virtual uint32 u4DecompressStereo16bit(uint8* pu1_dst, uint32 u4_byte_count) override
 	{
 		uint32	u4_bytes;
 
@@ -166,7 +166,7 @@ protected:
 	// Set the base address and size of the current block that is avaliable for decompressing
 	// Returns the number of bytes put into the output buffer
 	//
-	virtual void SetSampleSource(uint8* pu1_src, uint32 u4_src_len)
+	virtual void SetSampleSource(uint8* pu1_src, uint32 u4_src_len) override
 	{
 		pu1SourceData		= pu1_src;
 		u4SourceDataSize	= u4_src_len;
@@ -175,7 +175,7 @@ protected:
 	//******************************************************************************************
 	// get the number of bytes remaining in the current block, or 0 if none.
 	//
-	virtual uint32 u4GetRemainingData()
+	virtual uint32 u4GetRemainingData() override
 	{
 		return u4SourceDataSize;
 	}

--- a/jp2_pc/Source/Lib/Control/Control.hpp
+++ b/jp2_pc/Source/Lib/Control/Control.hpp
@@ -193,8 +193,8 @@ public:
 	//
 	//	Message that we need to process
 	//
-	void Process(const CMessageStep& msg_step);
-	void Process(const CMessageSystem& msg_system);
+	void Process(const CMessageStep& msg_step) override;
+	void Process(const CMessageSystem& msg_system) override;
 
 	// start and stop input capture, initial state is not captured
 	void Capture(bool b_state = true);

--- a/jp2_pc/Source/Lib/EntityDBase/Animal.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Animal.hpp
@@ -193,14 +193,14 @@ public:
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 
 	//
@@ -211,56 +211,56 @@ public:
 	virtual void PreRender
 	(
 		CRenderContext& renc			// Target, camera, settings, etc.
-	);
+	) override;
 
 	//******************************************************************************************
 	virtual void Process
 	(
 		const CMessagePhysicsReq& msgpr
-	);
+	) override;
 
 	//lint -save -e1411
 	//******************************************************************************************
 	virtual void Process
 	(
 		const CMessageCollision& msgcoll
-	);
+	) override;
 
 	//******************************************************************************************
 	virtual void Process
 	(
 		const CMessageMove& msgmv
-	);
+	) override;
 
 	//******************************************************************************************
 	virtual void Process
 	(
 		const CMessageDelete& msgdel
-	);
+	) override;
 
 	//******************************************************************************************
 	virtual void Process
 	(
 		const CMessageDeath& msgdeath
-	);
+	) override;
 
 	//*****************************************************************************************
 	virtual void HandleDamage
 	(
 		float f_damage, const CInstance* pins_aggressor = 0, const CInstance* pins_me = 0
-	);
+	) override;
 
 	//*****************************************************************************************
 	virtual CInstance* pinsCopy
 	(
-	) const;		// Makes a copy of this
+	) const override;		// Makes a copy of this
 
 	//
 	// Identifier functions.
 	//
 
 	//*****************************************************************************************
-	virtual void Cast(CAnimal** ppani)
+	virtual void Cast(CAnimal** ppani) override
 	{
 		*ppani = this;
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/Animate.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Animate.hpp
@@ -296,7 +296,7 @@ public:
 	//
 	virtual bool bCanHaveChildren
 	(
-	);
+	) override;
 	//
 	// Returns 'false.'
 	//
@@ -430,27 +430,27 @@ public:
 
 
 	//*****************************************************************************************
-	virtual int iGetTeam() const;
+	virtual int iGetTeam() const override;
 
 	//*****************************************************************************************
-	virtual const CAnimate* paniGetOwner() const;
+	virtual const CAnimate* paniGetOwner() const override;
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvBoundingVol() const;
+	virtual const CBoundVol* pbvBoundingVol() const override;
 
 	//*****************************************************************************************
-	virtual CInstance* pinsCopy() const;
+	virtual CInstance* pinsCopy() const override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 	//
 	// Message processing overrides.
@@ -461,31 +461,31 @@ public:
 	(
 		const CPlacement3<>& p3_new,
 		CEntity* pet_sender = 0
-	);
+	) override;
 
 	//******************************************************************************************
 	virtual void Process
 	(
 		const CMessagePhysicsReq& msgpr
-	);
+	) override;
 
 	//*****************************************************************************************
 	virtual void Process
 	(
 		const CMessageCollision& msgcoll	// A collision event.
-	);
+	) override;
 
 	//*****************************************************************************************
 	virtual void PreRender
 	(
 		CRenderContext& renc			// Target, camera, settings, etc.
-	);
+	) override;
 
 	//******************************************************************************************
 	virtual void Process
 	(
 		const CMessageStep& msgstep
-	);
+	) override;
 
 	//
 	// Identifier functions.
@@ -493,7 +493,7 @@ public:
 
 	//*****************************************************************************************
 	//lint -save -e1411
-	virtual void Cast(CAnimate** ppant)
+	virtual void Cast(CAnimate** ppant) override
 	{
 		*ppant = this;
 	}
@@ -589,15 +589,15 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual int iGetTeam() const;
+	virtual int iGetTeam() const override;
 
 	//*****************************************************************************************
-	virtual const CAnimate* paniGetOwner() const;
+	virtual const CAnimate* paniGetOwner() const override;
 
 	//*****************************************************************************************
-	virtual CInstance* pinsCopy() const;
+	virtual CInstance* pinsCopy() const override;
 
-	virtual void Cast(CBoundaryBox** ppbb)
+	virtual void Cast(CBoundaryBox** ppbb) override
 	{
 		*ppbb = this;
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/AnimationScript.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/AnimationScript.hpp
@@ -255,13 +255,13 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageStep&);
+	virtual void Process(const CMessageStep&) override;
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 };
 
 // Single global instance.

--- a/jp2_pc/Source/Lib/EntityDBase/CameraPrime.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/CameraPrime.hpp
@@ -83,8 +83,8 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual void Process(const CMessagePaint&);
-	virtual void Process(const CMessageSystem&);
+	virtual void Process(const CMessagePaint&) override;
+	virtual void Process(const CMessageSystem&) override;
 };
 
 // Single global instance.

--- a/jp2_pc/Source/Lib/EntityDBase/Entity.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Entity.hpp
@@ -185,14 +185,14 @@ public:
 	//
 
 	//lint -save -e1411
-	virtual void Cast(CEntity** ppet)
+	virtual void Cast(CEntity** ppet) override
 	{
 		*ppet = this;
 	}
 	//lint -restore
 
 	//*****************************************************************************************
-	virtual const char* strPartType() const;
+	virtual const char* strPartType() const override;
 };
 
 
@@ -287,20 +287,20 @@ public:
 	// Overrides.
 	//
 
-	void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0);
+	void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0) override;
 
 	// Respond to move messages by moving myself if my parent moves.
-	void Process(const CMessageMove& msgmove);
+	void Process(const CMessageMove& msgmove) override;
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 
 	//*****************************************************************************************
-	virtual const char* strPartType() const;
+	virtual const char* strPartType() const override;
 
 //protected:
 	// How can we update attached guys when we aren't in run mode if this is protected?

--- a/jp2_pc/Source/Lib/EntityDBase/EntityLight.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/EntityLight.hpp
@@ -81,10 +81,10 @@ public:
 	//
 
 	// Invalidate shadow buffer when objects added.
-	void Process(const CMessageCreate& msgcreate);  //lint !e1411  //Yes, this had the same name as other functions.
+	void Process(const CMessageCreate& msgcreate) override;  //lint !e1411  //Yes, this had the same name as other functions.
 
 	// Invalidate shadow buffer when I myself am moved.
-	void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0);
+	void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0) override;
 
 	//******************************************************************************************
 	//
@@ -107,25 +107,25 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual bool bIncludeInBuildPart() const
+	virtual bool bIncludeInBuildPart() const override
 	{
 		return false;
 	}
 
 	//*****************************************************************************************
-	virtual bool bCanHaveChildren()
+	virtual bool bCanHaveChildren() override
 	{
 		return false;
 	}
 
 	//*****************************************************************************************
-	virtual const char* strPartType() const;
+	virtual const char* strPartType() const override;
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 
 };

--- a/jp2_pc/Source/Lib/EntityDBase/Instance.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Instance.hpp
@@ -784,61 +784,61 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual float fDistanceFromGlobalCameraSqr() const;
+	virtual float fDistanceFromGlobalCameraSqr() const override;
 
 	//*****************************************************************************************
-	virtual CPresence3<> pr3Presence() const;
+	virtual CPresence3<> pr3Presence() const override;
 
 	//*****************************************************************************************
-	virtual void SetPresence(const CPresence3<> &pr3);
+	virtual void SetPresence(const CPresence3<> &pr3) override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3Placement() const;
+	virtual CPlacement3<> p3Placement() const override;
 
 	//*****************************************************************************************
-	virtual void SetPlacement(const CPlacement3<> &p3);
+	virtual void SetPlacement(const CPlacement3<> &p3) override;
 
 	//*****************************************************************************************
-	virtual CVector3<> v3Pos() const;
+	virtual CVector3<> v3Pos() const override;
 	
 	//*****************************************************************************************
-	virtual void SetPos(const CVector3<>& v3_pos);
+	virtual void SetPos(const CVector3<>& v3_pos) override;
 
 	//*****************************************************************************************
-	virtual CRotate3<> r3Rot() const;
+	virtual CRotate3<> r3Rot() const override;
 	
 	//*****************************************************************************************
-	virtual void SetRot(const CRotate3<>& r3_rot);
+	virtual void SetRot(const CRotate3<>& r3_rot) override;
 
 	//*****************************************************************************************
-	virtual float fGetScale() const;
+	virtual float fGetScale() const override;
 
 	//*****************************************************************************************
-	virtual void SetScale(float f_new_scale);
+	virtual void SetScale(float f_new_scale) override;
 
 	//*****************************************************************************************
-	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0);
+	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0) override;
 
 	//*****************************************************************************************
-	virtual rptr_const<CRenderType> prdtGetRenderType() const;
+	virtual rptr_const<CRenderType> prdtGetRenderType() const override;
 
 	//*****************************************************************************************
-	virtual rptr<CShape> pshGetShape() const;
+	virtual rptr<CShape> pshGetShape() const override;
 
 	//*****************************************************************************************
-	virtual rptr<CMesh> pmshGetMesh() const;
+	virtual rptr<CMesh> pmshGetMesh() const override;
 
 	//*****************************************************************************************
-	virtual bool bContainsMovingObject() const;
+	virtual bool bContainsMovingObject() const override;
 
 	//*****************************************************************************************
-	virtual void Cast(CInstance** ppins)
+	virtual void Cast(CInstance** ppins) override
 	{
 		*ppins = this;
 	}
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvBoundingVol() const;
+	virtual const CBoundVol* pbvBoundingVol() const override;
 
 
 	//*****************************************************************************************
@@ -1015,7 +1015,7 @@ public:
 	//
 	virtual bool bIsMoving
 	(
-	) const;
+	) const override;
 	//
 	// Returns 'true' if the instance is moving or is likely to move.
 	//
@@ -1025,7 +1025,7 @@ public:
 	//
 	virtual bool bCanHaveChildren
 	(
-	);
+	) override;
 	//
 	// Returns 'true' if the instance is immovable.
 	//
@@ -1035,7 +1035,7 @@ public:
 	//
 	virtual const char* strPartType
 	(
-	) const;
+	) const override;
 	//
 	// Returns a partition type string.
 	//
@@ -1045,7 +1045,7 @@ public:
 	//
 	virtual bool bEmptyPart
 	(
-	) const
+	) const override
 	//
 	// Returns 'true' if the partition is empty, otherwise returns 'false.'
 	//
@@ -1059,7 +1059,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	virtual bool bIsInstance() const
+	virtual bool bIsInstance() const override
 	//
 	// Returns true if this is an instance object.
 	//
@@ -1161,7 +1161,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	virtual bool bPreload(const CBoundVol* pbv, const CPresence3<>* pr3, bool b_is_contained = false);
+	virtual bool bPreload(const CBoundVol* pbv, const CPresence3<>* pr3, bool b_is_contained = false) override;
 	//
 	// Preloads object into memory.
 	//
@@ -1171,7 +1171,7 @@ public:
 	//
 	virtual uint32 u4GetUniqueHandle
 	(
-	) const;
+	) const override;
 	//
 	// Returns a value uniquely representing the object.
 	//
@@ -1193,7 +1193,7 @@ public:
 	virtual char * pcSave
 	(
 		char *  pc_buffer
-	) const;
+	) const override;
 	//
 	// Saves the instance delta into buffer.
 	//
@@ -1207,7 +1207,7 @@ public:
 	virtual const char* pcLoad
 	(
 		const char *  pc_buffer
-	);
+	) override;
 	//
 	// Sets the instance internal variables based on info in buffer.
 	//
@@ -1306,7 +1306,7 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual bool bIsBackdrop()
+	virtual bool bIsBackdrop() override
 	{
 		return true;
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgAudio.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgAudio.hpp
@@ -245,7 +245,7 @@ public:
 	}
 
 	//*****************************************************************************************
-	virtual void Queue() const;
+	virtual void Queue() const override;
 
 	//*****************************************************************************************
 	//
@@ -278,14 +278,14 @@ public:
 protected:
 	//*****************************************************************************************
 	//
-	void DeliverTo(CEntity* pet) const 
+	void DeliverTo(CEntity* pet) const override
 	{ 
 		pet->Process(*this); 
 	}
 
 	//*****************************************************************************************
 	//
-	const char* strName() const 
+	const char* strName() const override
 	{
 		return "Audio"; 
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgCollision.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgCollision.hpp
@@ -190,16 +190,16 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void Send() const;
+	virtual void Send() const override;
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Collision";
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgControl.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgControl.hpp
@@ -73,12 +73,12 @@ protected:
 	// Overrides.
 	//
 
-	void DeliverTo(CEntity* pet) const { pet->Process(*this); }
-	const char* strName() const { return "Control"; }
+	void DeliverTo(CEntity* pet) const override { pet->Process(*this); }
+	const char* strName() const override { return "Control"; }
 
 	//******************************************************************************************
 	//
-	virtual void Send() const;
+	virtual void Send() const override;
 	//
 	// Send this message.
 	//
@@ -90,7 +90,7 @@ protected:
 
 	//******************************************************************************************
 	//
-	virtual void ExtractReplayData() const;
+	virtual void ExtractReplayData() const override;
 	//
 	// Extract replay data specific to this message
 	//
@@ -142,20 +142,20 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "NewRaster";
 	}
 
 	//******************************************************************************************
 	//
-	virtual void Send() const;
+	virtual void Send() const override;
 	//
 	// Send this message.
 	//
@@ -167,7 +167,7 @@ protected:
 
 	//******************************************************************************************
 	//
-	virtual void ExtractReplayData() const;
+	virtual void ExtractReplayData() const override;
 	//
 	// Extract replay data specific to this message
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgCreate.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgCreate.hpp
@@ -63,13 +63,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Create";
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgDelete.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgDelete.hpp
@@ -69,10 +69,10 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const;
+	virtual void DeliverTo(CEntity* pet) const override;
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Delete";
 	}
@@ -81,7 +81,7 @@ protected:
 	//
 	virtual void Queue
 	(
-	) const;
+	) const override;
 	//
 	// Put this message on the queue.
 	//
@@ -91,7 +91,7 @@ protected:
 	//
 	virtual void Send
 	(
-	) const;
+	) const override;
 	//
 	// Send this message.
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgMagnet.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgMagnet.hpp
@@ -66,17 +66,17 @@ protected:
 	//
 	// Overides.
 	//
-	virtual void Queue() const;
+	virtual void Queue() const override;
 
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Magnet Break";
 	}
@@ -121,17 +121,17 @@ protected:
 	//
 	// Overides.
 	//
-	virtual void Queue() const;
+	virtual void Queue() const override;
 
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Magnet Move";
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgMove.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgMove.hpp
@@ -132,16 +132,16 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void Send() const;
+	virtual void Send() const override;
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Move";
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgPaint.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgPaint.hpp
@@ -88,13 +88,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Paint";
 	}
@@ -102,7 +102,7 @@ protected:
 public:
 	//******************************************************************************************
 	//
-	virtual void Send() const;
+	virtual void Send() const override;
 	//
 	// Send this message.
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgPhysicsReq.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgPhysicsReq.hpp
@@ -235,13 +235,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
-	{
+	virtual void DeliverTo(CEntity* pet) const override
+	   {
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Physics Request";
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgStep.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgStep.hpp
@@ -107,22 +107,22 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Step";
 	}
 
-	virtual const char* strData() const;
+	virtual const char* strData() const override;
 
 	//******************************************************************************************
 	//
-	virtual void Send() const;
+	virtual void Send() const override;
 	//
 	// Send this message.
 	//
@@ -134,7 +134,7 @@ protected:
 
 	//******************************************************************************************
 	//
-	virtual void ExtractReplayData() const;
+	virtual void ExtractReplayData() const override;
 	//
 	// Extract replay data specific to this message
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgSystem.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgSystem.hpp
@@ -90,7 +90,7 @@ public:
 
 	//******************************************************************************************
 	//
-	virtual void Send() const;
+	virtual void Send() const override;
 	//
 	// Send this message.
 	//
@@ -102,12 +102,12 @@ public:
 protected:
 	static bool bSimGoing;
 
-	void DeliverTo(CEntity* pet) const 
+	void DeliverTo(CEntity* pet) const override
 	{ 
 		pet->Process(*this); 
 	}
 
-	const char* strName() const 
+	const char* strName() const override
 	{ 
 		return "System"; 
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgTrigger.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/MessageTypes/MsgTrigger.hpp
@@ -91,17 +91,17 @@ protected:
 	//
 	// Overides.
 	//
-	virtual void Queue() const;
+	virtual void Queue() const override;
 
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Trigger";
 	}
@@ -161,13 +161,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Move Trigger To";
 	}
@@ -286,13 +286,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Pick Up";
 	}
@@ -346,13 +346,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Use";
 	}
@@ -402,13 +402,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "I am dying!";
 	}
@@ -477,13 +477,13 @@ protected:
 	//
 
 	//******************************************************************************************
-	virtual void DeliverTo(CEntity* pet) const
+	virtual void DeliverTo(CEntity* pet) const override
 	{
 		pet->Process(*this);
 	}
 
 	//******************************************************************************************
-	virtual const char* strName() const
+	virtual const char* strName() const override
 	{
 		return "Damage";
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/RenderDB.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/RenderDB.hpp
@@ -83,23 +83,23 @@ public:
 	//
 
 	//*****************************************************************************************
-	void Process(const CMessagePaint& msgpaint);  //lint !e1411
+	void Process(const CMessagePaint& msgpaint) override;  //lint !e1411
 
 	//******************************************************************************************
-	void Process(const CMessageMove& msgmv);
+	void Process(const CMessageMove& msgmv) override;
 
 	//******************************************************************************************
-	void Process(const CMessageSystem& msg_system);
+	void Process(const CMessageSystem& msg_system) override;
 
 	//*****************************************************************************************
-	char* pcSave(char*  pc) const;
+	char* pcSave(char*  pc) const override;
 
 	//*****************************************************************************************
-	const char* pcLoad(const char*  pc);
+	const char* pcLoad(const char*  pc) override;
 
 	//*****************************************************************************************
 	//
-	void SaveDefaults();
+	void SaveDefaults() override;
 	//
 	// Save the default values of the user modifiable settings.
 	//
@@ -107,7 +107,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	void RestoreDefaults();
+	void RestoreDefaults() override;
 	//
 	// Restore the default values of the user modifiable settings.
 	//

--- a/jp2_pc/Source/Lib/EntityDBase/Subsystem.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Subsystem.hpp
@@ -83,11 +83,11 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const
+	virtual char * pcSave(char *  pc_buffer) const override
 	{ return pc_buffer; }
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer)
+	virtual const char * pcLoad(const char *  pc_buffer) override
 	{ return pc_buffer; }
 
 	//*****************************************************************************************
@@ -120,7 +120,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual void Cast(CSubsystem** ppsub)
+	virtual void Cast(CSubsystem** ppsub) override
 	{
 		*ppsub = this;
 	}

--- a/jp2_pc/Source/Lib/EntityDBase/Teleport.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Teleport.hpp
@@ -50,10 +50,10 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char* pcSave(char* pc_buffer) const;
+	virtual char* pcSave(char* pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char* pcLoad(const char* pc_buffer);
+	virtual const char* pcLoad(const char* pc_buffer) override;
 };
 
 

--- a/jp2_pc/Source/Lib/EntityDBase/TextOverlay.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/TextOverlay.hpp
@@ -104,9 +104,9 @@ public:
 	//
 	// Overrides
 	//
-	void Process(const CMessageStep& msg_step);
-	void Process(const CMessagePaint& msgpaint);
-	void Process(const CMessageSystem& msg);
+	void Process(const CMessageStep& msg_step) override;
+	void Process(const CMessagePaint& msgpaint) override;
+	void Process(const CMessageSystem& msg) override;
 
 	
 	//*****************************************************************************************

--- a/jp2_pc/Source/Lib/EntityDBase/Water.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Water.cpp
@@ -324,7 +324,7 @@ public:
 
 	//**********************************************************************************************
 	virtual void RayIntersect(CInstance* pins, int i_subobj, CRayCast& rc,
-							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const
+							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const override
 	{
 		// Collide with rendering bounding box.
 		SObjectLoc obl;
@@ -337,7 +337,7 @@ public:
 	}
 
 	//**********************************************************************************************
-	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const
+	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const override
 	{
 		CEntityWater* petw = dynamic_cast<CEntityWater*>(pins);
 		if (!petw)
@@ -355,7 +355,7 @@ public:
 	}
 
 	//*****************************************************************************************
-	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const;
+	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const override;
 };
 
 //*********************************************************************************************

--- a/jp2_pc/Source/Lib/EntityDBase/Water.hpp
+++ b/jp2_pc/Source/Lib/EntityDBase/Water.hpp
@@ -156,22 +156,22 @@ public:
 	virtual bool bContainsCacheableMeshes();
 
 	//*****************************************************************************************
-	virtual void InitializeDataStatic();
+	virtual void InitializeDataStatic() override;
 
 	//*****************************************************************************************
-	virtual void PreRender(CRenderContext& renc);
+	virtual void PreRender(CRenderContext& renc) override;
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageStep& msgstep);
+	virtual void Process(const CMessageStep& msgstep) override;
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageSystem& msgsys);
+	virtual void Process(const CMessageSystem& msgsys) override;
 
 	//*****************************************************************************************
-	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0);
+	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0) override;
 
 	//*****************************************************************************************
-	virtual void Cast(CEntityWater** ppetw)
+	virtual void Cast(CEntityWater** ppetw) override
 	{
 		*ppetw = this;
 	}
@@ -216,7 +216,7 @@ public:
 	//
 	virtual bool bIsMoving
 	(
-	) const;
+	) const override;
 	//
 	// Returns 'true' always, as water is always dynamic.
 	//

--- a/jp2_pc/Source/Lib/GeomDBase/InvisibleShape.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/InvisibleShape.hpp
@@ -55,25 +55,25 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual CVector3<> v3GetPhysicsBox() const
+	virtual CVector3<> v3GetPhysicsBox() const override
 	{
 		return bvbVolume.v3GetMax();
 	}
 
 	//*****************************************************************************************
-	virtual CVector3<> v3GetPivot() const
+	virtual CVector3<> v3GetPivot() const override
 	{
 		return v3Pivot;
 	}
 
 	//******************************************************************************************
-	virtual const CBoundVol& bvGet() const
+	virtual const CBoundVol& bvGet() const override
 	{
 		return bvbVolume;
 	}
 
 	//******************************************************************************************
-	virtual rptr<CRenderType> prdtCopy()
+	virtual rptr<CRenderType> prdtCopy() override
 	{
 		Assert(false);
 		return rptr0;

--- a/jp2_pc/Source/Lib/GeomDBase/Mesh.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Mesh.hpp
@@ -562,13 +562,13 @@ public:
 	}
 
 	//******************************************************************************************
-	int iNumPoints() const
+	int iNumPoints() const override
 	{
 		return pav3Points.uLen;
 	}
 
 	//******************************************************************************************
-	int iNumVertices() const
+	int iNumVertices() const override
 	{
 		return pamvVertices.uLen;
 	}
@@ -580,13 +580,13 @@ public:
 	}
 
 	//******************************************************************************************
-	int iNumPolygons() const
+	int iNumPolygons() const override
 	{
 		return pampPolygons.uLen;
 	}
 
 	//******************************************************************************************
-	int iNumTriangles() const;
+	int iNumTriangles() const override;
 
 
 	//******************************************************************************************
@@ -608,32 +608,32 @@ public:
 		const CPArray<COcclude*>&	papoc,				// Array of occluding objects.
 		ESideOf						esf_view			// Shape's relation to the view volume
 														// (for trivial acceptance).
-	) const;
+	) const override;
 	//
 	// Defined in Pipeline.cpp.
 	//
 
 	//******************************************************************************************
-	virtual const CBoundVol& bvGet() const
+	virtual const CBoundVol& bvGet() const override
 	{
 		return bvbVolume;
 	}
 
 	//*****************************************************************************************
-	virtual CVector3<> v3GetPhysicsBox() const
+	virtual CVector3<> v3GetPhysicsBox() const override
 	{
 		return v3Max;
 	}
 
 	//*****************************************************************************************
-	virtual CVector3<> v3GetPivot() const
+	virtual CVector3<> v3GetPivot() const override
 	{
 		return v3Pivot;
 	}
 
 	//******************************************************************************************
 	virtual void GetExtents(CInstance* pins, const CTransform3<>& tf3_shape,
-		CVector3<>& rv3_min, CVector3<>& rv3_max) const;
+		CVector3<>& rv3_min, CVector3<>& rv3_max) const override;
 
 	//******************************************************************************************
 	void AdjustBoundingVolumeForDetailReducedVersions();
@@ -656,20 +656,20 @@ public:
 
 
 	//******************************************************************************************
-	virtual rptr<CRenderType> prdtCopy()
+	virtual rptr<CRenderType> prdtCopy() override
 	{
 		Assert(false);
 		return rptr0;
 	}
 
 	//******************************************************************************************
-	virtual CPArray< CVector3<> > pav3GetWrap() const;
+	virtual CPArray< CVector3<> > pav3GetWrap() const override;
 
 	//******************************************************************************************
-	virtual void CreateWrap();
+	virtual void CreateWrap() override;
 
 	//******************************************************************************************
-	virtual void CreateWrapBox();
+	virtual void CreateWrapBox() override;
 
 	//******************************************************************************************
 	virtual void CreateMipMaps
@@ -677,7 +677,7 @@ public:
 		uint32 u4_smallest = 0xffffffff			// Generate all mips by default
 	);
 	//******************************************************************************************
-	virtual bool bSimpleShape();
+	virtual bool bSimpleShape() override;
 
 	//
 	// CFetchable overrides.  (for prefetching)
@@ -703,7 +703,7 @@ public:
 	class CPolyIterator;
 
 	//******************************************************************************************
-	virtual CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const;
+	virtual CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const override;
 
 	//******************************************************************************************
 	//
@@ -741,7 +741,7 @@ public:
 	//
 	virtual void MakeNoTexture
 	(
-	);
+	) override;
 	//
 	// Makes the surface apply flat-shading.
 	//
@@ -756,7 +756,7 @@ public:
 	//**********************************
 
 	//******************************************************************************************
-	virtual void Validate() const;
+	virtual void Validate() const override;
 
 protected:
 
@@ -815,7 +815,7 @@ public:
 	//  Cast override:
 
 	//*****************************************************************************************
-	virtual void Cast(rptr_const<CMesh>* ppmesh) const
+	virtual void Cast(rptr_const<CMesh>* ppmesh) const override
 	{
 		*ppmesh = rptr_const_this(this);
 	}
@@ -916,26 +916,26 @@ public:
 	);
 
 	//******************************************************************************************
-	virtual const CBoundVol& bvGet() const
+	virtual const CBoundVol& bvGet() const override
 	{
 		return bvbVolume;
 	}
 
 	//******************************************************************************************
-	virtual rptr<CRenderType> prdtCopy()
+	virtual rptr<CRenderType> prdtCopy() override
 	{
 		Assert(false);
 		return rptr0;
 	}
 
 	//******************************************************************************************
-	int iNumPoints() const
+	int iNumPoints() const override
 	{
 		return pamvVertices.uLen;
 	}
 
 	//******************************************************************************************
-	int iNumVertices() const
+	int iNumVertices() const override
 	{
 		return pamvVertices.uLen;
 	}
@@ -947,19 +947,19 @@ public:
 	}
 
 	//******************************************************************************************
-	int iNumPolygons() const
+	int iNumPolygons() const override
 	{
 		return 1;
 	}
 
 	//******************************************************************************************
-	int iNumTriangles() const
+	int iNumTriangles() const override
 	{
 		return 1;
 	}
 
 	//******************************************************************************************
-	virtual CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const
+	virtual CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const override
 	{
 		Assert(false);
 		return NULL;
@@ -1122,7 +1122,7 @@ public:
 	//
 	virtual bool bIsAnimated
 	(
-	) const
+	) const override
 	//
 	// Returns 'true' if the shape is animated (e.g., is an animating mesh).
 	//
@@ -1152,7 +1152,7 @@ public:
 		const CPArray<COcclude*>&	papoc,				// Array of occluding objects.
 		ESideOf						esf_view			// Shape's relation to the view volume
 														// (for trivial acceptance).
-	) const;
+	) const override;
 	//
 	//	Overridden to enable the mesh to decide when to animate itself.
 	//
@@ -1210,7 +1210,7 @@ public:
 		const CPArray<COcclude*>&	papoc,				// Array of occluding objects.
 		ESideOf						esf_view			// Shape's relation to the view volume
 														// (for trivial acceptance).
-	) const;
+	) const override;
 	//
 	//	Overridden to enable the mesh to decide when to animate itself.
 	//

--- a/jp2_pc/Source/Lib/GeomDBase/MeshIterator.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/MeshIterator.hpp
@@ -324,74 +324,74 @@
 
 		//******************************************************************************************
 		void TransformPoints(const CTransform3<>& tf3_shape_camera, const CCamera& cam,
-			CPArray<SClipPoint> paclpt_points, bool b_outcodes);
+			CPArray<SClipPoint> paclpt_points, bool b_outcodes) override;
 
-		void Reset_()
+		void Reset_() override
 		{
 			Reset();
 		}
 
-		bool bNext_()
+		bool bNext_() override
 		{
 			return bNext();
 		}
 
-		bool bBackface_(const CVector3<>& v3_cam)
+		bool bBackface_(const CVector3<>& v3_cam) override
 		{
 			return bBackface(v3_cam);
 		}
 
-		CPlane plPlane_()
+		CPlane plPlane_() override
 		{
 			return plPlane();
 		}
 
-		CVector3<> v3Point_()
+		CVector3<> v3Point_() override
 		{
 			return v3Point();
 		}
 
-		bool bCurved_()
+		bool bCurved_() override
 		{
 			return bCurved();
 		}
 
-		CMatrix3<> mx3ObjToTexture_()
+		CMatrix3<> mx3ObjToTexture_() override
 		{
 			return mx3ObjToTexture();
 		}
 
-		const CTexture* ptexTexture_()
+		const CTexture* ptexTexture_() override
 		{
 			return ptexTexture();
 		}
 
-		int iNumVertices_()
+		int iNumVertices_() override
 		{
 			return iNumVertices();
 		}
 
-		CVector3<> v3Point_(int i_poly_vertex)
+		CVector3<> v3Point_(int i_poly_vertex) override
 		{
 			return v3Point(i_poly_vertex);
 		}
 
-		CDir3<> d3Normal_(int i_poly_vertex)
+		CDir3<> d3Normal_(int i_poly_vertex) override
 		{
 			return d3Normal(i_poly_vertex);
 		}
 
-		CTexCoord tcTexCoord_(int i_poly_vertex)
+		CTexCoord tcTexCoord_(int i_poly_vertex) override
 		{
 			return tcTexCoord(i_poly_vertex);
 		}
 
-		int iShapeVertex_(int i_poly_vertex)
+		int iShapeVertex_(int i_poly_vertex) override
 		{
 			return iShapeVertex(i_poly_vertex);
 		}
 
-		int iShapePoint_(int i_poly_vertex)
+		int iShapePoint_(int i_poly_vertex) override
 		{
 			return iShapePoint(i_poly_vertex);
 		}

--- a/jp2_pc/Source/Lib/GeomDBase/PartitionSpace.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/PartitionSpace.hpp
@@ -176,7 +176,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	virtual void Cast(CPartitionSpace** ppparts)
+	virtual void Cast(CPartitionSpace** ppparts) override
 	//
 	// Assigns a 'this' pointer for the CPartitionSpace or descendant object.
 	//
@@ -189,7 +189,7 @@ public:
 	//
 	virtual const CBoundVol* pbvBoundingVol
 	(
-	) const;
+	) const override;
 	//
 	// Returns the bounding volume for the partition.
 	//
@@ -199,7 +199,7 @@ public:
 	//
 	virtual const char* strPartType
 	(
-	) const;
+	) const override;
 	//
 	// Returns a partition type string.
 	//
@@ -253,67 +253,67 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual float fDistanceFromGlobalCameraSqr() const;
+	virtual float fDistanceFromGlobalCameraSqr() const override;
 
 	//*****************************************************************************************
-	virtual uint32 u4GetUniqueHandle() const;
+	virtual uint32 u4GetUniqueHandle() const override;
 
 	//*****************************************************************************************
-	virtual CPresence3<> pr3Presence() const;
+	virtual CPresence3<> pr3Presence() const override;
 
 	//*****************************************************************************************
-	virtual void SetPresence(const CPresence3<> &pr3);
+	virtual void SetPresence(const CPresence3<> &pr3) override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3Placement() const;
+	virtual CPlacement3<> p3Placement() const override;
 
 	//*****************************************************************************************
-	virtual void SetPlacement(const CPlacement3<>& p3);
+	virtual void SetPlacement(const CPlacement3<>& p3) override;
 
 	//*****************************************************************************************
-	virtual CVector3<> v3Pos() const;
+	virtual CVector3<> v3Pos() const override;
 	
 	//*****************************************************************************************
-	virtual void SetPos(const CVector3<>& v3_pos);
+	virtual void SetPos(const CVector3<>& v3_pos) override;
 
 	//*****************************************************************************************
-	virtual CRotate3<> r3Rot() const;
+	virtual CRotate3<> r3Rot() const override;
 	
 	//*****************************************************************************************
-	virtual void SetRot(const CRotate3<>& r3_rot);
+	virtual void SetRot(const CRotate3<>& r3_rot) override;
 
 	//*****************************************************************************************
-	virtual float fGetScale() const;
+	virtual float fGetScale() const override;
 
 	//*****************************************************************************************
-	virtual void SetScale(float f_new_scale);
+	virtual void SetScale(float f_new_scale) override;
 	
 	//*****************************************************************************************
-	virtual int iSizeOf() const;
+	virtual int iSizeOf() const override;
 
 	//*****************************************************************************************
-	virtual bool bIsPureSpatial() const;
+	virtual bool bIsPureSpatial() const override;
 	
 	//*****************************************************************************************
 	//virtual void Save(int i_handle) const;
 	
 	//*****************************************************************************************
-	virtual char* pcSaveSpatial(char *pc_buffer) const;
+	virtual char* pcSaveSpatial(char *pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;  // See instance.hpp
+	virtual char * pcSave(char *  pc_buffer) const override;  // See instance.hpp
 
 	//*****************************************************************************************
-	virtual const char* pcLoad(const char *  pc_buffer);  // See instance.hpp
+	virtual const char* pcLoad(const char *  pc_buffer) override;  // See instance.hpp
 
 	//*****************************************************************************************
-	virtual void SetParent(CPartition* ppart = 0);
+	virtual void SetParent(CPartition* ppart = 0) override;
 	
 	//*****************************************************************************************
-	virtual void GetMinMaxDistance(float& rf_min, float& rf_max, CShapePresence& rsp);
+	virtual void GetMinMaxDistance(float& rf_min, float& rf_max, CShapePresence& rsp) override;
 
 	//*****************************************************************************************
-	virtual bool bIsEqualToSpatial(const CPartition* ppart) const;
+	virtual bool bIsEqualToSpatial(const CPartition* ppart) const override;
 
 };
 
@@ -358,22 +358,22 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual CPresence3<> pr3Presence() const;
+	virtual CPresence3<> pr3Presence() const override;
 
 	//*****************************************************************************************
-	virtual void SetPresence(const CPresence3<> &pr3);
+	virtual void SetPresence(const CPresence3<> &pr3) override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3Placement() const;
+	virtual CPlacement3<> p3Placement() const override;
 
 	//*****************************************************************************************
-	virtual void SetPlacement(const CPlacement3<>& p3);
+	virtual void SetPlacement(const CPlacement3<>& p3) override;
 
 	//*****************************************************************************************
-	virtual CVector3<> v3Pos() const;
+	virtual CVector3<> v3Pos() const override;
 	
 	//*****************************************************************************************
-	virtual void SetPos(const CVector3<>& v3_pos);
+	virtual void SetPos(const CVector3<>& v3_pos) override;
 
 };
 

--- a/jp2_pc/Source/Lib/GeomDBase/Shape.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Shape.hpp
@@ -839,7 +839,7 @@ public:
 	//
 	// Overrides.
 	//
-	virtual void Cast(rptr_const<CShape>* ppsh) const
+	virtual void Cast(rptr_const<CShape>* ppsh) const override
 	{
 		*ppsh = rptr_const_this(this);
 	}

--- a/jp2_pc/Source/Lib/GeomDBase/Skeleton.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Skeleton.hpp
@@ -145,7 +145,7 @@ public:
 
 	//******************************************************************************************
 	virtual void GetExtents(CInstance* pins, const CTransform3<>& tf3_shape,
-		CVector3<>& rv3_min, CVector3<>& rv3_max) const;
+		CVector3<>& rv3_min, CVector3<>& rv3_max) const override;
 
 	//
 	// Inherit Render and CPolyIterator.
@@ -175,7 +175,7 @@ public:
 		const CPArray<COcclude*>&	papoc,				// Array of occluding objects.
 		ESideOf						esf_view			// Shape's relation to the view volume
 														// (for trivial acceptance).
-	) const;
+	) const override;
 
 	//
 	// Forward nested class declaration; include "SkeletonIterator.hpp" for definition.
@@ -183,16 +183,16 @@ public:
 	class CPolyIterator;
 
 	//******************************************************************************************
-	virtual CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const;
+	virtual CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const override;
 
 	//******************************************************************************************
-	virtual rptr_const<CBioMesh> rpbmCast() const
+	virtual rptr_const<CBioMesh> rpbmCast() const override
 	{
 		return rptr_const_this(this);
 	}
 
 	//******************************************************************************************
-	virtual CPArray< CVector3<> > pav3GetWrap() const
+	virtual CPArray< CVector3<> > pav3GetWrap() const override
 	{
 		return CPArray< CVector3<> >(0, 0);
 	}
@@ -201,7 +201,7 @@ public:
 	//  Cast override:
 
 	//*****************************************************************************************
-	virtual void Cast(rptr_const<CBioMesh>* ppbm) const
+	virtual void Cast(rptr_const<CBioMesh>* ppbm) const override
 	{
 		*ppbm = rptr_const_this(this);
 	}

--- a/jp2_pc/Source/Lib/GeomDBase/SkeletonIterator.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/SkeletonIterator.hpp
@@ -174,34 +174,34 @@
 
 		//******************************************************************************************
 		void TransformPoints(const CTransform3<>& tf3_shape_camera, const CCamera& cam,
-			CPArray<SClipPoint> paclpt_points, bool b_outcodes);
+			CPArray<SClipPoint> paclpt_points, bool b_outcodes) override;
 
-		bool bBackface_(const CVector3<>& v3_cam)
+		bool bBackface_(const CVector3<>& v3_cam) override
 		{
 			return bBackface();
 		}
 
-		CPlane plPlane_()
+		CPlane plPlane_() override
 		{
 			return plPlane();
 		}
 
-		bool bCurved_()
+		bool bCurved_() override
 		{
 			return bCurved();
 		}
 
-		CVector3<> v3Point_()
+		CVector3<> v3Point_() override
 		{
 			return v3Point();
 		}
 
-		CVector3<> v3Point_(int i_poly_vertex)
+		CVector3<> v3Point_(int i_poly_vertex) override
 		{
 			return v3Point(i_poly_vertex);
 		}
 
-		CDir3<> d3Normal_(int i_poly_vertex)
+		CDir3<> d3Normal_(int i_poly_vertex) override
 		{
 			return d3Normal(i_poly_vertex);
 		}

--- a/jp2_pc/Source/Lib/GeomDBase/Terrain.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Terrain.cpp
@@ -75,13 +75,13 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual TSoundMaterial smatGetMaterialType() const
+	virtual TSoundMaterial smatGetMaterialType() const override
 	{
 		return tmatSoundMaterial;
 	}
 
 	//*****************************************************************************************
-	virtual TSoundMaterial smatGetMaterialType(const CVector3<>& v3_world) const
+	virtual TSoundMaterial smatGetMaterialType(const CVector3<>& v3_world) const override
 	{
 		// Get the sound material at this location.
 		const CTerrainObj* ptobj = wWorld.ptobjGetTopTerrainObjAt(v3_world.tX, v3_world.tY);
@@ -96,7 +96,7 @@ public:
 
 	//**********************************************************************************************
 	virtual void RayIntersect(CInstance* pins, int i_subobj, CRayCast& rc,
-							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const
+							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const override
 	{
 		CTerrain* ptrr = ptCast<CTerrain>(pins);
 		AlwaysAssert(ptrr);

--- a/jp2_pc/Source/Lib/GeomDBase/Terrain.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/Terrain.hpp
@@ -216,25 +216,25 @@ public:
 	// Overrides.
 	//
 
-	void Cast(CTerrain** ptrr)
+	void Cast(CTerrain** ptrr) override
 	{
 		*ptrr = this;
 	}
 
-	bool bGetWorldExtents(CVector3<>& v3_min, CVector3<>& v3_max) const;
+	bool bGetWorldExtents(CVector3<>& v3_min, CVector3<>& v3_max) const override;
 
-	void Process(const CMessageMove& msgmv);
-	void Process(const CMessagePaint& msgpaint);
-
-	//*****************************************************************************************
-	char* pcSave(char* pc) const;
+	void Process(const CMessageMove& msgmv) override;
+	void Process(const CMessagePaint& msgpaint) override;
 
 	//*****************************************************************************************
-	const char* pcLoad(const char* pc);
+	char* pcSave(char* pc) const override;
+
+	//*****************************************************************************************
+	const char* pcLoad(const char* pc) override;
 
 	//*****************************************************************************************
 	//
-	void SaveDefaults();
+	void SaveDefaults() override;
 	//
 	// Save the default values of the user modifiable settings.
 	//
@@ -242,7 +242,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	void RestoreDefaults();
+	void RestoreDefaults() override;
 	//
 	// Restore the default values of the user modifiable settings.
 	//

--- a/jp2_pc/Source/Lib/GeomDBase/TerrainObj.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/TerrainObj.hpp
@@ -133,7 +133,7 @@ public:
 
 	//*****************************************************************************************
 	// override the default implementation in cPartition which assigns NULL.
-	virtual void Cast(CTerrainObj** ptrrobj)
+	virtual void Cast(CTerrainObj** ptrrobj) override
 	{
 		*ptrrobj=this;
 	}
@@ -144,21 +144,21 @@ public:
 	}
 
 	//*****************************************************************************************
-	virtual void SetPos(const CVector3<>& v3_pos)
+	virtual void SetPos(const CVector3<>& v3_pos) override
 	{
 		pr3Pres.v3Pos = v3_pos;
 	}
 
 	//*****************************************************************************************
-	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0);
+	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
-	virtual CInstance* pinsCopy() const;
+	virtual CInstance* pinsCopy() const override;
 	
 	//******************************************************************************************
 	//

--- a/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.cpp
+++ b/jp2_pc/Source/Lib/GeomDBase/TerrainTexture.cpp
@@ -151,19 +151,19 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void BeginFrame()
+	virtual void BeginFrame() override
 	{
 		prasScreen->Lock();
 	}
 
 	//******************************************************************************************
-	virtual void EndFrame()
+	virtual void EndFrame() override
 	{
 		prasScreen->Unlock();
 	}
 
 	//******************************************************************************************
-	virtual void DrawPolygon(CRenderPolygon& rp)
+	virtual void DrawPolygon(CRenderPolygon& rp) override
 	{
 		// Invoke the CDrawPolygon code, using the screen as both screen and Z buffer.
 		if (rp.seterfFace[erfTRANSPARENT])
@@ -458,13 +458,13 @@ namespace NMultiResolution
 
 
 		//*****************************************************************************************
-		virtual void Execute()
+		virtual void Execute() override
 		{
 			static_cast<CTextureNode::CPriv*>(ptxnItem)->DoTextureUpdate(pqntinRoot);
 		}
 
 		//*****************************************************************************************
-		virtual void PostScheduleExecute()
+		virtual void PostScheduleExecute() override
 		{
 		}
 	};

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTree.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTree.hpp
@@ -866,12 +866,12 @@ namespace NMultiResolution
 			const CPArray<COcclude*>& papoc,			// Array of occluding objects.
 			ESideOf				      esf_view			// Shape's relation to the view volume
 														// (for trivial acceptance).
-		) const;
+		) const override;
 		//
 		// Defined in Pipeline.cpp.
 		//
 
-		virtual const CBoundVol& bvGet() const
+		virtual const CBoundVol& bvGet() const override
 		{
 			//
 			// The terrain basically encompasses the entire world, so just return infinity.
@@ -883,29 +883,29 @@ namespace NMultiResolution
 			return bvi;
 		}
 
-		virtual rptr<CRenderType> prdtCopy()
+		virtual rptr<CRenderType> prdtCopy() override
 		{
 			Assert(false);
 			return rptr0;
 		}
 
-		int iNumPolygons() const
+		int iNumPolygons() const override
 		{
 			// Return an upper bound on the triangle count.
 			return iNumPoints() * 2;
 		}
 
-		int iNumTriangles() const
+		int iNumTriangles() const override
 		{
 			return iNumPolygons();
 		}
 
-		int iNumPoints() const
+		int iNumPoints() const override
 		{
 			return CQuadVertexTIN::uMaxAlloc();
 		}
 
-		int iNumVertices() const
+		int iNumVertices() const override
 		{
 			// We do not share vertices, so there are 3 per polygon.
 			return iNumPolygons() * 3;
@@ -917,7 +917,7 @@ namespace NMultiResolution
 			return iNumPolygons() * 3;
 		}
 
-		virtual TReal rPolyPlaneThickness() const;
+		virtual TReal rPolyPlaneThickness() const override;
 
 
 		//******************************************************************************************
@@ -1014,7 +1014,7 @@ namespace NMultiResolution
 				const CCamera&			cam,
 				CPArray<SClipPoint>		paclpt_points,
 				bool					b_outcodes
-			);
+			) override;
 
 			//******************************************************************************************
 			bool bNext()
@@ -1115,22 +1115,22 @@ namespace NMultiResolution
 			// Virtual overrides.
 			//
 
-			void Reset_()
+			void Reset_() override
 			{
 				Reset();
 			}
 
-			bool bNext_()
+			bool bNext_() override
 			{
 				return bNext();
 			}
 
-			CPlane plPlane_()
+			CPlane plPlane_() override
 			{
 				return plPlane();
 			}
 
-			CVector3<> v3Point_()
+			CVector3<> v3Point_() override
 			{
 				return v3Point();
 			}
@@ -1140,54 +1140,54 @@ namespace NMultiResolution
 				return d3Normal();
 			}
 
-			bool bCurved_()
+			bool bCurved_() override
 			{
 				return bCurved();
 			}
 
-			CMatrix3<> mx3ObjToTexture_()
+			CMatrix3<> mx3ObjToTexture_() override
 			{
 				return mx3ObjToTexture();
 			}
 
-			const CTexture* ptexTexture_()
+			const CTexture* ptexTexture_() override
 			{
 				return ptexTexture();
 			}
 
-			int iNumVertices_()
+			int iNumVertices_() override
 			{
 				return iNumVertices();
 			}
 
-			CVector3<> v3Point_(int i_poly_vertex)
+			CVector3<> v3Point_(int i_poly_vertex) override
 			{
 				return v3Point(i_poly_vertex);
 			}
 
-			CDir3<> d3Normal_(int i_poly_vertex)
+			CDir3<> d3Normal_(int i_poly_vertex) override
 			{
 				return d3Normal(i_poly_vertex);
 			}
 
-			CTexCoord tcTexCoord_(int i_poly_vertex)
+			CTexCoord tcTexCoord_(int i_poly_vertex) override
 			{
 				return tcTexCoord(i_poly_vertex);
 			}
 
-			int iShapeVertex_(int i_poly_vertex)
+			int iShapeVertex_(int i_poly_vertex) override
 			{
 				return iShapeVertex(i_poly_vertex);
 			}
 
-			int iShapePoint_(int i_poly_vertex)
+			int iShapePoint_(int i_poly_vertex) override
 			{
 				return iShapePoint(i_poly_vertex);
 			}
 		};
 
 		//******************************************************************************************
-		CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const
+		CShape::CPolyIterator* pPolyIterator(const CInstance* pins, const CRenderContext* prenc) const override
 		{
 			return new CPolyIterator(*this, pins, prenc);
 		}

--- a/jp2_pc/Source/Lib/Groff/ValueTable.hpp
+++ b/jp2_pc/Source/Lib/Groff/ValueTable.hpp
@@ -408,7 +408,7 @@ public:
 	//
 	virtual uint uWriteCount
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -416,7 +416,7 @@ public:
 	virtual uint uWrite
 	(
 		char** ppc_buffer
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -424,7 +424,7 @@ public:
 	virtual uint uRead
 	(
 		char** ppc_buffer
-	);
+	) override;
 };
 
 
@@ -523,7 +523,7 @@ public:
 	//
 	virtual uint uWriteCount
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -531,7 +531,7 @@ public:
 	virtual uint uWrite
 	(
 		char** ppc_buffer
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -539,7 +539,7 @@ public:
 	virtual uint uRead
 	(
 		char** ppc_buffer
-	);
+	) override;
 };
 
 
@@ -637,7 +637,7 @@ public:
 	//
 	virtual uint uWriteCount
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -645,7 +645,7 @@ public:
 	virtual uint uWrite
 	(
 		char** ppc_buffer
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -653,7 +653,7 @@ public:
 	virtual uint uRead
 	(
 		char** ppc_buffer
-	);
+	) override;
 };
 
 
@@ -751,7 +751,7 @@ public:
 	//
 	virtual uint uWriteCount
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -759,7 +759,7 @@ public:
 	virtual uint uWrite
 	(
 		char** ppc_buffer
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -767,7 +767,7 @@ public:
 	virtual uint uRead
 	(
 		char** ppc_buffer
-	);
+	) override;
 };
 
 
@@ -865,7 +865,7 @@ public:
 	//
 	virtual uint uWriteCount
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -873,7 +873,7 @@ public:
 	virtual uint uWrite
 	(
 		char** ppc_buffer
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -881,7 +881,7 @@ public:
 	virtual uint uRead
 	(
 		char** ppc_buffer
-	);
+	) override;
 };
 
 
@@ -1089,7 +1089,7 @@ public:
 	//
 	virtual uint uWriteCount
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -1097,7 +1097,7 @@ public:
 	virtual uint uWrite
 	(
 		char** ppc_buffer
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -1105,7 +1105,7 @@ public:
 	virtual uint uRead
 	(
 		char** ppc_buffer
-	);
+	) override;
 };
 
 

--- a/jp2_pc/Source/Lib/Physics/InfoBox.hpp
+++ b/jp2_pc/Source/Lib/Physics/InfoBox.hpp
@@ -140,7 +140,7 @@ public:
 	//
 	virtual CPhysicsInfo* pphiCopy
 	(
-	);
+	) override;
 	//
 	// Copies this, returning a unique, non-instanced object outside of the instancing system.
 	//
@@ -167,20 +167,20 @@ public:
 
 	//******************************************************************************************
 	//
-	virtual void ZeroRefs();
+	virtual void ZeroRefs() override;
 	// 
 	//	Overridden to allow pphibFindShared to handle its own memory.
 	//
 	//**********************************
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvGetBoundVol() const
+	virtual const CBoundVol* pbvGetBoundVol() const override
 	{
 		return &bvbBoundVol;
 	}
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvGetCollideVol() const
+	virtual const CBoundVol* pbvGetCollideVol() const override
 	{
 		return &bvbCollideVol;
 	}
@@ -191,25 +191,25 @@ public:
 		CInstance *pins, 
 		bool b_just_update = false, 
 		const CPlacement3<>& p3_vel = p3VELOCITY_ZERO
-	) const;
+	) const override;
 
 	//*****************************************************************************************
-	virtual void Deactivate(CInstance *pins) const;
+	virtual void Deactivate(CInstance *pins) const override;
 
 	//*****************************************************************************************
-	virtual bool bIsActive(const CInstance* pins) const;
+	virtual bool bIsActive(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual bool bIsMoving(const CInstance* pins) const;
+	virtual bool bIsMoving(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3GetVelocity(const CInstance* pins) const;
+	virtual CPlacement3<> p3GetVelocity(const CInstance* pins) const override;
 
 	//*****************************************************************************************
 	static void UpdateWDBase(int i_index);
 
 	//*****************************************************************************************
-	virtual void UpdateWDBase(CInstance* pins, int i_index, int i_element) const;
+	virtual void UpdateWDBase(CInstance* pins, int i_index, int i_element) const override;
 
 	//**********************************************************************************************
 	//
@@ -227,25 +227,25 @@ public:
 		int ai_sound[],						// Sounds.
 		float aaf_magnet_pos[][3],			// Magnet positions.
 		float af_breaking[]					// Magnet strengths.
-	) const;
+	) const override;
 	//
 	//  Initializes arrays for call to CreateBoxModel.
 	//
 	//**************************
 
 	//**********************************************************************************************
-	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const;
+	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const override;
 
 	//*****************************************************************************************
-	virtual void ForceVelocity(CInstance* pins_target, const CVector3<>& v3_new_velocity) const;
+	virtual void ForceVelocity(CInstance* pins_target, const CVector3<>& v3_new_velocity) const override;
 	
 	//*****************************************************************************************
-	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const;
+	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const override;
 
-	virtual CPhysicsInfoBox* ppibCast()
+	virtual CPhysicsInfoBox* ppibCast() override
 	{ return this; }
 
-	virtual CPhysicsInfoBox const * ppibCast() const
+	virtual CPhysicsInfoBox const * ppibCast() const override
 	{ return this; }
 
 
@@ -255,10 +255,10 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual TReal fVolume(CInstance* pins) const;
+	virtual TReal fVolume(CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual TReal fMass(const CInstance* pins) const;
+	virtual TReal fMass(const CInstance* pins) const override;
 
 	//*****************************************************************************************
 	//

--- a/jp2_pc/Source/Lib/Physics/InfoCompound.hpp
+++ b/jp2_pc/Source/Lib/Physics/InfoCompound.hpp
@@ -148,22 +148,22 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvGetBoundVol() const
+	virtual const CBoundVol* pbvGetBoundVol() const override
 	{
 		return &bvbBound;
 	}
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvGetCollideVol() const
+	virtual const CBoundVol* pbvGetCollideVol() const override
 	{
 		return &bvbCollide;
 	}
 
 	//*****************************************************************************************
-	virtual TReal fVolume(CInstance* pins) const;
+	virtual TReal fVolume(CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual TReal fMass(const CInstance* pins) const;
+	virtual TReal fMass(const CInstance* pins) const override;
 
 	//*****************************************************************************************
 	virtual void Activate
@@ -171,44 +171,44 @@ public:
 		CInstance *pins, 
 		bool b_just_update = false, 
 		const CPlacement3<>& p3_vel = p3VELOCITY_ZERO
-	) const;
+	) const override;
 
 	//*****************************************************************************************
-	virtual void Deactivate(CInstance *pins) const;
+	virtual void Deactivate(CInstance *pins) const override;
 
 	//*****************************************************************************************
-	virtual bool bIsActive(const CInstance* pins) const;
+	virtual bool bIsActive(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual bool bIsMoving(const CInstance* pins) const;
+	virtual bool bIsMoving(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3GetVelocity(const CInstance* pins) const;
+	virtual CPlacement3<> p3GetVelocity(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual void UpdateWDBase(CInstance* pins, int i_index,	int	i_element) const;
+	virtual void UpdateWDBase(CInstance* pins, int i_index,	int	i_element) const override;
 
 	//**********************************************************************************************
 	virtual void RayIntersect(CInstance* pins, int i_subobj, CRayCast& rc,
-							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const;
+							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const override;
 
 	//*****************************************************************************************
-	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const;
+	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const override;
 
 	//*****************************************************************************************
-	virtual void ForceVelocity(CInstance* pins_target, const CVector3<>& v3_new_velocity) const;
+	virtual void ForceVelocity(CInstance* pins_target, const CVector3<>& v3_new_velocity) const override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3Base(CInstance* pins) const;
+	virtual CPlacement3<> p3Base(CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual CPresence3<> pr3Collide(CInstance* pins) const;
+	virtual CPresence3<> pr3Collide(CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual void HandleMessage(const CMessagePhysicsReq& msgpr, CInstance *pins) const;
+	virtual void HandleMessage(const CMessagePhysicsReq& msgpr, CInstance *pins) const override;
 
 	//*****************************************************************************************
-	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const;
+	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const override;
 
 	//**********************************************************************************************
 	virtual void SetupSuperBox
@@ -225,12 +225,12 @@ public:
 		int ai_sound[],						// Sounds.
 		float aaf_magnet_pos[][3],			// Magnet positions.
 		float af_breaking[]					// Magnet strengths.
-	) const;
+	) const override;
 	//**************************
 
 
-	virtual CPhysicsInfoCompound* pphicCast() { return this; }
-	virtual const CPhysicsInfoCompound* pphicCast() const { return this; }
+	virtual CPhysicsInfoCompound* pphicCast() override { return this; }
+	virtual const CPhysicsInfoCompound* pphicCast() const override { return this; }
 };
 
 #endif

--- a/jp2_pc/Source/Lib/Physics/InfoPlayer.hpp
+++ b/jp2_pc/Source/Lib/Physics/InfoPlayer.hpp
@@ -99,16 +99,16 @@ public:
 		CInstance *pins, 
 		bool b_just_update = false, 
 		const CPlacement3<>& p3_vel = p3VELOCITY_ZERO
-	) const;
+	) const override;
 
 	//*****************************************************************************************
-	virtual void Deactivate(CInstance *pins) const;
+	virtual void Deactivate(CInstance *pins) const override;
 
 	//*****************************************************************************************
-	virtual void UpdateWDBase(CInstance* pins, int i_index) const;
+	virtual void UpdateWDBase(CInstance* pins, int i_index) const override;
 
 	//*****************************************************************************************
-	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const;
+	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const override;
 };
 
 #endif

--- a/jp2_pc/Source/Lib/Physics/InfoSkeleton.hpp
+++ b/jp2_pc/Source/Lib/Physics/InfoSkeleton.hpp
@@ -167,7 +167,7 @@ public:
 	//
 	virtual CPhysicsInfo* pphiCopy
 	(
-	)
+	) override
 	//
 	// Copies this, returning a unique, non-instanced object outside of the instancing system.
 	//
@@ -182,19 +182,19 @@ public:
 
 	//*****************************************************************************************
 	//
-	virtual const CBoundVol* pbvGetBoundVol() const
+	virtual const CBoundVol* pbvGetBoundVol() const override
 	{
 		return &phibBounding.bvbBoundVol;
 	}
 
 	//*****************************************************************************************
-	virtual TReal fVolume(CInstance* pins) const
+	virtual TReal fVolume(CInstance* pins) const override
 	{
 		return phibBounding.fVolume(pins);
 	}
 
 	//*****************************************************************************************
-	virtual TReal fMass(const CInstance* pins) const
+	virtual TReal fMass(const CInstance* pins) const override
 	{
 		return phibBounding.fMass(pins);
 	}
@@ -206,42 +206,42 @@ public:
 		CInstance *pins,
 		bool b_just_update = false,
 		const CPlacement3<>& p3_vel = p3VELOCITY_ZERO
-	) const;
+	) const override;
 	//
 	//**************************
 
 	//*****************************************************************************************
-	virtual void Deactivate(CInstance *pins) const;
+	virtual void Deactivate(CInstance *pins) const override;
 
 	//*****************************************************************************************
-	virtual bool bIsActive(const CInstance* pins) const;
+	virtual bool bIsActive(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual bool bIsMoving(const CInstance* pins) const;
+	virtual bool bIsMoving(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3GetVelocity(const CInstance* pins) const;
+	virtual CPlacement3<> p3GetVelocity(const CInstance* pins) const override;
 
 	//*****************************************************************************************
-	virtual void HandleMessage(const CMessagePhysicsReq& msgpr,	CInstance *pins) const;
+	virtual void HandleMessage(const CMessagePhysicsReq& msgpr,	CInstance *pins) const override;
 
 	//*****************************************************************************************
-	virtual void UpdateWDBase(CInstance * pins,	int	i_index) const;
+	virtual void UpdateWDBase(CInstance * pins,	int	i_index) const override;
 
 	//**********************************************************************************************
 	virtual void RayIntersect(CInstance* pins, int i_subobj, CRayCast& rc,
-							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const;
+							  const CPlacement3<>& p3, TReal r_length, TReal r_diameter) const override;
 
 	//*****************************************************************************************
-	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const;
+	virtual void ApplyImpulse(CInstance* pins, int i_subobj, const CVector3<>& v3_pos, const CVector3<>& v3_impulse) const override;
 
 	//*****************************************************************************************
-	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const;
+	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const override;
 
-	virtual CPhysicsInfoSkeleton* ppisCast()
+	virtual CPhysicsInfoSkeleton* ppisCast() override
 	{ return this; }
 
-	virtual const CPhysicsInfoSkeleton* ppisCast() const
+	virtual const CPhysicsInfoSkeleton* ppisCast() const override
 	{ return this; }
 
 	//******************************************************************************************
@@ -394,24 +394,24 @@ public:
 	(
 		const CInstance* pins = 0,
 		TSoundMaterial tsmat = 0
-	) const;
+	) const override;
 
 	//*****************************************************************************************
 	virtual float fArmourMultiplier
 	(
 		const CInstance* pins = 0,
 		TSoundMaterial tsmat = 0
-	) const;
+	) const override;
 
 	//*****************************************************************************************
-	virtual void Init(CAnimate* pani) const;
+	virtual void Init(CAnimate* pani) const override;
 
 	//*****************************************************************************************
 	virtual void HandleMessage
 	(
 		const CMessagePhysicsReq& msgpr,
 		CInstance *pins
-	) const;
+	) const override;
 
 	//*****************************************************************************************
 	virtual void DrawPhysics
@@ -419,24 +419,24 @@ public:
 		CInstance* pins, 		// Owning instance.
 		CDraw& draw,			// Line draw object.
 		CCamera& cam			// Current view camera.
-	) const;
+	) const override;
 
 	//*****************************************************************************************
 	virtual CVector3<> v3GetHeadPosition
 	(
 		const CInstance* pins
-	) const;
+	) const override;
 
 	//*****************************************************************************************
-	virtual CVector3<> v3GetTailPosition
+	virtual   CVector3<> v3GetTailPosition
 	(
 		const CInstance* pins
-	) const;
+	) const override;
 
 protected:
 
 	//*****************************************************************************************
-	virtual void CreatePhysics(CInstance* pins, int i_index, float aaf_state[7][3]) const;
+	virtual void CreatePhysics(CInstance* pins, int i_index, float aaf_state[7][3]) const override;
 
 	//*****************************************************************************************
 	virtual void GetData
@@ -445,7 +445,7 @@ protected:
 		float loc[7],
 		float points[iMAX_SKELETAL_ELEMENTS][3], float matrices[iMAX_SKELETAL_ELEMENTS][3][3],
 		int Am_I_Supported[iMAX_SKELETAL_ELEMENTS]
-	) const;
+	) const override;
 };
 
 //**********************************************************************************************
@@ -480,24 +480,24 @@ public:
 	(
 		const CInstance* pins = 0,
 		TSoundMaterial tsmat = 0
-	) const;
+	) const override;
 
 	//*****************************************************************************************
 	virtual float fArmourMultiplier
 	(
 		const CInstance* pins = 0,
 		TSoundMaterial tsmat = 0
-	) const;
+	) const override;
 
 	//*****************************************************************************************
 	virtual void HandleMessage
 	(
 		const CMessagePhysicsReq& msgpr,
 		CInstance *pins
-	) const;
+	) const override;
 
 	//*****************************************************************************************
-	virtual void Init(CAnimate* pani) const;
+	virtual void Init(CAnimate* pani) const override;
 
 	//*****************************************************************************************
 	virtual void DrawPhysics
@@ -505,12 +505,12 @@ public:
 		CInstance* pins, 		// Owning instance.
 		CDraw& draw,			// Line draw object.
 		CCamera& cam			// Current view camera.
-	) const;
+	) const override;
 
 protected:
 
 	//*****************************************************************************************
-	virtual void CreatePhysics(CInstance* pins, int i_index, float aaf_state[7][3]) const;
+	virtual void CreatePhysics(CInstance* pins, int i_index, float aaf_state[7][3]) const override;
 
 	//*****************************************************************************************
 	virtual void GetData
@@ -519,7 +519,7 @@ protected:
 		float loc[7],
 		float points[iMAX_SKELETAL_ELEMENTS][3], float matrices[iMAX_SKELETAL_ELEMENTS][3][3],
 		int Am_I_Supported[iMAX_SKELETAL_ELEMENTS]
-	) const;
+	) const override;
 };
 
 //**********************************************************************************************
@@ -551,7 +551,7 @@ public:
 	(
 		const CMessagePhysicsReq& msgpr,
 		CInstance *pins
-	) const;
+	) const override;
 	//
 	//**************************
 
@@ -562,7 +562,7 @@ public:
 		CInstance *	pins,		// The instance to update
 		int			i_index		// The index of that instance in the appropriate physics
 								// system array.
-	) const;
+	) const override;
 	//
 	//**************************
 
@@ -571,24 +571,24 @@ public:
 	(
 		const CInstance* pins = 0,
 		TSoundMaterial tsmat = 0
-	) const;
+	) const override;
 
 	//*****************************************************************************************
 	virtual float fArmourMultiplier
 	(
 		const CInstance* pins = 0,
 		TSoundMaterial tsmat = 0
-	) const;
+	) const override;
 
 	//*****************************************************************************************
-	virtual void Init(CAnimate* pani) const;
+	virtual void Init(CAnimate* pani) const override;
 
 	//*****************************************************************************************
-	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const;
+	virtual void DrawPhysics(CInstance* pins, CDraw& draw, CCamera& cam) const override;
 
 protected:
 	//*****************************************************************************************
-	virtual void CreatePhysics(CInstance* pins, int i_index, float aaf_state[7][3]) const;
+	virtual void CreatePhysics(CInstance* pins, int i_index, float aaf_state[7][3]) const override;
 
 	//*****************************************************************************************
 	//
@@ -598,7 +598,7 @@ protected:
 		float loc[7],
 		float points[iMAX_SKELETAL_ELEMENTS][3], float matrices[iMAX_SKELETAL_ELEMENTS][3][3],
 		int Am_I_Supported[iMAX_SKELETAL_ELEMENTS] 
-	) const;
+	) const override;
 };
 
 #endif

--- a/jp2_pc/Source/Lib/Physics/Magnet.hpp
+++ b/jp2_pc/Source/Lib/Physics/Magnet.hpp
@@ -322,55 +322,55 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual const char* strPartType() const
+	virtual const char* strPartType() const override
 	{ 
 		return "CMagnetPair"; 
 	}
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvBoundingVol() const;
+	virtual const CBoundVol* pbvBoundingVol() const override;
 
 	//*****************************************************************************************
-	virtual CPresence3<> pr3Presence() const;
+	virtual CPresence3<> pr3Presence() const override;
 
 	//*****************************************************************************************
-	virtual void SetPresence(const CPresence3<> &pr3);
+	virtual void SetPresence(const CPresence3<> &pr3) override;
 
 	//*****************************************************************************************
-	virtual CPlacement3<> p3Placement() const;
+	virtual CPlacement3<> p3Placement() const override;
 
 	//*****************************************************************************************
-	virtual void SetPlacement(const CPlacement3<>& p3);
+	virtual void SetPlacement(const CPlacement3<>& p3) override;
 
 	//*****************************************************************************************
-	virtual CVector3<> v3Pos() const;
+	virtual CVector3<> v3Pos() const override;
 	
 	//*****************************************************************************************
-	virtual void SetPos(const CVector3<>& v3_pos);
+	virtual void SetPos(const CVector3<>& v3_pos) override;
 
 	//*****************************************************************************************
-	virtual CRotate3<> r3Rot() const;
+	virtual CRotate3<> r3Rot() const override;
 	
 	//*****************************************************************************************
-	virtual void SetRot(const CRotate3<>& r3_rot);
+	virtual void SetRot(const CRotate3<>& r3_rot) override;
 
 	//*****************************************************************************************
-	virtual float fGetScale() const;
+	virtual float fGetScale() const override;
 
 	//*****************************************************************************************
-	virtual void SetScale(float f_new_scale);
+	virtual void SetScale(float f_new_scale) override;
 
 	//*****************************************************************************************
-	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0);
+	virtual void Move(const CPlacement3<>& p3_new, CEntity* pet_sender = 0) override;
 
 	//*****************************************************************************************
-	virtual int iSizeOf() const;
+	virtual int iSizeOf() const override;
 
 	//*****************************************************************************************
-	virtual char* pcSave(char* pc_buffer) const;  // See instance.hpp
+	virtual char* pcSave(char* pc_buffer) const override;  // See instance.hpp
 
 	//*****************************************************************************************
-	virtual const char* pcLoad(const char* pc_buffer);  // See instance.hpp
+	virtual const char* pcLoad(const char* pc_buffer) override;  // See instance.hpp
 
 	class CPriv;
 };

--- a/jp2_pc/Source/Lib/Physics/PhysicsSystem.hpp
+++ b/jp2_pc/Source/Lib/Physics/PhysicsSystem.hpp
@@ -274,11 +274,11 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageSystem& msgsys);
+	virtual void Process(const CMessageSystem& msgsys) override;
 
 	//*****************************************************************************************
 	//
-	virtual void Process(const CMessageStep& msgstep);
+	virtual void Process(const CMessageStep& msgstep) override;
 	//
 	// Gives the physics system a few clock cycles to process object motion.
 	//
@@ -286,7 +286,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	void Process(const CMessageMove& msgmv);
+	void Process(const CMessageMove& msgmv) override;
 	//
 	// Updates active objects which are moved elsewhere.
 	//
@@ -294,7 +294,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	void Process(const CMessageCollision& msgcoll);
+	void Process(const CMessageCollision& msgcoll) override;
 	//
 	// Provides auxilliary effects for collisions.
 	//
@@ -302,7 +302,7 @@ public:
 
 	//*****************************************************************************************
 	//
-	virtual void Process(const CMessageDelete& msgdel);
+	virtual void Process(const CMessageDelete& msgdel) override;
 	//
 	// Handles removal of world objects.
 	//
@@ -310,17 +310,17 @@ public:
 
 	//*****************************************************************************************
 	//
-	virtual void Process(const CMessagePaint& msgpaint);
+	virtual void Process(const CMessagePaint& msgpaint) override;
 	//
 	// If bShowBones is on, draws physics boxes, bones, other debugging info.
 	//
 	//**********************************
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 	class CPriv;
 };

--- a/jp2_pc/Source/Lib/Physics/WaterDisturbance.hpp
+++ b/jp2_pc/Source/Lib/Physics/WaterDisturbance.hpp
@@ -90,16 +90,16 @@ public:
 	//
 
 	// Step message might disturb some water!
-	virtual void Process(const CMessageStep& msgstep);
+	virtual void Process(const CMessageStep& msgstep) override;
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 	//*****************************************************************************************
-	virtual void Cast(CWaterDisturbance** pwd)
+	virtual void Cast(CWaterDisturbance** pwd) override
 	{
 		*pwd = this;
 	}
@@ -107,7 +107,7 @@ public:
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 };
 

--- a/jp2_pc/Source/Lib/Physics/Waves.hpp
+++ b/jp2_pc/Source/Lib/Physics/Waves.hpp
@@ -569,17 +569,17 @@ public:
 	// Overrides.
 	//
 
-	virtual void SwapPrev();
+	virtual void SwapPrev() override;
 
-	virtual void CopyPrev();
+	virtual void CopyPrev() override;
 
 protected:
 
-	virtual void Iterate(TSeconds s_step_cur);
+	virtual void Iterate(TSeconds s_step_cur) override;
 
-	virtual void ApplyBoundary();
+	virtual void ApplyBoundary() override;
 
-	virtual void SetMaxStep();
+	virtual void SetMaxStep() override;
 };
 
 
@@ -691,9 +691,9 @@ public:
 	// Overrides.
 	//
 
-	virtual void Iterate(TSeconds s_step_cur);
+	virtual void Iterate(TSeconds s_step_cur) override;
 
-	virtual bool bElementActive(int i_y, int i_x) const
+	virtual bool bElementActive(int i_y, int i_x) const override
 	{
 		return pa2mrVelocityFactor[i_y][i_x] > 0;
 	}

--- a/jp2_pc/Source/Lib/Renderer/Camera.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Camera.hpp
@@ -270,7 +270,7 @@ public:
 	//
 	virtual bool bCanHaveChildren
 	(
-	);
+	) override;
 	//
 	// Returns 'false.'
 	//
@@ -570,20 +570,20 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual void Cast(CCamera** ppcam)
+	virtual void Cast(CCamera** ppcam) override
 	{
 		*ppcam = this;
 	}
 
 	//*****************************************************************************************
-	virtual const CBoundVol* pbvBoundingVol() const
+	virtual const CBoundVol* pbvBoundingVol() const override
 	// Returns the bounding volume for the camera's partition.
 	{
 		return pbvVolume;
 	}
 
 	//*****************************************************************************************
-	virtual bool bIncludeInBuildPart() const
+	virtual bool bIncludeInBuildPart() const override
 	{
 		return false;
 	}
@@ -676,10 +676,10 @@ protected:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 private:
 

--- a/jp2_pc/Source/Lib/Renderer/Clip.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Clip.hpp
@@ -198,7 +198,7 @@ public:
 	}
 
 	//******************************************************************************************
-	TReal rEdgeT(const CVector3<>& v3_0, const CVector3<>& v3_1) const
+	TReal rEdgeT(const CVector3<>& v3_0, const CVector3<>& v3_1) const override
 	{
 		// Implemented with rDistance().
 		TReal r_0 = rDistance(v3_0);
@@ -207,7 +207,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfIntersectPolygon(CPArray<SRenderVertex*> paprv_poly, ESideOf aesf_sides[]) const
+	virtual ESideOf esfIntersectPolygon(CPArray<SRenderVertex*> paprv_poly, ESideOf aesf_sides[]) const override
 	{
 		// Return combination of all points.  Use esfSideOf, to return esfON when appropriate,
 		// for storage in array.
@@ -222,7 +222,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfIntersectPolygonMesh(CPArray<CMesh::SVertex*> papmv_poly, ESideOf aesf_sides[]) const
+	virtual ESideOf esfIntersectPolygonMesh(CPArray<CMesh::SVertex*> papmv_poly, ESideOf aesf_sides[]) const override
 	{
 		// Return combination of all points.  Use esfSideOf, to return esfON when appropriate,
 		// for storage in array.

--- a/jp2_pc/Source/Lib/Renderer/GeomTypes.hpp
+++ b/jp2_pc/Source/Lib/Renderer/GeomTypes.hpp
@@ -528,19 +528,19 @@ public:
 	//
 	
 	//******************************************************************************************
-	virtual EBVType ebvGetType() const
+	virtual EBVType ebvGetType() const override
 	{
 		return ebvINFINITE;
 	}
 
 	//******************************************************************************************
-	virtual int iSizeOf() const
+	virtual int iSizeOf() const override
 	{
 		return sizeof(*this);
 	}
 
 	//******************************************************************************************
-	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const
+	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const override
 	{
 		rv3_min = CVector3<>(FLT_MIN, FLT_MIN, FLT_MIN);
 		rv3_max = CVector3<>(FLT_MAX, FLT_MAX, FLT_MAX);
@@ -549,88 +549,88 @@ public:
 	//******************************************************************************************
 	virtual float fMaxExtent
 	(
-	) const
+	) const override
 	{
 		return FLT_MAX;
 	}
 
 	//******************************************************************************************
-	virtual TReal rGetVolume(TReal) const
+	virtual TReal rGetVolume(TReal) const override
 	{
 		return FLT_MAX;
 	}
 
 	//******************************************************************************************
-	virtual const CBoundVolInfinite* pbviCast() const { return this; }
+	virtual const CBoundVolInfinite* pbviCast() const override { return this; }
 
 	//
 	// Any volume whatsoever is inside the infinite volume.
 	//
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolInfinite& bvi, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINSIDE;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOfHelp(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINTERSECT;
 	}
@@ -680,79 +680,79 @@ public:
 	//
 	
 	//******************************************************************************************
-	virtual EBVType ebvGetType() const
+	virtual EBVType ebvGetType() const override
 	{
 		return ebvPOINT;
 	}
 
 	//******************************************************************************************
-	virtual int iSizeOf() const
+	virtual int iSizeOf() const override
 	{
 		return sizeof(*this);
 	}
 
 	//******************************************************************************************
-	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const
+	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const override
 	{
 		rv3_min = rv3_max = tf3.v3Pos;
 	}
 
 	//******************************************************************************************
-	virtual float fMaxExtent() const
+	virtual float fMaxExtent() const override
 	{
 		return 0;
 	}
 
 	//******************************************************************************************
-	virtual TReal rGetVolume(TReal) const
+	virtual TReal rGetVolume(TReal) const override
 	{
 		return 0;
 	}
 
 	//******************************************************************************************
-	virtual const CBoundVolPoint* pbvptCast() const { return this; }
+	virtual const CBoundVolPoint* pbvptCast() const override { return this; }
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const;
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override;
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const;
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolInfinite& bvi, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPoint& bvpt, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOfHelp(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return bv.esfSideOf(*this, ppr3_it, ppr3_this);
 	}
@@ -802,42 +802,42 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Save(int i_handle) const;
+	virtual void Save(int i_handle) const override;
 	
 	//******************************************************************************************
-	virtual EBVType ebvGetType() const
+	virtual EBVType ebvGetType() const override
 	{
 		return ebvSPHERE;
 	}
 
 	//******************************************************************************************
-	virtual int iSizeOf() const
+	virtual int iSizeOf() const override
 	{
 		return sizeof(*this);
 	}
 
 	//******************************************************************************************
-	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const;
+	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const override;
 
 	//******************************************************************************************
 	virtual float fMaxExtent
 	(
-	) const
+	) const override
 	{
 		return rRadius;
 	}
 
-	virtual const CBoundVolSphere* pbvsCast() const { return this; }
+	virtual const CBoundVolSphere* pbvsCast() const override { return this; }
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const;
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override;
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const;
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Invoke helper function for double dispatch.
 		return bv.esfSideOfHelp(*this, ppr3_it, ppr3_this);
@@ -845,41 +845,41 @@ public:
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolInfinite& bvi, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINTERSECT;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPoint& bvpt, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return CBoundVol::esfSideOf(bvpt, ppr3_this, ppr3_it);
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOfHelp(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Implement helper function for double dispatch.
 		return bv.esfSideOf(*this, ppr3_it, ppr3_this);
@@ -997,54 +997,54 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Save(int i_handle) const
+	virtual void Save(int i_handle) const override
 	{
 		Assert(0);
 	}
 	
 	//******************************************************************************************
-	virtual EBVType ebvGetType() const
+	virtual EBVType ebvGetType() const override
 	{
 		return ebvPLANE;
 	}
 
 	//******************************************************************************************
-	virtual int iSizeOf() const
+	virtual int iSizeOf() const override
 	{
 		return sizeof(*this);
 	}
 
 	//******************************************************************************************
-	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const
+	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const override
 	{
 		rv3_min = CVector3<>(FLT_MIN, FLT_MIN, FLT_MIN);
 		rv3_max = CVector3<>(FLT_MAX, FLT_MAX, FLT_MAX);
 	}
 	
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const;
+	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const override;
 
 	//******************************************************************************************
-	virtual float fMaxExtent() const
+	virtual float fMaxExtent() const override
 	{
 		return FLT_MAX;
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override
 	{
 		return CPlaneTolerance::esfSideOf(v3);
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override
 	{
 		return CPlaneTolerance::esfSideOf(pav3_solid);
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Invoke helper function for double dispatch.
 		return bv.esfSideOfHelp(*this, ppr3_it, ppr3_this);
@@ -1052,48 +1052,48 @@ public:
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolInfinite& bvi, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINTERSECT;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPoint& bvpt, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return CBoundVol::esfSideOf(bvpt, ppr3_this, ppr3_it);
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOfHelp(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Implement helper function for double dispatch.
 		return bv.esfSideOf(*this, ppr3_it, ppr3_this);
 	}
 
 	//******************************************************************************************
-	virtual TReal rGetVolume(TReal) const
+	virtual TReal rGetVolume(TReal) const override
 	{
 		return FLT_MAX;
 	}
@@ -1231,10 +1231,10 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Save(int i_handle) const;
+	virtual void Save(int i_handle) const override;
 	
 	//******************************************************************************************
-	virtual EBVType ebvGetType() const
+	virtual EBVType ebvGetType() const override
 	{
 		return ebvBOX;
 	}
@@ -1253,16 +1253,16 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual int iSizeOf() const
+	virtual int iSizeOf() const override
 	{
 		return sizeof(*this);
 	}
 
 	//******************************************************************************************
-	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const;
+	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const override;
 
 	//******************************************************************************************
-	virtual float fMaxExtent() const
+	virtual float fMaxExtent() const override
 	{
 		return rExtent;
 	}
@@ -1275,28 +1275,28 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual const CBoundVolBox* pbvbCast() const { return this; }
+	virtual const CBoundVolBox* pbvbCast() const override { return this; }
 
 	//
 	// Intersection functions.
 	//
 	
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const;
+	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const override;
 	
 	//******************************************************************************************
 	virtual bool bRayIntersect(SVolumeLoc* pvl_result, const CPresence3<>& pr3_this,
-		const CPlacement3<>& p3_origin, TReal r_length, TReal r_diameter) const;
+		const CPlacement3<>& p3_origin, TReal r_length, TReal r_diameter) const override;
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const;
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override;
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const;
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Invoke helper function for double dispatch.
 		return bv.esfSideOfHelp(*this, ppr3_it, ppr3_this);
@@ -1304,41 +1304,41 @@ public:
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolInfinite& bvi, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINTERSECT;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPoint& bvpt, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return CBoundVol::esfSideOf(bvpt, ppr3_this, ppr3_it);
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOfHelp(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Implement helper function for double dispatch.
 		return bv.esfSideOf(*this, ppr3_it, ppr3_this);
@@ -1348,7 +1348,7 @@ public:
 	//
 	virtual CTransform3<> tf3Box
 	(
-	) const;
+	) const override;
 	//
 	// Returns:
 	//		A transform which converts the unit cube (0..1) to this box (in object space).
@@ -1362,7 +1362,7 @@ public:
 	virtual CTransform3<> tf3Box
 	(
 		const CTransform3<>& tf3
-	) const;
+	) const override;
 	//
 	// Returns:
 	//		A transform which converts the unit cube (0..1) to this box (in object space).
@@ -1372,7 +1372,7 @@ public:
 	//**********************************
 
 	//******************************************************************************************
-	virtual TReal rGetVolume(TReal r_scale) const;
+	virtual TReal rGetVolume(TReal r_scale) const override;
 
 	//******************************************************************************************
 	//
@@ -1446,49 +1446,49 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Save(int i_handle) const
+	virtual void Save(int i_handle) const override
 	{
 		Assert(0);
 	}
 	
 	//******************************************************************************************
-	virtual EBVType ebvGetType() const
+	virtual EBVType ebvGetType() const override
 	{
 		return ebvPOLYHEDRON;
 	}
 
 	//******************************************************************************************
-	virtual int iSizeOf() const
+	virtual int iSizeOf() const override
 	{
 		return sizeof(*this);
 	}
 
 	//******************************************************************************************
-	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const;
+	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const override;
 
 	//******************************************************************************************
 	virtual float fMaxExtent
 	(
-	) const
+	) const override
 	{
 		return bvsSphere.rRadius;
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const;
+	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const override;
 
 	//******************************************************************************************
-	virtual const CBoundVolPolyhedron* pbvpCast() const { return this; }
+	virtual const CBoundVolPolyhedron* pbvpCast() const override { return this; }
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const;
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override;
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const;
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Invoke helper function for double dispatch.
 		return bv.esfSideOfHelp(*this, ppr3_it, ppr3_this);
@@ -1496,41 +1496,41 @@ public:
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolInfinite& bvi, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINTERSECT;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPoint& bvpt, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return CBoundVol::esfSideOf(bvpt, ppr3_this, ppr3_it);
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOfHelp(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Implement helper function for double dispatch.
 		return bv.esfSideOf(*this, ppr3_it, ppr3_this);
@@ -1599,35 +1599,35 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Save(int i_handle) const
+	virtual void Save(int i_handle) const override
 	{
 		Assert(0);
 	}
 	
 	//******************************************************************************************
-	virtual EBVType ebvGetType() const
+	virtual EBVType ebvGetType() const override
 	{
 		return ebvCAMERA;
 	}
 
 	//******************************************************************************************
-	virtual int iSizeOf() const
+	virtual int iSizeOf() const override
 	{
 		return sizeof(*this);
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const = 0;
+	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const override = 0;
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const = 0;
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override = 0;
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const = 0;
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override = 0;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Invoke helper function for double dispatch.
 		return bv.esfSideOfHelp(*this, ppr3_it, ppr3_this);
@@ -1635,47 +1635,47 @@ public:
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolInfinite& bvi, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return esfINTERSECT;
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPoint& bvpt, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		return CBoundVol::esfSideOf(bvpt, ppr3_this, ppr3_it);
 	}
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const = 0;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override = 0;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const = 0;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override = 0;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const = 0;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override = 0;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const = 0;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override = 0;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const = 0;
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override = 0;
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOfHelp(const CBoundVol& bv, 
-		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const
+		const CPresence3<>* ppr3_this = 0, const CPresence3<>* ppr3_it = 0) const override
 	{
 		// Implement helper function for double dispatch.
 		return bv.esfSideOf(*this, ppr3_it, ppr3_this);
 	}
 
-	virtual const CBoundVolCamera* pbvcamCast() const { return this; }
+	virtual const CBoundVolCamera* pbvcamCast() const override { return this; }
 
 	//
 	// Helper function for other classes intersecting with CBoundVolCamera.

--- a/jp2_pc/Source/Lib/Renderer/GeomTypesCamera.cpp
+++ b/jp2_pc/Source/Lib/Renderer/GeomTypesCamera.cpp
@@ -143,19 +143,19 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual float fMaxExtent() const
+	virtual float fMaxExtent() const override
 	{
 		return FLT_MAX;
 	}
 
 	//******************************************************************************************
-	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const
+	virtual void GetWorldExtents(const CTransform3<>& tf3, CVector3<>& rv3_min, CVector3<>& rv3_max) const override
 	{
 		AlwaysAssert(0);
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CVector3<>& v3) const
+	virtual ESideOf esfSideOf(const CVector3<>& v3) const override
 	{
 		if (clpLeft. bContains(v3) &&
 			clpRight.bContains(v3) &&
@@ -169,7 +169,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const
+	virtual ESideOf esfSideOf(CPArray< CVector3<> > pav3_solid) const override
 	{
 		ESideOf esf = 0;
 		ESideOf esf_sub;
@@ -198,7 +198,7 @@ public:
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolPlane& bvpl, 
-		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const
+		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const override
 	{
 		// If the volume is esfOUTSIDE, so is the plane.  Otherwise, they intersect.
 		return bvpl.esfSideOf(*this, ppr3_it, ppr3_this) == esfOUTSIDE ? esfOUTSIDE : esfINTERSECT;
@@ -206,7 +206,7 @@ public:
 
 	//******************************************************************************************
 	virtual ESideOf esfSideOf(const CBoundVolSphere& bvs, 
-		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const
+		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const override
 	{
 		// Transform the sphere.
 		CVolSphere vs_it(bvs.rRadius, ppr3_it);
@@ -239,7 +239,7 @@ public:
 	}
 	
 	//******************************************************************************************
-	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const
+	virtual ESideOf esfSideOf(const CTransform3<>& tf3_box) const override
 	{
 		// Intersect with each plane in turn.
 		ESideOf esf = 0;
@@ -269,7 +269,7 @@ public:
 
 	//******************************************************************************************
 	ESideOf esfSideOf(const CBoundVolBox& bvb, 
-		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const
+		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const override
 	{
 		// Get the box transform, transform by the required presence.
 		CTransform3<> tf3_box = ppr3_this || ppr3_it ? 
@@ -282,14 +282,14 @@ public:
 
 	//******************************************************************************************
 	ESideOf esfSideOf(const CBoundVolPolyhedron& bvp, 
-		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const
+		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const override
 	{
 		return bvp.esfIsSideOfPoints(*this, ppr3_it, ppr3_this);
 	}
 
 	//******************************************************************************************
 	ESideOf esfSideOf(const CBoundVolCamera& bvcam, 
-		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const
+		const CPresence3<>* ppr3_this, const CPresence3<>* ppr3_it) const override
 	{
 		return esfINTERSECT;
 	}
@@ -307,7 +307,7 @@ public:
 	//
 
 	//******************************************************************************************
-	CSet<EOutCode> seteocOutCodes(const CVector3<>& v3) const
+	CSet<EOutCode> seteocOutCodes(const CVector3<>& v3) const override
 	{
 		CSet<EOutCode> eoc;
 
@@ -342,7 +342,7 @@ public:
 
 	//******************************************************************************************
 	ESideOf esfClipPolygonInside(CRenderPolygon& rpoly, CPipelineHeap& plh, bool b_perspective,
-		CSet<EOutCode> seteoc_poly) const
+		CSet<EOutCode> seteoc_poly) const override
 	{
 		//
 		// This is pretty simple.  Clip the polygon against each plane in turn, returning
@@ -822,8 +822,8 @@ public:
 	}
 
 	//******************************************************************************************
-	TReal rEdgeT(const CVector3<>& v3_0, const CVector3<>& v3_1) const
-	{
+	TReal rEdgeT(const CVector3<>& v3_0, const CVector3<>& v3_1) const override
+    {
 		// Override this to avoid divide by 0 in template version.
 		return 0;
 	}

--- a/jp2_pc/Source/Lib/Renderer/Light.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Light.hpp
@@ -204,20 +204,20 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual const CBoundVol& bvGet() const
+	virtual const CBoundVol& bvGet() const override
 	{
 		// Not implemented yet.
 		return bviVolume;
 	}
 
 	//******************************************************************************************
-	virtual void Cast(rptr_const<CLight>* pplt) const
+	virtual void Cast(rptr_const<CLight>* pplt) const override
 	{
 		*pplt = rptr_const_this(this);
 	}
 
 	//******************************************************************************************
-	virtual rptr<CRenderType> prdtCopy()
+	virtual rptr<CRenderType> prdtCopy() override
 	{
 		// Not implemented yet.
 		Assert(false);
@@ -260,7 +260,7 @@ public:
 	// Overrides.
 	//
 
-	virtual SLightInfo ltiGetInfo(const CVector3<>&) const
+	virtual SLightInfo ltiGetInfo(const CVector3<>&) const override
 	{
 		// Returns constant, non-directional light.
 		return SLightInfo(lvIntensity);
@@ -300,12 +300,12 @@ public:
 	// Overrides.
 	//
 
-	virtual bool bIsDirectional() const
+	virtual bool bIsDirectional() const override
 	{
 		return true;
 	}
 
-	virtual void SetViewingContext(const CPresence3<>& pr3);
+	virtual void SetViewingContext(const CPresence3<>& pr3) override;
 
 	//******************************************************************************************
 	//
@@ -364,15 +364,15 @@ public:
 	// Overrides.
 	//
 
-	virtual void SetViewingContext(const CPresence3<>& pr3);
+	virtual void SetViewingContext(const CPresence3<>& pr3) override;
 
-	virtual SLightInfo ltiGetInfo(const CVector3<>&) const
+	virtual SLightInfo ltiGetInfo(const CVector3<>&) const override
 	{
 		return SLightInfo(lvIntensity, d3Dir, angwSize);
 	}
 
 	//******************************************************************************************
-	virtual void UpdateShadows(CPartition* ppart);
+	virtual void UpdateShadows(CPartition* ppart) override;
 	//
 	// Currently, this merely creates the buffer the first time this is called only.  
 	// Truly updating it comes later.
@@ -427,14 +427,14 @@ public:
 	// Overrides.
 	//
 
-	virtual bool bIsPositional() const
+	virtual bool bIsPositional() const override
 	{
 		return true;
 	}
 
-	virtual void SetViewingContext(const CPresence3<>& pr3);
+	virtual void SetViewingContext(const CPresence3<>& pr3) override;
 
-	virtual SLightInfo ltiGetInfo(const CVector3<>& v3) const;
+	virtual SLightInfo ltiGetInfo(const CVector3<>& v3) const override;
 };
 
 
@@ -483,9 +483,9 @@ public:
 	// Overrides.
 	//
 
-	virtual void SetViewingContext(const CPresence3<>& pr3);
+	virtual void SetViewingContext(const CPresence3<>& pr3) override;
 
-	virtual SLightInfo ltiGetInfo(const CVector3<>& v3) const;
+	virtual SLightInfo ltiGetInfo(const CVector3<>& v3) const override;
 };
 
 //**********************************************************************************************

--- a/jp2_pc/Source/Lib/Renderer/Particles.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Particles.cpp
@@ -500,7 +500,7 @@ public:
 	(
 		const CCamera& cam,
 		const CTransform3<>& tf3_to_norm_cam
-	);
+	) override;
 	//
 	// Prepares the particle to add to the renderer.
 	//
@@ -567,7 +567,7 @@ public:
 	(
 		const CCamera& cam,
 		const CTransform3<>& tf3_to_norm_cam
-	);
+	) override;
 	//
 	// Prepares the particle to add to the renderer.
 	//
@@ -629,7 +629,7 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual CVector3<> v3Position(TSec sec) const;
+	virtual CVector3<> v3Position(TSec sec) const override;
 
 protected:
 
@@ -637,7 +637,7 @@ protected:
 	void Setup();
 
 	//*****************************************************************************************
-	virtual float fCamSize(const CCamera& cam, float f_cam_y) const
+	virtual float fCamSize(const CCamera& cam, float f_cam_y) const override
 	{
 		// fSize refers to screen pixels, so convert to camera space.
 		return fSize * f_cam_y / (fScreenWidth * 0.5f);

--- a/jp2_pc/Source/Lib/Renderer/Primitives/FastBump.hpp
+++ b/jp2_pc/Source/Lib/Renderer/Primitives/FastBump.hpp
@@ -932,7 +932,7 @@ public:
 	//
 
 	//******************************************************************************************
-	TPixel pixFromColour(CColour clr) const
+	TPixel pixFromColour(CColour clr) const override
 	{
 		// Do a palette search to find best match to clr.  
 		// Return a CBumpAnglePair with default angles.
@@ -947,7 +947,7 @@ public:
 	}
 
 	//******************************************************************************************
-	CColour clrFromPixel(TPixel pix) const
+	CColour clrFromPixel(TPixel pix) const override
 	{
 		// Just extract colour from bump angle, and look up in palette.
 		int i_index = ((CBumpAnglePair&)pix).u1GetColour();

--- a/jp2_pc/Source/Lib/Renderer/RenderCache.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCache.hpp
@@ -147,7 +147,7 @@ public:
 		CRenderContext& renc, CShapePresence& rsp,
 		const CTransform3<>& tf3_shape_camera, const CPArray<COcclude*>& papoc,
 		ESideOf esf_view
-	) const;
+	) const override;
 	//
 	// Defined in Pipeline.cpp.
 	//
@@ -734,13 +734,13 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual void Execute();
+	virtual void Execute() override;
 
 	//*****************************************************************************************
-	virtual void PostScheduleExecute();
+	virtual void PostScheduleExecute() override;
 
 	//*****************************************************************************************
-	virtual void LogItem(CConsoleBuffer& con) const;
+	virtual void LogItem(CConsoleBuffer& con) const override;
 
 };
 

--- a/jp2_pc/Source/Lib/Renderer/RenderCacheLRUItem.hpp
+++ b/jp2_pc/Source/Lib/Renderer/RenderCacheLRUItem.hpp
@@ -71,7 +71,7 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual void Delete()
+	virtual void Delete() override
 	{
 		if (rcsRenderCacheSettings.bFreezeCaches)
 			return;

--- a/jp2_pc/Source/Lib/Renderer/ScreenRenderDWI.cpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenRenderDWI.cpp
@@ -209,7 +209,7 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual CSet<ERenderFeature> seterfModify()
+	virtual CSet<ERenderFeature> seterfModify() override
 	{
 		static const CSet<ERenderFeature> seterf_modify = Set
 		     (erfLIGHT)
@@ -246,7 +246,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual CSet<ERenderFeature> seterfDefault()
+	virtual CSet<ERenderFeature> seterfDefault() override
 	{
 		static const CSet<ERenderFeature> seterf_default = Set
 		     (erfZ_BUFFER)
@@ -281,7 +281,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual void UpdateSettings()
+	virtual void UpdateSettings() override
 	{
 		CorrectRenderState(pSettings->seterfState);
 		Assert(prasScreen);
@@ -290,19 +290,19 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual bool bTargetHardware() const
+	virtual bool bTargetHardware() const override
 	{
 		return prasScreen == prasMainScreen.ptGet() && d3dDriver.bUseD3D();
 	}
 
 	//******************************************************************************************
-	virtual bool bTargetMainScreen() const
+	virtual bool bTargetMainScreen() const override
 	{
 		return prasScreen == prasMainScreen.ptGet();
 	}
 
 	//******************************************************************************************
-	virtual TPixel pixSetBackground(TPixel pix_background)
+	virtual TPixel pixSetBackground(TPixel pix_background) override
 	{
 		TPixel pix_old = pixBackground;
 		pixBackground  = pix_background;
@@ -310,7 +310,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual void SetHardwareOut(bool b_allow_hardware)
+	virtual void SetHardwareOut(bool b_allow_hardware) override
 	{
 		bHardwareOut = false;
 
@@ -331,7 +331,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual void BeginFrame()
+	virtual void BeginFrame() override
 	{
 		Assert(prasScreen);
 
@@ -350,7 +350,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual void ClearMemSurfaces()
+	virtual void ClearMemSurfaces() override
 	{
 		if (pSettings->bClearBackground)
 		{
@@ -380,7 +380,7 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual void EndFrame()
+	virtual void EndFrame() override
 	{
 		// Double the lines on the screen.
 		if (pSettings->bDoubleVertical)
@@ -394,7 +394,7 @@ public:
 	virtual void DrawPolygons
 	(
 		CPArray<CRenderPolygon*> paprpoly
-	)
+	) override
 	{
 		// Set even scanlines only flag.
 		bEvenScanlinesOnly = pSettings->bHalfScanlines;
@@ -516,14 +516,14 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual CScreenRender* psrCreateCompatible(rptr<CRaster> pras_screen)
+	virtual CScreenRender* psrCreateCompatible(rptr<CRaster> pras_screen) override
 	{
 		Assert(pras_screen->iPixelBits == prasScreen->iPixelBits);
 		return new CScreenRenderDWIT<TPIX>(pSettings, pras_screen);
 	}
 
 	//******************************************************************************************
-	virtual void DrawPolygon(CRenderPolygon& rp);
+	virtual void DrawPolygon(CRenderPolygon& rp) override;
 };
 
 

--- a/jp2_pc/Source/Lib/Renderer/ScreenRenderDWI.hpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenRenderDWI.hpp
@@ -59,7 +59,7 @@ public:
 	(
 		CScreenRender::SSettings* pscrenset,	// Settings.
 		rptr<CRaster> pras_screen				// Screen raster.
-	);
+	) override;
 };
 
 // Global instance of this render descriptor.

--- a/jp2_pc/Source/Lib/Renderer/ScreenRenderShadow.cpp
+++ b/jp2_pc/Source/Lib/Renderer/ScreenRenderShadow.cpp
@@ -97,7 +97,7 @@ private:
 	//
 
 	//******************************************************************************************
-	virtual void BeginFrame()
+	virtual void BeginFrame() override
 	{
 		Assert(prasScreen);
 
@@ -112,13 +112,13 @@ private:
 	}
 
 	//******************************************************************************************
-	virtual void EndFrame()
+	virtual void EndFrame() override
 	{
 		prasScreen->Unlock();
 	}
 
 	//******************************************************************************************
-	virtual void DrawPolygons(CPArray<CRenderPolygon*> paprpoly)
+	virtual void DrawPolygons(CPArray<CRenderPolygon*> paprpoly) override
 	{
 		//CZBufferShadow::SetConversion(fSHADOW_Z_MULTIPLIER, 0);
 

--- a/jp2_pc/Source/Lib/Renderer/Shadow.cpp
+++ b/jp2_pc/Source/Lib/Renderer/Shadow.cpp
@@ -116,13 +116,13 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void BeginFrame()
+	virtual void BeginFrame() override
 	{
 		prasScreen->Lock();
 	}
 
 	//******************************************************************************************
-	virtual void EndFrame()
+	virtual void EndFrame() override
 	{
 		prasScreen->Unlock();
 	}
@@ -133,7 +133,7 @@ public:
 	//
 
 	//******************************************************************************************
-	void DrawPolygon(CRenderPolygon& rp)
+	void DrawPolygon(CRenderPolygon& rp) override
 	{
 		CCycleTimer ctmr;
 

--- a/jp2_pc/Source/Lib/Sys/ConIO.hpp
+++ b/jp2_pc/Source/Lib/Sys/ConIO.hpp
@@ -127,7 +127,7 @@ public:
 	//
 	virtual void Show
 	(
-	) const;
+	) const override;
 	//
 	// Displays characters in buffer onto the text output dialog box. Sizes the font to fit
 	// the entire buffer in the standard dialog box. Does nothing if the dialog box is closed.

--- a/jp2_pc/Source/Lib/Sys/DebugConsole.hpp
+++ b/jp2_pc/Source/Lib/Sys/DebugConsole.hpp
@@ -98,12 +98,12 @@ public:
 	// underflow and overflow are pure virtual and are the only 2 members that must be
 	// implemented.
 	//
-	int underflow();
+	int underflow() override;
 
 	//******************************************************************************************
 	// Makes a string out of a char and sends it to the debugger and optionally a file
 	//
-	int overflow(int ch);
+	int overflow(int ch) override;
 
 	//******************************************************************************************
 	// data members

--- a/jp2_pc/Source/Lib/Sys/Profile.hpp
+++ b/jp2_pc/Source/Lib/Sys/Profile.hpp
@@ -468,7 +468,7 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual void WriteToBuffer(CStrBuffer& strbuf, int i_indent = 0, bool b_show_hidden = false)
+	virtual void WriteToBuffer(CStrBuffer& strbuf, int i_indent = 0, bool b_show_hidden = false) override
 	//
 	// Outputs self and children to the buffer, with header.
 	//

--- a/jp2_pc/Source/Lib/Trigger/Action.hpp
+++ b/jp2_pc/Source/Lib/Trigger/Action.hpp
@@ -223,7 +223,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	// No data needs to be saved...
@@ -255,11 +255,11 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 	// override the action time function and return the time in seconds that the voiceover
 	// takes to play.
-	virtual TSec sGetActionTime()
+	virtual TSec sGetActionTime() override
 	{
 		return sActionLength;
 	}
@@ -310,7 +310,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No action needs to be saved
@@ -341,7 +341,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -367,7 +367,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -409,7 +409,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	// No data needs to be saved
@@ -447,7 +447,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -496,7 +496,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -555,7 +555,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -607,7 +607,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -648,7 +648,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -685,7 +685,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -715,7 +715,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -742,7 +742,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -768,7 +768,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -806,7 +806,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	// No data needs to be saved
@@ -845,7 +845,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	// No data needs to be saved
@@ -883,7 +883,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	// No data needs to be saved
@@ -924,7 +924,7 @@ public:
 
 	virtual ~CScriptedAnimationAction();
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	// No data needs to be saved
@@ -954,13 +954,13 @@ public:
 
 	//*****************************************************************************************
 	// The start function of this action does nothing at all
-	virtual void Start()
+	virtual void Start() override
 	{
 	}
 
 	//*****************************************************************************************
 	// Return the preset delay
-	virtual TSec sGetActionTime()
+	virtual TSec sGetActionTime() override
 	{
 		return sDelay;
 	}
@@ -994,7 +994,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	uint32	u4Handle;								// Trigger to affect.
@@ -1025,7 +1025,7 @@ public:
 
 	//*****************************************************************************************
 	// The start function of this action does nothing at all
-	virtual void Start();
+	virtual void Start() override;
 
 
 protected:
@@ -1065,11 +1065,11 @@ public:
 
 	//*****************************************************************************************
 	// The start function of this action does nothing at all
-	virtual void Start();
+	virtual void Start() override;
 
 	//*****************************************************************************************
 	// The length of a text action is the display period
-	virtual TSec sGetActionTime()
+	virtual TSec sGetActionTime() override
 	{
 		return TSec(fTime);
 	}

--- a/jp2_pc/Source/Lib/Trigger/GameActions.hpp
+++ b/jp2_pc/Source/Lib/Trigger/GameActions.hpp
@@ -79,7 +79,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	CFeeling	feelNewEmotions;	// The new emotional state of the animal.  If an entry is negative, do not change it.
@@ -106,7 +106,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	CAnimal*	paniTarget;			// The animal to affect.  Zero if none.
@@ -131,7 +131,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	
 protected:
 	// No data needs to be saved
@@ -164,8 +164,8 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
-	virtual void Stop();
+	virtual void Start() override;
+	virtual void Stop() override;
 	
 protected:
 	// No data needs to be saved
@@ -197,7 +197,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	// No data to save
@@ -229,7 +229,7 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
+	virtual void Start() override;
 	//virtual void Stop();
 	
 protected:
@@ -262,9 +262,9 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
-	virtual const char* pcLoad(const char* pc);
-	virtual char* pcSave(char* pc) const;
+	virtual void Start() override;
+	virtual const char* pcLoad(const char* pc) override;
+	virtual char* pcSave(char* pc) const override;
 	
 protected:
 	// bVisible needs to be saved
@@ -291,9 +291,9 @@ public:
 		CLoadWorld*				pload				// the loader.
 	);
 
-	virtual void Start();
-	virtual const char* pcLoad(const char* pc);
-	virtual char* pcSave(char* pc) const;
+	virtual void Start() override;
+	virtual const char* pcLoad(const char* pc) override;
+	virtual char* pcSave(char* pc) const override;
 	
 	static int iCurrentHint;						// Global hint ID (need to save).
 
@@ -324,9 +324,9 @@ public:
 
 	virtual ~CSubstituteAIAction();
 
-	virtual void Start();
-	virtual const char* pcLoad(const char* pc);
-	virtual char* pcSave(char* pc) const;
+	virtual void Start() override;
+	virtual const char* pcLoad(const char* pc) override;
+	virtual char* pcSave(char* pc) const override;
 
 protected:
 	uint32 u4HashTarget;		// Hash of names of instances to modify.
@@ -361,7 +361,7 @@ public:
 
 	//*****************************************************************************************
 	// The start function of this action tells the world the game is over.
-	virtual void Start();
+	virtual void Start() override;
 };
 
 //*********************************************************************************************
@@ -386,7 +386,7 @@ public:
 
 	//*****************************************************************************************
 	// The start function of this action tells the world the game is over.
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	bool bDropHeldItem;		// True if player should drop the thing she's holding
@@ -414,7 +414,7 @@ public:
 
 	//*****************************************************************************************
 	// The start function of this action tells the world the game is over.
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	bool bWakeUp;			// True if AI system should wake up, false if AI system should go to sleep.
@@ -444,7 +444,7 @@ public:
 
 	virtual ~CWaterDisturbanceAction ();
 
-	virtual void Start();
+	virtual void Start() override;
 
 protected:
 	uint32 u4Target;		// Hash of names of instances to modify.

--- a/jp2_pc/Source/Lib/Trigger/Trigger.hpp
+++ b/jp2_pc/Source/Lib/Trigger/Trigger.hpp
@@ -239,7 +239,7 @@ public:
 	//
 	// Overides.
 	//	
-	virtual const CBoundVol* pbvBoundingVol() const
+	virtual const CBoundVol* pbvBoundingVol() const override
 	{ 
 		return bv_BoundingVolume; 
 	}
@@ -250,7 +250,7 @@ public:
 	// trigger requires step messages it may overload this function, but this must be 
 	// called when the ewn function has finished so that delayed messages still get fired
 	//
-	virtual void Process(const CMessageStep& msgstep);
+	virtual void Process(const CMessageStep& msgstep) override;
 
 
 	//*****************************************************************************************
@@ -260,17 +260,17 @@ public:
 	// The defaul implemntation of this virtual function just calls the Move member
 	// of the instance base class.
 	//
-	virtual void Process(const CMessageMoveTriggerTo& msgmtrigto);
+	virtual void Process(const CMessageMoveTriggerTo& msgmtrigto) override;
 
 
 	//*****************************************************************************************
 	// the base class handles all boolean expressions through this message.
 	//
-	virtual void Process(const CMessageTrigger& trigmsg);
+	virtual void Process(const CMessageTrigger& trigmsg) override;
 
 
 	//*****************************************************************************************
-	virtual bool bIncludeInBuildPart() const
+	virtual bool bIncludeInBuildPart() const override
 	{
 		return false;
 	}
@@ -285,20 +285,20 @@ public:
 	virtual void Move(const CPlacement3<>& p3_new);
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
 	// override the default implementation in CPartition which assigns NULL.
 	//
-	virtual void Cast(CTrigger** pptr)
+	virtual void Cast(CTrigger** pptr) override
 	{
 		*pptr=this;
 	}
@@ -513,32 +513,32 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual bool bIncludeInBuildPart() const
+	virtual bool bIncludeInBuildPart() const override
 	{
 		return true;
 	}
 
 	//*****************************************************************************************
-	virtual void Process(const CMessageStep& msgstep);
+	virtual void Process(const CMessageStep& msgstep) override;
 
 	//*****************************************************************************************
-	virtual bool bEvaluateNow();
+	virtual bool bEvaluateNow() override;
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
-	virtual CInstance* pinsCopy() const;
+	virtual CInstance* pinsCopy() const override;
 	
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CLocationTrigger"; 
 	}
@@ -546,7 +546,7 @@ public:
 	//*****************************************************************************************
 	// override the default implementation in CPartition which assigns NULL.
 	//
-	virtual void Cast(CLocationTrigger** pptr)
+	virtual void Cast(CLocationTrigger** pptr) override
 	{
 		*pptr=this;
 	}
@@ -566,8 +566,8 @@ public:
 
 	// Messages to process.
 	//void Process(const CMessageHere& msg);
-	void Process(const CMessageMove& msg);
-	virtual void Process(const CMessageMoveTriggerTo& msgmtrigto);
+	void Process(const CMessageMove& msg) override;
+	virtual void Process(const CMessageMoveTriggerTo& msgmtrigto) override;
 
 	//*****************************************************************************************
 	static bool bValidateTriggerProperties
@@ -659,20 +659,20 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 	//*****************************************************************************************
-	virtual bool bEvaluateNow();
+	virtual bool bEvaluateNow() override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CCreatureTrigger"; 
 	}
@@ -684,9 +684,9 @@ public:
 
 	//******************************************************************************************
 	// Messages to process.
-	void Process(const CMessageDeath& msg);
-	void Process(const CMessageDamage& msg);
-	void Process(const CMessageMove& msg);
+	void Process(const CMessageDeath& msg) override;
+	void Process(const CMessageDamage& msg) override;
+	void Process(const CMessageMove& msg) override;
 
 	//*****************************************************************************************
 	static bool bValidateTriggerProperties
@@ -735,25 +735,25 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CObjectTrigger"; 
 	}
 
 	//******************************************************************************************
 	// these are the messages that this trigger will respond to..
-	void Process(const CMessagePickUp& msgpu);
-	void Process(const CMessageUse& msguse);
+	void Process(const CMessagePickUp& msgpu) override;
+	void Process(const CMessageUse& msguse) override;
 
 	//******************************************************************************************
 	// List control functions
@@ -805,25 +805,25 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CMagnetTrigger"; 
 	}
 
 	//******************************************************************************************
 	// these are the messages that this trigger will respond to..
-	void Process(const CMessageMagnetMove& msgmagm);
-	void Process(const CMessageMagnetBreak& msgmagb);
+	void Process(const CMessageMagnetMove& msgmagm) override;
+	void Process(const CMessageMagnetBreak& msgmagb) override;
 
 	//*****************************************************************************************
 	static bool bValidateTriggerProperties
@@ -875,26 +875,26 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char* pcSave(char* pc_buffer) const;
+	virtual char* pcSave(char* pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char* pcLoad(const char*  pc_buffer);
+	virtual const char* pcLoad(const char*  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char* buffer, int i_buffer_length);
+	virtual int iGetDescription(char* buffer, int i_buffer_length) override;
 #endif
 
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CStartTrigger";
 	}
 
 	//******************************************************************************************
 	// these are the messages that this trigger will respond to..
-	void Process(const CMessageStep& msgstep);
+	void Process(const CMessageStep& msgstep) override;
 
-	void Process(const CMessageSystem& msgsys);
+	void Process(const CMessageSystem& msgsys) override;
 
 	//*****************************************************************************************
 	static bool bValidateTriggerProperties
@@ -941,24 +941,24 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CCollisionTrigger"; 
 	}
 
 	//******************************************************************************************
 	// these are the messages that this trigger will respond to..
-	void Process(const CMessageCollision& msg);
+	void Process(const CMessageCollision& msg) override;
 
 	//*****************************************************************************************
 	static bool bValidateTriggerProperties
@@ -1018,24 +1018,24 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CSequenceTrigger"; 
 	}
 
 	//******************************************************************************************
 	// these are the messages that this trigger will respond to..
-	void Process(const CMessageTrigger& trigmsg);
+	void Process(const CMessageTrigger& trigmsg) override;
 
 	//*****************************************************************************************
 	// function will return true or false with regards to all the object references contained
@@ -1087,17 +1087,17 @@ public:
 
 	//******************************************************************************************
 	// these are the messages that this trigger will respond to..
-	void Process(const CMessageStep& msg);
+	void Process(const CMessageStep& msg) override;
 
 	//*****************************************************************************************
-	virtual bool bEvaluateNow();
+	virtual bool bEvaluateNow() override;
 	//
 	// Simply returns the current evaluate state of the trigger.
 	//
 	//*********************************
 
 	//******************************************************************************************
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CBooleanTrigger"; 
 	}
@@ -1140,27 +1140,27 @@ public:
 	~CTimerTrigger();
 
 	//******************************************************************************************
-	void Process(const CMessageStep& msg);
+	void Process(const CMessageStep& msg) override;
 
 	//******************************************************************************************
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CTimerTrigger"; 
 	}
 
 	//*****************************************************************************************
-	virtual char* pcSave(char*  pc_buffer) const;
+	virtual char* pcSave(char*  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
-	virtual bool bEvaluateNow()
+	virtual bool bEvaluateNow() override
 	{
 		return bState;
 	}
@@ -1209,20 +1209,20 @@ public:
 	~CVariableTrigger();
 
 	//******************************************************************************************
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CVariableTrigger"; 
 	}
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
 	//*****************************************************************************************
 	virtual bool bEvaluateNow
 	(
-	);
+	) override;
 	//
 	// Simply returns the current value of the trigger.
 	//
@@ -1292,20 +1292,20 @@ public:
 	//
 
 	//*****************************************************************************************
-	virtual char * pcSave(char *  pc_buffer) const;
+	virtual char * pcSave(char *  pc_buffer) const override;
 
 	//*****************************************************************************************
-	virtual const char * pcLoad(const char *  pc_buffer);
+	virtual const char * pcLoad(const char *  pc_buffer) override;
 
 	//*****************************************************************************************
-	virtual bool bEvaluateNow();
+	virtual bool bEvaluateNow() override;
 
 #if VER_TEST
 	//*****************************************************************************************
-	virtual int iGetDescription(char *buffer, int i_buffer_length);
+	virtual int iGetDescription(char *buffer, int i_buffer_length) override;
 #endif
 
-	const char* strPartType() const
+	const char* strPartType() const override
 	{ 
 		return "CMoreMassTrigger"; 
 	}

--- a/jp2_pc/Source/Lib/View/Grab.hpp
+++ b/jp2_pc/Source/Lib/View/Grab.hpp
@@ -298,7 +298,7 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Process(const CMessagePaint& msgpaint);
+	virtual void Process(const CMessagePaint& msgpaint) override;
 };
 
 

--- a/jp2_pc/Source/Lib/View/Pixel.cpp
+++ b/jp2_pc/Source/Lib/View/Pixel.cpp
@@ -78,7 +78,7 @@ public:
 	}
 
 	//******************************************************************************************
-	TPixel pixFromColour(CColour clr) const
+	TPixel pixFromColour(CColour clr) const override
 	{
 		// Do a palette search to find best match to clr.
 		Assert(ppalAttached);
@@ -86,7 +86,7 @@ public:
 	}
 
 	//******************************************************************************************
-	CColour clrFromPixel(TPixel pix) const
+	CColour clrFromPixel(TPixel pix) const override
 	{
 		// Just look up the palette colour.
 		Assert(ppalAttached);
@@ -113,13 +113,13 @@ public:
 	}
 
 	//******************************************************************************************
-	TPixel pixFromColour(CColour clr) const
+	TPixel pixFromColour(CColour clr) const override
 	{
 		return clr.u4Value;
 	}
 
 	//******************************************************************************************
-	CColour clrFromPixel(TPixel pix) const
+	CColour clrFromPixel(TPixel pix) const override
 	{
 		return CColour(pix, 0);
 	}
@@ -143,7 +143,7 @@ public:
 	}
 
 	//******************************************************************************************
-	TPixel pixFromColour(CColour clr) const
+	TPixel pixFromColour(CColour clr) const override
 	{
 		return (uShift1R(clr.u1Red,   3) << 11) |
 			   (uShift1R(clr.u1Green, 2) <<  5) |
@@ -151,7 +151,7 @@ public:
 	}
 
 	//******************************************************************************************
-	CColour clrFromPixel(TPixel pix) const
+	CColour clrFromPixel(TPixel pix) const override
 	{
 		return CColour
 		(
@@ -180,7 +180,7 @@ public:
 	}
 
 	//******************************************************************************************
-	TPixel pixFromColour(CColour clr) const
+	TPixel pixFromColour(CColour clr) const override
 	{
 		return (uShift1R(clr.u1Red,   3) << 10) |
 			   (uShift1R(clr.u1Green, 3) <<  5) |
@@ -188,7 +188,7 @@ public:
 	}
 
 	//******************************************************************************************
-	CColour clrFromPixel(TPixel pix) const
+	CColour clrFromPixel(TPixel pix) const override
 	{
 		return CColour
 		(
@@ -217,7 +217,7 @@ public:
 	}
 
 	//******************************************************************************************
-	TPixel pixFromColour(CColour clr) const
+	TPixel pixFromColour(CColour clr) const override
 	{
 		return (uShift1R(clr.u1Red,   4) << 8) |
 			   (uShift1R(clr.u1Green, 4) << 4) |
@@ -225,7 +225,7 @@ public:
 	}
 
 	//******************************************************************************************
-	CColour clrFromPixel(TPixel pix) const
+	CColour clrFromPixel(TPixel pix) const override
 	{
 		return CColour
 		(

--- a/jp2_pc/Source/Lib/View/Raster.cpp
+++ b/jp2_pc/Source/Lib/View/Raster.cpp
@@ -335,26 +335,26 @@
 		//
 
 		//******************************************************************************************
-		TPixel pixGet(int i_index) const
+		TPixel pixGet(int i_index) const override
 		{
 			return *ppixAddress(i_index);
 		}
 
 		//******************************************************************************************
-		void PutPixel(int i_index, TPixel pix)
+		void PutPixel(int i_index, TPixel pix) override
 		{
 			*ppixAddress(i_index) = pix;
 		}
 
 		//******************************************************************************************
-		virtual void Fill(int i_index, int i_count, TPixel pix)
+		virtual void Fill(int i_index, int i_count, TPixel pix) override
 		{
 			Assert(i_index + i_count <= rasbOwner.iTotalPixels());
 			::Fill(ppixAddress(i_index), i_count, PIX(pix));
 		}
 
 		//******************************************************************************************
-		virtual void Rect(const SRect& rect, TPixel pix)
+		virtual void Rect(const SRect& rect, TPixel pix) override
 		{
 			Assert(uint(rect.iY + rect.iHeight) <= rasbOwner.iHeight);
 

--- a/jp2_pc/Source/Lib/View/Raster.hpp
+++ b/jp2_pc/Source/Lib/View/Raster.hpp
@@ -1197,7 +1197,7 @@ public:
 	(
 		rptr<CRasterMem>	pras_ref,
 		bool				b_transparent = false
-	);
+	) override;
 
 	//******************************************************************************************
 	void DeleteRasterMemory

--- a/jp2_pc/Source/Lib/View/RasterD3D.hpp
+++ b/jp2_pc/Source/Lib/View/RasterD3D.hpp
@@ -315,7 +315,7 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void Lock();
+	virtual void Lock() override;
 
 	//******************************************************************************************
 	static bool bIsLockedAll()
@@ -324,13 +324,13 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual bool bIsLocked()
+	virtual bool bIsLocked() override
 	{
 		return bLocked;
 	}
 
 	//******************************************************************************************
-	virtual void Unlock();
+	virtual void Unlock() override;
 
 	//******************************************************************************************
 	//
@@ -338,7 +338,7 @@ public:
 	//
 
 	//******************************************************************************************
-	virtual void* pd3dtexGet()
+	virtual void* pd3dtexGet() override
 	{
 		Assert(pd3dtexTex);
 
@@ -348,34 +348,34 @@ public:
 	}
 
 	//******************************************************************************************
-	virtual bool bUpload();
+	virtual bool bUpload() override;
 
 	//******************************************************************************************
-	virtual bool bUpload(int i_x, int i_y, int i_width, int i_height);
+	virtual bool bUpload(int i_x, int i_y, int i_width, int i_height) override;
 
 	//******************************************************************************************
-	virtual void RemoveFromVideo();
+	virtual void RemoveFromVideo() override;
 
 	//******************************************************************************************
-	virtual void RemoveFromSystem();
+	virtual void RemoveFromSystem() override;
 
 	//******************************************************************************************
-	virtual uint32 u4GetTypeID() const;
+	virtual uint32 u4GetTypeID() const override;
 
 	//******************************************************************************************
-	virtual bool bRestore();
+	virtual bool bRestore() override;
 
 	//******************************************************************************************
-	virtual bool bVerifyConstruction() const;
+	virtual bool bVerifyConstruction() const override;
 
 	//******************************************************************************************
-	virtual bool bD3DRaster() const
+	virtual bool bD3DRaster() const override
 	{
 		return true;
 	}
 
 	//******************************************************************************************
-	virtual CRasterD3D* prasd3dGet();
+	virtual CRasterD3D* prasd3dGet() override;
 
 	//******************************************************************************************
 	//

--- a/jp2_pc/Source/Lib/View/RasterVid.hpp
+++ b/jp2_pc/Source/Lib/View/RasterVid.hpp
@@ -312,22 +312,22 @@ public:
 	// Overrides.
 	//
 
-	virtual void Lock();
+	virtual void Lock() override;
 
 	//******************************************************************************************
-	virtual bool bIsLocked()
+	virtual bool bIsLocked() override
 	{
 		return bLocked;
 	}
 
-	virtual void Unlock();
+	virtual void Unlock() override;
 
-	void AttachPalette(CPal* ppal, CPixelFormat* ppxf = 0);
+	void AttachPalette(CPal* ppal, CPixelFormat* ppxf = 0) override;
 
-	void Clear(TPixel pix);
+	void Clear(TPixel pix) override;
 
 	void Blit(int i_dx, int i_dy, CRaster& ras_src, SRect* prect_src = 0,			
-		bool b_clip = true, bool b_colour_key = 0, TPixel pix_colour_key = 0);
+		bool b_clip = true, bool b_colour_key = 0, TPixel pix_colour_key = 0) override;
 
 	//******************************************************************************************
 	//
@@ -506,11 +506,11 @@ public:
 
 	~CRasterWin();
 
-	bool bRestore(int i_dderr);
+	bool bRestore(int i_dderr) override;
 
 	bool bRestoreLostSurfaces();
 
-	void AttachPalette(CPal* ppal, CPixelFormat* ppxf = 0);
+	void AttachPalette(CPal* ppal, CPixelFormat* ppxf = 0) override;
 
 	//******************************************************************************************
 	//
@@ -639,7 +639,7 @@ public:
 	//**********************************
 	
 	//******************************************************************************************
-	virtual void Lock();
+	virtual void Lock() override;
 	
 	//******************************************************************************************
 	//

--- a/jp2_pc/Source/Test/AI/FakePhysics.hpp
+++ b/jp2_pc/Source/Test/AI/FakePhysics.hpp
@@ -159,7 +159,7 @@ public:
 		(
 			const CMessagePhysicsReq& msgpr,
 			CInstance *pins
-		) const;
+		) const override;
 };
 
 
@@ -202,7 +202,7 @@ public:
 		(
 			TSec secElapsedTime,
 			CInstance*	pins
-		) const;
+		) const override;
 		//
 		//	Adds intentionality to animal movement.
 		//

--- a/jp2_pc/Source/Test/AI/FakeShape.hpp
+++ b/jp2_pc/Source/Test/AI/FakeShape.hpp
@@ -136,7 +136,7 @@ class CShapeTree : public CTestShapeInfo
 		virtual void Draw
 		(
 			CInstance*	pins	// The object that is being drawn.
-		) const;
+		) const override;
 		//
 		//	Draws the object at current location with "this" shape.
 		//
@@ -164,7 +164,7 @@ class CShapeWall : public CTestShapeInfo
 		virtual void Draw
 		(
 			CInstance*	pins	// The object that is being drawn.
-		) const;
+		) const override;
 		//
 		//	Draws the object at current location with "this" shape.
 		//
@@ -193,7 +193,7 @@ class CShapeDinosaur : public CTestShapeInfo
 		virtual void Draw
 		(
 			CInstance*	pins	// The object that is being drawn.
-		) const;
+		) const override;
 		//
 		//	Draws the object at current location with "this" shape.
 		//
@@ -221,7 +221,7 @@ class CShapeSheep : public CTestShapeInfo
 		virtual void Draw
 		(
 			CInstance*	pins	// The object that is being drawn.
-		) const;
+		) const override;
 		//
 		//	Draws the object at current location with "this" shape.
 		//
@@ -251,7 +251,7 @@ class CShapeWolf : public CTestShapeInfo
 		virtual void Draw
 		(
 			CInstance*	pins	// The object that is being drawn.
-		) const;
+		) const override;
 		//
 		//	Draws the object at current location with "this" shape.
 		//
@@ -280,7 +280,7 @@ class CShapeMeat : public CTestShapeInfo
 		virtual void Draw
 		(
 			CInstance*	pins	// The object that is being drawn.
-		) const;
+		) const override;
 		//
 		//	Draws the object at current location with "this" shape.
 		//
@@ -308,7 +308,7 @@ class CShapeGrass : public CTestShapeInfo
 		virtual void Draw
 		(
 			CInstance*	pins	// The object that is being drawn.
-		) const;
+		) const override;
 		//
 		//	Draws the object at current location with "this" shape.
 		//

--- a/jp2_pc/Source/Test/AI/TestAnimal.hpp
+++ b/jp2_pc/Source/Test/AI/TestAnimal.hpp
@@ -269,7 +269,7 @@ public:
 	virtual void Process
 	(
 		const CMessageStep& msgstep
-	)
+	) override
 	{
 		if (pphiGetPhysicsInfo())
 		{

--- a/jp2_pc/Source/Test/AudioTest.cpp
+++ b/jp2_pc/Source/Test/AudioTest.cpp
@@ -104,7 +104,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/Test/AudioTest.h
+++ b/jp2_pc/Source/Test/AudioTest.h
@@ -21,7 +21,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAudioTestApp)
 	public:
-	virtual BOOL InitInstance();
+	virtual BOOL InitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/Test/AudioTestDoc.h
+++ b/jp2_pc/Source/Test/AudioTestDoc.h
@@ -29,17 +29,17 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAudioTestDoc)
 	public:
-	virtual BOOL OnNewDocument();
-	virtual void Serialize(CArchive& ar);
-	virtual void OnCloseDocument();
+	virtual BOOL OnNewDocument() override;
+	virtual void Serialize(CArchive& ar) override;
+	virtual void OnCloseDocument() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
 	virtual ~CAudioTestDoc();
 #ifdef _DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 	CAuScene * GetScene () { return pscene; }

--- a/jp2_pc/Source/Test/AudioTestView.h
+++ b/jp2_pc/Source/Test/AudioTestView.h
@@ -21,19 +21,19 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAudioTestView)
 	public:
-	virtual void OnDraw(CDC* pDC);  // overridden to draw this view
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
-	virtual void OnInitialUpdate();
+	virtual void OnDraw(CDC* pDC) override;  // overridden to draw this view
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
+	virtual void OnInitialUpdate() override;
 	protected:
-	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint);
+	virtual void OnUpdate(CView* pSender, LPARAM lHint, CObject* pHint) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
 	virtual ~CAudioTestView();
 #ifdef _DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 protected:

--- a/jp2_pc/Source/Test/MainFrm.h
+++ b/jp2_pc/Source/Test/MainFrm.h
@@ -17,15 +17,15 @@ public:
 // Overrides
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMainFrame)
-	virtual BOOL PreCreateWindow(CREATESTRUCT& cs);
+	virtual BOOL PreCreateWindow(CREATESTRUCT& cs) override;
 	//}}AFX_VIRTUAL
 
 // Implementation
 public:
 	virtual ~CMainFrame();
 #ifdef _DEBUG
-	virtual void AssertValid() const;
-	virtual void Dump(CDumpContext& dc) const;
+	virtual void AssertValid() const override;
+	virtual void Dump(CDumpContext& dc) const override;
 #endif
 
 protected:  // control bar embedded members

--- a/jp2_pc/Source/Test/Physics/WaveTest.cpp
+++ b/jp2_pc/Source/Test/Physics/WaveTest.cpp
@@ -340,7 +340,7 @@ public:
 	// Overrides.
 	//
 
-	void Init()
+	void Init() override
 	{
 		vpScr.SetVirtualSize(mLength, -mLength);
 		vpScr.SetVirtualOrigin(0, -mLength/2);
@@ -348,12 +348,12 @@ public:
 		SetContinuous(true);
 	}
 
-	void NewRaster()
+	void NewRaster() override
 	{
 		vpScr.SetSize(prasMainScreen->iWidth, prasMainScreen->iHeight);
 	}
 
-	void Paint()
+	void Paint() override
 	{ 
 		prasMainScreen->Clear(CColour(0, 0, 0));
 
@@ -381,7 +381,7 @@ public:
 		}
 	}
 
-	void Step()
+	void Step() override
 	{
 		if (bFirst)
 		{
@@ -398,13 +398,13 @@ public:
 		conStd.Show();
 	}
 
-	void MouseMove(int i_x, int i_y)
+	void MouseMove(int i_x, int i_y) override
 	{
 		// Call function handling virtual coordinates.
 		MouseMove(CVector2<>(vpScr.vcVirtualX(i_x), vpScr.vcVirtualY(i_y)));
 	}
 
-	void KeyPress(int i_key)
+	void KeyPress(int i_key) override
 	{
 		switch (i_key)
 		{
@@ -866,7 +866,7 @@ public:
 	};
 
 	//********************************************************************************************
-	void Init()
+	void Init() override
 	{
 #if GREY
 		vpScr.SetVirtualSize(mLength, mWidth, true);
@@ -889,7 +889,7 @@ public:
 	}
 
 	//********************************************************************************************
-	void NewRaster()
+	void NewRaster() override
 	{
 		vpScr.SetSize(prasMainScreen->iWidth, prasMainScreen->iHeight);
 #if GREY
@@ -901,7 +901,7 @@ public:
 	}
 
 	//********************************************************************************************
-	void Paint()
+	void Paint() override
 	{ 
 #if GREY
 		// Fill the screen with the water map, showing height via colour.
@@ -1026,7 +1026,7 @@ public:
 	}
 
 	//********************************************************************************************
-	void Step()
+	void Step() override
 	{
 		if (bFirst)
 		{
@@ -1045,7 +1045,7 @@ public:
 	}
 
 	//********************************************************************************************
-	void KeyPress(int i_key)
+	void KeyPress(int i_key) override
 	{
 		switch (i_key)
 		{
@@ -1106,14 +1106,14 @@ public:
 	}
 
 	//********************************************************************************************
-	void MouseMove(int i_x, int i_y)
+	void MouseMove(int i_x, int i_y) override
 	{
 		// Call function handling virtual coordinates.
 		MouseMove(CVector2<>(vpScr.vcVirtualX(i_x), vpScr.vcVirtualY(i_y)));
 	}
 
 	//********************************************************************************************
-	void MenuCommand(int i_command, bool*)
+	void MenuCommand(int i_command, bool*) override
 	{
 		switch (i_command)
 		{

--- a/jp2_pc/Source/Test/Test3DObjs.hpp
+++ b/jp2_pc/Source/Test/Test3DObjs.hpp
@@ -130,7 +130,7 @@ public:
 	}
 
 
-	virtual void Process(const CMessageStep& msgstep)
+	virtual void Process(const CMessageStep& msgstep) override
 	{
 		if (!v3RotateVelocity.bIsZero())
 			pr3Presence().r3Rot *= v3RotateVelocity;

--- a/jp2_pc/Source/Test/TestBump.cpp
+++ b/jp2_pc/Source/Test/TestBump.cpp
@@ -316,7 +316,7 @@ public:
 	(
 		CScanPoly<real, CCoord>& scanp,		// Scan-polygon iterator.
 		int i_light							// The lighting value to use.
-	);
+	) override;
 
 	//******************************************************************************************
 	//
@@ -325,7 +325,7 @@ public:
 		CScanPoly<real, CCoord>& scanp,			// Scan-polygon iterator.
 		CRasterSimple<CBumpDir>& ras_normals,	// Normal-map encoding bumps.
 		CLight& lt								// The lighting to apply.
-	);
+	) override;
 };
 
 //**********************************************************************************************
@@ -871,7 +871,7 @@ protected:
 	}
 
 public:
-	void Init()
+	void Init() override
 	{
 #if GAMMATEST
 		u1Intensity = 128;
@@ -886,7 +886,7 @@ public:
 #endif
 	}
 
-	void NewRaster()
+	void NewRaster() override
 	{
 #if !GAMMATEST
 		Init();
@@ -905,7 +905,7 @@ public:
 	}
 */
 
-	void Step()
+	void Step() override
 	{
 #if !GAMMATEST
 		::Step();
@@ -913,7 +913,7 @@ public:
 #endif
 	}
 
-	void Paint()
+	void Paint() override
 	{
 #if GAMMATEST
 		prasMainScreen->Clear(0);
@@ -963,7 +963,7 @@ public:
 #endif
 	}
 
-	void KeyPress(int i_key)
+	void KeyPress(int i_key) override
 	{
 #if GAMMATEST
 		switch (i_key)

--- a/jp2_pc/Source/Test/TestMath.cpp
+++ b/jp2_pc/Source/Test/TestMath.cpp
@@ -80,7 +80,7 @@ public:
 
 	int iRefreshCount;
 
-	void Init()
+	void Init() override
 	{
 		iRefreshCount = 0;
 
@@ -95,7 +95,7 @@ public:
 		SetContinuous(true);
 	}
 
-	void Step()
+	void Step() override
 	{
 		float f_approx_sqrt, f_accurate_sqrt, f_diff_sqrt;
 		float f_approx_inv_sqrt, f_accurate_inv_sqrt, f_diff_inv_sqrt;
@@ -158,7 +158,7 @@ public:
 
 
 	//******************************************************************************************
-	void Paint()
+	void Paint() override
 	{
 		//
 		// Test random number generator.

--- a/jp2_pc/Source/Test/TestPipeLine.cpp
+++ b/jp2_pc/Source/Test/TestPipeLine.cpp
@@ -365,7 +365,7 @@ public:
 	}
 
 	//******************************************************************************************
-	void Init()
+	void Init() override
 	{
 		// Set flag to initialize only once.
 		if (bIsInitialized)
@@ -410,7 +410,7 @@ public:
 
 
 	//******************************************************************************************
-	void Step()
+	void Step() override
 	{
 		// Print general render stats.
 		conStd.SetCursorPosition(0, uStatLine);
@@ -438,7 +438,7 @@ public:
 
 
 	//******************************************************************************************
-	void Paint()
+	void Paint() override
 	{
 		prasMainScreen->Clear(0);
 
@@ -486,7 +486,7 @@ public:
 	}
 
 	//******************************************************************************************
-	void KeyPress(int c_key_code)
+	void KeyPress(int c_key_code) override
 	{
 /*
 		// Get a pointer to the main camera.
@@ -956,7 +956,7 @@ public:
 */
 	}
 
-	void NewRaster()
+	void NewRaster() override
 	{
 		ShowMenuAndStats();
 

--- a/jp2_pc/Source/Test/attribdlg.h
+++ b/jp2_pc/Source/Test/attribdlg.h
@@ -38,7 +38,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CSoundAttribDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -46,7 +46,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CSoundAttribDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };
@@ -78,7 +78,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CListenerAttribDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -114,7 +114,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CEnvAttribDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -144,7 +144,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CSceneAttribDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -177,7 +177,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CMusicSoundAttribDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/Tools/CollisionEditor/CollisionEditor.h
+++ b/jp2_pc/Source/Tools/CollisionEditor/CollisionEditor.h
@@ -31,8 +31,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CCollisionEditorApp)
 	public:
-	virtual BOOL InitInstance();
-	virtual int ExitInstance();
+	virtual BOOL InitInstance() override;
+	virtual int ExitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/Tools/CollisionEditor/CollisionEditorDlg.cpp
+++ b/jp2_pc/Source/Tools/CollisionEditor/CollisionEditorDlg.cpp
@@ -50,7 +50,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/Tools/CollisionEditor/CollisionEditorDlg.h
+++ b/jp2_pc/Source/Tools/CollisionEditor/CollisionEditorDlg.h
@@ -29,8 +29,8 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CCollisionEditorDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
-	virtual void OnCancel();
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
+	virtual void OnCancel() override;
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -39,7 +39,7 @@ protected:
 	bool	bModified;
 	// Generated message map functions
 	//{{AFX_MSG(CCollisionEditorDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();

--- a/jp2_pc/Source/Tools/CollisionEditor/EditMaterialDlg.h
+++ b/jp2_pc/Source/Tools/CollisionEditor/EditMaterialDlg.h
@@ -257,7 +257,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CEditMaterialDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -265,7 +265,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CEditMaterialDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnPaint();
 	afx_msg	void OnTestS1();
 	afx_msg	void OnTestS2();
@@ -279,7 +279,7 @@ protected:
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 	afx_msg void OnVScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 
-	virtual void OnOK();
+	virtual void OnOK() override;
 	afx_msg void OnSelChangeList();
 	afx_msg void OnTestSample();
 	afx_msg void OnStopSample();

--- a/jp2_pc/Source/Tools/CollisionEditor/SampleListDlg.h
+++ b/jp2_pc/Source/Tools/CollisionEditor/SampleListDlg.h
@@ -20,7 +20,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CSampleListDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -29,7 +29,7 @@ protected:
 
 	//{{AFX_MSG(CSampleListDlg)
 
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnHScroll(UINT nSBCode, UINT nPos, CScrollBar* pScrollBar);
 
 	//}}AFX_MSG

--- a/jp2_pc/Source/Tools/GroffExp/GroffExp.cpp
+++ b/jp2_pc/Source/Tools/GroffExp/GroffExp.cpp
@@ -184,7 +184,7 @@ public:
 	//
 	int ExtCount
 	(
-	)
+	) override
 	{
 		// Currently there is only one format supported.
 		return 1;
@@ -197,7 +197,7 @@ public:
 	const TCHAR* Ext
 	(
 		int n
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -205,14 +205,14 @@ public:
 	//
 	const TCHAR* LongDesc
 	(
-	);
+	) override;
 
 	//******************************************************************************************
 	// Short ASCII file export description.
 	//
 	const TCHAR* ShortDesc
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -220,7 +220,7 @@ public:
 	//
 	const TCHAR* AuthorName
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -228,7 +228,7 @@ public:
 	//
 	const TCHAR* CopyrightMessage
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -236,7 +236,7 @@ public:
 	//
 	const TCHAR* OtherMessage1
 	(
-	)
+	) override
 	{ 
 		return _T(""); 
 	}
@@ -247,7 +247,7 @@ public:
 	//
 	const TCHAR* OtherMessage2
 	(
-	)
+	) override
 	{ 
 		return _T(""); 
 	}
@@ -258,7 +258,7 @@ public:
 	//
 	unsigned int Version
 	(
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -267,7 +267,7 @@ public:
 	void ShowAbout
 	(
 		HWND hWnd
-	);
+	) override;
 
 
 	//******************************************************************************************
@@ -278,7 +278,7 @@ public:
 		const TCHAR*  tchr_export_name,		// File name and path to export to.
 		ExpInterface* pei_export_interface,	// Class for enumerating the nodes in the scene.
 		Interface*    pip_interface			// Interface pointer for calling MAX API's.
-	);
+	) override;
 };
 
 
@@ -301,7 +301,7 @@ public:
 	//
 	int IsPublic
 	(
-	)
+	) override
 	{ 
 		return true;
 	}
@@ -312,7 +312,7 @@ public:
 	void* Create
 	(
 		BOOL loading = false
-	)
+	) override
 	{ 
 		return new JP2Export;
 	}
@@ -322,7 +322,7 @@ public:
 	//
 	const TCHAR* ClassName
 	(
-	)
+	) override
 	{ 
 		return guiInterface.strGetString(IDS_JP2_CLASSNAME); 
 	}
@@ -332,7 +332,7 @@ public:
 	//
 	SClass_ID SuperClassID
 	(
-	)
+	) override
 	{ 
 		return SCENE_EXPORT_CLASS_ID; 
 	}
@@ -342,7 +342,7 @@ public:
 	//
 	Class_ID ClassID
 	(
-	)
+	) override
 	{ 
 		return Class_ID(0x297455F, 0x17C9693D); 
 	}
@@ -352,7 +352,7 @@ public:
 	//
 	const TCHAR* Category
 	(
-	)
+	) override
 	{ 
 		return guiInterface.strGetString(IDS_JP2_EXPORTER);  
 	}
@@ -468,7 +468,7 @@ public:
 	int callback
 	(
 		INode* pin_inode
-	);
+	) override;
 	
 
 	//*****************************************************************************************

--- a/jp2_pc/Source/Tools/QuantizerTool/QuantizerTool.h
+++ b/jp2_pc/Source/Tools/QuantizerTool/QuantizerTool.h
@@ -21,7 +21,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CQuantizerToolApp)
 	public:
-	virtual BOOL InitInstance();
+	virtual BOOL InitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/Tools/QuantizerTool/QuantizerToolDlg.cpp
+++ b/jp2_pc/Source/Tools/QuantizerTool/QuantizerToolDlg.cpp
@@ -27,7 +27,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/Tools/QuantizerTool/QuantizerToolDlg.h
+++ b/jp2_pc/Source/Tools/QuantizerTool/QuantizerToolDlg.h
@@ -19,7 +19,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CQuantizerToolDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -28,7 +28,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CQuantizerToolDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnDestroy();
 	afx_msg void OnPaint();

--- a/jp2_pc/Source/Trespass/ctrls.h
+++ b/jp2_pc/Source/Trespass/ctrls.h
@@ -124,9 +124,9 @@ public:
     CUIStatic(CUICtrlCallback * pParent);
     virtual ~CUIStatic();
 
-    BOOL    TokenLoad(HANDLE hFile);
+    BOOL    TokenLoad(HANDLE hFile) override;
 
-    void    Draw(CRaster * pDst, RECT * prcClip);
+    void    Draw(CRaster * pDst, RECT * prcClip) override;
     BOOL    SetRaster(CRaster * pRaster, bool bTrans = TRUE);
 
     void    Init();
@@ -154,21 +154,21 @@ public:
     CUIButton(CUICtrlCallback * pParent);
     virtual ~CUIButton();
 
-    virtual void    DoFrame(POINT ptMouse);
-    virtual void    Draw(CRaster * pRaster, RECT * prcClip);
+    virtual void    DoFrame(POINT ptMouse) override;
+    virtual void    Draw(CRaster * pRaster, RECT * prcClip) override;
 
-    virtual void    MouseMove(int x, int y, UINT keyFlags);
-    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags);
-    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags);
+    virtual void    MouseMove(int x, int y, UINT keyFlags) override;
+    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags) override;
+    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags) override;
 
-    virtual BOOL    TokenLoad(HANDLE hFile);
+    virtual BOOL    TokenLoad(HANDLE hFile) override;
     virtual BOOL    SetRaster(CRaster * psprite, int iState);
     virtual CRaster * GetRaster();
 
-    virtual BOOL    HitTest(POINT pt);
+    virtual BOOL    HitTest(POINT pt) override;
     virtual void    Init();
 
-    virtual void    ReleaseCapture();
+    virtual void    ReleaseCapture() override;
 
 protected:
     UINT             m_uiCmd;
@@ -200,19 +200,19 @@ public:
     CUIListbox(CUICtrlCallback * pParent);
     virtual ~CUIListbox();
 
-    virtual CUICtrl *   CaptureMouse(CUICtrl * pctrl){return m_pParent->CaptureMouse(pctrl);}
-    virtual void        ReleaseMouse(CUICtrl * pctrl){m_pParent->ReleaseMouse(pctrl);}
-    virtual void        UIButtonUp(CUIButton * pbutton);
-    virtual void        CtrlInvalidateRect(RECT * prc) {m_pParent->CtrlInvalidateRect(prc);}
-    virtual void        ReleaseCapture();
+    virtual CUICtrl *   CaptureMouse(CUICtrl * pctrl) override {return m_pParent->CaptureMouse(pctrl);}
+    virtual void        ReleaseMouse(CUICtrl * pctrl) override {m_pParent->ReleaseMouse(pctrl);}
+    virtual void        UIButtonUp(CUIButton * pbutton) override;
+    virtual void        CtrlInvalidateRect(RECT * prc) override {m_pParent->CtrlInvalidateRect(prc);}
+    virtual void        ReleaseCapture() override;
 
-    virtual void    DoFrame(POINT ptMouse);
-    virtual void    Draw(CRaster * pRaster, RECT * prcClip);
+    virtual void    DoFrame(POINT ptMouse) override;
+    virtual void    Draw(CRaster * pRaster, RECT * prcClip) override;
 
-    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags);
-    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags);
+    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags) override;
+    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags) override;
 
-    virtual BOOL    TokenLoad(HANDLE hFile);
+    virtual BOOL    TokenLoad(HANDLE hFile) override;
 
             BOOL    Initialize();
 
@@ -325,18 +325,18 @@ public:
     CUICheckbox(CUICtrlCallback * pParent);
     virtual ~CUICheckbox();
 
-    virtual void    DoFrame(POINT ptMouse);
-    virtual void    Draw(CRaster * pRaster, RECT * prcClip);
+    virtual void    DoFrame(POINT ptMouse) override;
+    virtual void    Draw(CRaster * pRaster, RECT * prcClip) override;
 
-    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags);
-    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags);
+    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags) override;
+    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags) override;
 
-    virtual BOOL    TokenLoad(HANDLE hFile);
+    virtual BOOL    TokenLoad(HANDLE hFile) override;
 
     virtual BOOL    GetDown() { return m_bDown; }
     virtual void    SetDown(BOOL bDown) { if (bDown != m_bDown) { m_bDown = bDown; InvalidateSelf(); } }
 
-    virtual void    ReleaseCapture();
+    virtual void    ReleaseCapture() override;
 
 private:
     UINT            m_uiCmd;
@@ -354,13 +354,13 @@ public:
     CUITextbox(CUICtrlCallback * pParent);
     virtual ~CUITextbox();
 
-    virtual void    Draw(CRaster * pRaster, RECT * prcClip);
+    virtual void    Draw(CRaster * pRaster, RECT * prcClip) override;
     virtual void    Draw(LPBYTE pbDst,
                          int iDstWidth,
                          int iDstHeight,
                          int iDstPitch,
                          int iDstBytes,
-                         RECT * prcClip);
+                         RECT * prcClip) override;
 
     virtual void    SetPalette(HPALETTE hpal);
     virtual void    SetPalette(LOGPALETTE * plogpal);
@@ -392,7 +392,7 @@ public:
     virtual BYTE    GetBackLitOffset() { return m_bBackLitOffset;}
     virtual void    SetBackLitOffset(BYTE bOffset) { m_bBackLitOffset = bOffset; m_pParent->CtrlInvalidateRect(&m_rc); m_bUpdate = TRUE; }
 
-    virtual BOOL    TokenLoad(HANDLE hFile);
+    virtual BOOL    TokenLoad(HANDLE hFile) override;
 
     virtual BOOL InitSurface();
 private:
@@ -422,8 +422,8 @@ public:
     CUISlider(CUICtrlCallback * pParent);
     virtual ~CUISlider();
 
-    virtual void    DoFrame(POINT ptMouse);
-    virtual void    Draw(CRaster * pRaster, RECT * prcClip);
+    virtual void    DoFrame(POINT ptMouse) override;
+    virtual void    Draw(CRaster * pRaster, RECT * prcClip) override;
 
     virtual BOOL    GetBorder() { return m_bBorder;}
     virtual void    SetBorder(BOOL bBorder) { m_bBorder = bBorder;}
@@ -434,13 +434,13 @@ public:
     virtual int     GetCurrUnit() { return m_iCurrUnit; }
     virtual void    SetCurrUnit(int iUnit);
 
-    virtual void    MouseMove(int x, int y, UINT keyFlags);
-    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags);
-    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags);
+    virtual void    MouseMove(int x, int y, UINT keyFlags) override;
+    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags) override;
+    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags) override;
 
-    virtual BOOL    TokenLoad(HANDLE hFile);
+    virtual BOOL    TokenLoad(HANDLE hFile) override;
 
-    virtual void    ReleaseCapture();
+    virtual void    ReleaseCapture() override;
 
 private:
     UINT            m_uiCmd;
@@ -464,11 +464,11 @@ public:
     CUIEditbox(CUICtrlCallback * pParent);
     virtual ~CUIEditbox();
 
-    virtual void    DoFrame(POINT ptMouse);
-    virtual void    Draw(CRaster * pRaster, RECT * prcClip);
+    virtual void    DoFrame(POINT ptMouse) override;
+    virtual void    Draw(CRaster * pRaster, RECT * prcClip) override;
 
-    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags);
-    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags);
+    virtual BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags) override;
+    virtual BOOL    LButtonUp(int x, int y, UINT keyFlags) override;
 
     virtual void    OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags);
     virtual void    OnChar(TCHAR tch, int cRepeat);
@@ -494,7 +494,7 @@ public:
     virtual BOOL    GetBorder() { return m_bBorder;}
     virtual void    SetBorder(BOOL bBorder) { m_bBorder = bBorder; m_bUpdate = TRUE;}
 
-    virtual BOOL    TokenLoad(HANDLE hFile);
+    virtual BOOL    TokenLoad(HANDLE hFile) override;
 
 protected:
     int             m_iMaxSize;
@@ -526,14 +526,14 @@ public:
     CUIProgressBar(CUICtrlCallback * pParent);
     virtual ~CUIProgressBar();
 
-    BOOL  TokenLoad(HANDLE hFile);
-    void  Draw(CRaster * pRaster, RECT * prcClip);
+    BOOL  TokenLoad(HANDLE hFile) override;
+    void  Draw(CRaster * pRaster, RECT * prcClip) override;
     void  Draw(LPBYTE pbDst,
                int iDstWidth,
                int iDstHeight,
                int iDstPitch,
                int iDstBytes,
-               RECT * prcClip);
+               RECT * prcClip) override;
 
     int   DeltaPos(int iIncrement);
     int   SetPos(int iNewPos);
@@ -559,12 +559,12 @@ public:
     CUIHotspot(CUICtrlCallback * pParent);
     virtual ~CUIHotspot();
 
-    BOOL  TokenLoad(HANDLE hFile);
-    void  Draw(CRaster * pRaster, RECT * prcClip);
+    BOOL  TokenLoad(HANDLE hFile) override;
+    void  Draw(CRaster * pRaster, RECT * prcClip) override;
 
-    void    MouseMove(int x, int y, UINT keyFlags);
-    BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags);
-    BOOL    LButtonUp(int x, int y, UINT keyFlags);
+    void    MouseMove(int x, int y, UINT keyFlags) override;
+    BOOL    LButtonDown(int x, int y, BOOL bDoubleClick, UINT keyFlags) override;
+    BOOL    LButtonUp(int x, int y, UINT keyFlags) override;
 
 protected:
     bool        m_bFrame;

--- a/jp2_pc/Source/Trespass/dialogs.h
+++ b/jp2_pc/Source/Trespass/dialogs.h
@@ -233,7 +233,7 @@ public:
     virtual ~CMultiWnd() {;}
 
 protected:
-    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) override;
 };
 
 
@@ -258,10 +258,10 @@ public:
     virtual void    OnOK();
 
 protected:
-    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+    virtual LRESULT BaseHandler(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) override;
 
-    virtual void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify);
-    virtual BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam);
+    virtual void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify) override;
+    virtual BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam) override;
 };
 
 

--- a/jp2_pc/Source/Trespass/keyremap.h
+++ b/jp2_pc/Source/Trespass/keyremap.h
@@ -26,17 +26,17 @@ public:
     CControlsWnd(CUIManager * puimgr);
     virtual ~CControlsWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
-    void UIButtonUp(CUIButton * pbutton);
-    void UIHotspotClick(CUIHotspot * pctrl, BOOL bDown);
-    void OnActivateApp(BOOL fActivate, DWORD dwThreadId);
+    void GetWndFile(LPSTR psz, int ic) override;
+    void UIButtonUp(CUIButton * pbutton) override;
+    void UIHotspotClick(CUIHotspot * pctrl, BOOL bDown) override;
+    void OnActivateApp(BOOL fActivate, DWORD dwThreadId) override;
 
-    void OnMButtonDown(BOOL fDoubleClick, int x, int y, UINT keyFlags);
-    void OnLButtonDown(BOOL fDoubleClick, int x, int y, UINT keyFlags);
-    void OnRButtonDown(BOOL fDoubleClick, int x, int y, UINT keyFlags);
-    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags);
+    void OnMButtonDown(BOOL fDoubleClick, int x, int y, UINT keyFlags) override;
+    void OnLButtonDown(BOOL fDoubleClick, int x, int y, UINT keyFlags) override;
+    void OnRButtonDown(BOOL fDoubleClick, int x, int y, UINT keyFlags) override;
+    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags) override;
 
 protected:
     bool        m_bKeyWait;

--- a/jp2_pc/Source/Trespass/main.h
+++ b/jp2_pc/Source/Trespass/main.h
@@ -93,10 +93,10 @@ public:
     CConfigureWnd();
     virtual ~CConfigureWnd();
 
-    BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam);
-    void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify);
-    void OnCancel();
-    void OnOK();
+    BOOL OnInitDialog(HWND hwnd, HWND hwndFocus, LPARAM lParam) override;
+    void OnCommand(HWND hwnd, int id, HWND hwndCtl, UINT codeNotify) override;
+    void OnCancel() override;
+    void OnOK() override;
 
 private:
 

--- a/jp2_pc/Source/Trespass/rasterdc.hpp
+++ b/jp2_pc/Source/Trespass/rasterdc.hpp
@@ -26,9 +26,9 @@ public:
     CRasterDC(HDC hdcBase, int iWidth, int iHeight, int iBits);
     virtual ~CRasterDC();
 
-    void Lock();
-    void Unlock();
-    void Clear(TPixel pix);
+    void Lock() override;
+    void Unlock() override;
+    void Clear(TPixel pix) override;
 
     void Blit(int idx, 
               int idy, 
@@ -36,7 +36,7 @@ public:
               SRect* prect_src = 0,
               bool b_clip = true, 
               bool b_colour_key = 0,
-              TPixel pix_colour_key = 0);
+              TPixel pix_colour_key = 0) override;
 
     HDC hdcGet();
     void ReleaseDC(HDC hdc);

--- a/jp2_pc/Source/Trespass/uidlgs.h
+++ b/jp2_pc/Source/Trespass/uidlgs.h
@@ -33,12 +33,12 @@ public:
     CUIDlg(CUIManager * puimgr);
     virtual ~CUIDlg();
 
-    virtual void InnerLoopCall() 
+    virtual void InnerLoopCall() override
     { 
         CUIWnd::InnerLoopCall();
     }
 
-    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags)
+    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags) override
     {
         if (!fDown && vk == VK_ESCAPE)
         {
@@ -50,10 +50,10 @@ public:
         }
     }
 
-    BOOL UIButtonAudioCmd(CUIButton * pbutton, BUTTONCMD bc);
+    BOOL UIButtonAudioCmd(CUIButton * pbutton, BUTTONCMD bc) override;
 
-    BOOL OnCreate();
-    void OnDestroy();
+    BOOL OnCreate() override;
+    void OnDestroy() override;
 
     virtual BOOL AllowEscape() { return m_bKeyStyle & KEYSTYLE_ESCAPE; }
     virtual BOOL AllowEnter() { return m_bKeyStyle & KEYSTYLE_ENTER; }
@@ -69,13 +69,13 @@ public:
     CMainScreenWnd(CUIManager * puimgr);
     virtual ~CMainScreenWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
-    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags);
-    void OnTimer(UINT uiID);
+    void GetWndFile(LPSTR psz, int ic) override;
+    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags) override;
+    void OnTimer(UINT uiID) override;
 
-    void UIButtonUp(CUIButton * pbutton);
+    void UIButtonUp(CUIButton * pbutton) override;
 
 private:
     UINT                m_uiInitial;
@@ -96,10 +96,10 @@ public:
     void DestroyUIWnd();
     void InnerWindowLoop(bool bPaint);
 
-    BOOL OnCreate();
-    void OnTimer(UINT uiID);
+    BOOL OnCreate() override;
+    void OnTimer(UINT uiID) override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
     DWORD   HandleNotify(DWORD dwParam1, DWORD dwParam2, DWORD dwParam3);
 
@@ -130,13 +130,13 @@ public:
     CDirectLoadWnd(CUIManager * puimgr);
     virtual ~CDirectLoadWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
-    void UIListboxClick(CUICtrl * pctrl, int iIndex);
-    void UIListboxDblClk(CUICtrl * pctrl, int iIndex);
+    void UIButtonUp(CUIButton * pbutton) override;
+    void UIListboxClick(CUICtrl * pctrl, int iIndex) override;
+    void UIListboxDblClk(CUICtrl * pctrl, int iIndex) override;
 };
 
 
@@ -146,11 +146,11 @@ public:
     CNewGameWnd(CUIManager * puimgr);
     virtual ~CNewGameWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
+    void UIButtonUp(CUIButton * pbutton) override;
 };
 
 
@@ -160,18 +160,18 @@ public:
     CGameWnd(CUIManager * puimgr);
     virtual ~CGameWnd();
 
-    BOOL OnCreate();
-    void OnDestroy();
+    BOOL OnCreate() override;
+    void OnDestroy() override;
 
-    void GetWndFile(LPSTR psz, int ic);
-    void OnKey(UINT vk, BOOL fDown, int cRepet, UINT flags);
-    void OnChar(TCHAR ch, int cRepeat);
-    BOOL OnEraseBkgnd(HWND hwnd, HDC hdc);
-    void DrawWndInfo(CRaster * pRaster, RECT * prc);
-    void ResizeScreen(int iWidth, int iHeight);
-    void InnerLoopCall();
+    void GetWndFile(LPSTR psz, int ic) override;
+    void OnKey(UINT vk, BOOL fDown, int cRepet, UINT flags) override;
+    void OnChar(TCHAR ch, int cRepeat) override;
+    BOOL OnEraseBkgnd(HWND hwnd, HDC hdc) override;
+    void DrawWndInfo(CRaster * pRaster, RECT * prc) override;
+    void ResizeScreen(int iWidth, int iHeight) override;
+    void InnerLoopCall() override;
 
-    void UIEditboxKey(CUICtrl * pctrl, UINT vk, int cRepeat, UINT flags);
+    void UIEditboxKey(CUICtrl * pctrl, UINT vk, int cRepeat, UINT flags) override;
 
     void SetupGameStoppage();
     void ClearGameStoppage(BOOL bStartSim);
@@ -189,11 +189,11 @@ public:
     CQuitWnd(CUIManager * puimgr);
     virtual ~CQuitWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
+    void UIButtonUp(CUIButton * pbutton) override;
 };
 
 class COptionsWnd : public CUIDlg
@@ -202,11 +202,11 @@ public:
     COptionsWnd(CUIManager * puimgr);
     virtual ~COptionsWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
+    void UIButtonUp(CUIButton * pbutton) override;
 };
 
 class CInGameOptionsWnd : public CUIDlg
@@ -215,11 +215,11 @@ public:
     CInGameOptionsWnd(CUIManager * puimgr);
     virtual ~CInGameOptionsWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
+    void UIButtonUp(CUIButton * pbutton) override;
 };
 
 
@@ -229,13 +229,13 @@ public:
     CAudioWnd(CUIManager * puimgr);
     virtual ~CAudioWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
-    void UISliderChange(CUISlider * pctrl, int iNewValue);
-    void UIHotspotClick(CUIHotspot * pctrl, BOOL bDown);
+    void UIButtonUp(CUIButton * pbutton) override;
+    void UISliderChange(CUISlider * pctrl, int iNewValue) override;
+    void UIHotspotClick(CUIHotspot * pctrl, BOOL bDown) override;
 
     void OnOk();
     void OnCancel();
@@ -267,13 +267,13 @@ public:
     CLoadGameWnd(CUIManager * puimgr);
     virtual ~CLoadGameWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
-    void UIListboxClick(CUICtrl * pctrl, int iIndex);
-    void UIListboxDblClk(CUICtrl * pctrl, int iIndex);
+    void UIButtonUp(CUIButton * pbutton) override;
+    void UIListboxClick(CUICtrl * pctrl, int iIndex) override;
+    void UIListboxDblClk(CUICtrl * pctrl, int iIndex) override;
 
     void UpdateButtons();
     void ActualLoad();
@@ -289,17 +289,17 @@ public:
     CSaveGameWnd(CUIManager * puimgr);
     virtual ~CSaveGameWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
-    void UIEditboxKey(CUICtrl * pctrl, UINT vk, int cRepeat, UINT flags);
-    void UIEditboxMaxText(CUICtrl * pctrl);
-    void UIListboxClick(CUICtrl * pctrl, int iIndex);
+    void UIButtonUp(CUIButton * pbutton) override;
+    void UIEditboxKey(CUICtrl * pctrl, UINT vk, int cRepeat, UINT flags) override;
+    void UIEditboxMaxText(CUICtrl * pctrl) override;
+    void UIListboxClick(CUICtrl * pctrl, int iIndex) override;
 
-    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags);
-    void OnChar(TCHAR ch, int cRepeat);
+    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags) override;
+    void OnChar(TCHAR ch, int cRepeat) override;
 
     void UpdateButtons(BOOL bIgnoreText = FALSE);
     void ActualSave();
@@ -316,11 +316,11 @@ public:
     CRenderWnd(CUIManager * puimgr);
     virtual ~CRenderWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
+    void UIButtonUp(CUIButton * pbutton) override;
 
     void OnOk();
     void Persist();
@@ -370,11 +370,11 @@ public:
     CHintWnd(CUIManager * puimgr);
     virtual ~CHintWnd();
 
-    BOOL OnCreate();
+    BOOL OnCreate() override;
 
-    void GetWndFile(LPSTR psz, int ic);
+    void GetWndFile(LPSTR psz, int ic) override;
 
-    void UIButtonUp(CUIButton * pbutton);
+    void UIButtonUp(CUIButton * pbutton) override;
 };
 
 
@@ -389,8 +389,8 @@ public:
     CMsgDlg(CUIManager * puimgr);
     virtual ~CMsgDlg();
 
-    BOOL OnCreate();
-    void UIButtonUp(CUIButton * pbutton);
+    BOOL OnCreate() override;
+    void UIButtonUp(CUIButton * pbutton) override;
 
     virtual int JustStatement() { return -1;}
     virtual BOOL GetText(LPSTR pszText, int icLen) { return FALSE; }
@@ -406,12 +406,12 @@ public:
     CYesNo(CUIManager * puimgr) : CMsgDlg(puimgr) { m_bKeyStyle = KEYSTYLE_ESCAPE;}
     virtual ~CYesNo() {;}
 
-    void GetWndFile(LPSTR psz, int ic)
+    void GetWndFile(LPSTR psz, int ic) override
     {
         strcpy(psz, "yesno.ddf");
     }
 
-    virtual BOOL GetText(LPSTR pszText, int icLen) 
+    virtual BOOL GetText(LPSTR pszText, int icLen) override
     { 
         return FALSE; 
     }
@@ -426,7 +426,7 @@ public:
         m_iMsgId = iMsgId;
     }
     
-    int JustStatement() { return m_iMsgId;}
+    int JustStatement() override { return m_iMsgId;}
 
 private:
     int     m_iMsgId;
@@ -441,7 +441,7 @@ public:
         m_pszMsg = pszMsg;
     }
 
-    virtual BOOL GetText(LPSTR pszText, int icLen)
+    virtual BOOL GetText(LPSTR pszText, int icLen) override
     {
         if (!m_pszMsg || (int)strlen(m_pszMsg) + 1 > icLen)
         {
@@ -464,12 +464,12 @@ public:
     COKDlg(CUIManager * puimgr) : CMsgDlg(puimgr) { m_bKeyStyle = KEYSTYLE_ESCAPE;}
     virtual ~COKDlg() {;}
 
-    void GetWndFile(LPSTR psz, int ic)
+    void GetWndFile(LPSTR psz, int ic) override
     {
         strcpy(psz, "okdlg.ddf");
     }
 
-    virtual BOOL GetText(LPSTR pszText, int icLen) { return FALSE; }
+    virtual BOOL GetText(LPSTR pszText, int icLen) override { return FALSE; }
 };
 
 
@@ -482,7 +482,7 @@ public:
         m_pszMsg = pszMsg;
     }
 
-    virtual BOOL GetText(LPSTR pszText, int icLen)
+    virtual BOOL GetText(LPSTR pszText, int icLen) override
     {
         if (!m_pszMsg || (int)strlen(m_pszMsg) + 1 > icLen)
         {
@@ -508,7 +508,7 @@ public:
         m_iMsgId = iMsgId;
     }
     
-    int JustStatement() { return m_iMsgId;}
+    int JustStatement() override { return m_iMsgId;}
 
 private:
     int     m_iMsgId;

--- a/jp2_pc/Source/Trespass/uiwnd.h
+++ b/jp2_pc/Source/Trespass/uiwnd.h
@@ -105,10 +105,10 @@ public:
 
     virtual BOOL AddToUICtrlSet(CUICtrl * pctrl);
     virtual CUICtrl * GetUICtrl(DWORD dwID);
-    virtual CUICtrl *   CaptureMouse(CUICtrl * pctrl);
-    virtual void        ReleaseMouse(CUICtrl * pctrl);
+    virtual CUICtrl *   CaptureMouse(CUICtrl * pctrl) override;
+    virtual void        ReleaseMouse(CUICtrl * pctrl) override;
     virtual void InvalidateRect(RECT * prc);
-    virtual void CtrlInvalidateRect(RECT * prc) { InvalidateRect(prc); }
+    virtual void CtrlInvalidateRect(RECT * prc) override { InvalidateRect(prc); }
     virtual void DoUIHandling();
 
     virtual void DrawWndInfo(LPBYTE pbDst,

--- a/jp2_pc/Source/Trespass/video.h
+++ b/jp2_pc/Source/Trespass/video.h
@@ -42,7 +42,7 @@ public:
     virtual ~CVideoWnd();
 
     BOOL Play(LPCSTR pszFile);
-    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags);
+    void OnKey(UINT vk, BOOL fDown, int cRepeat, UINT flags) override;
 
     BOOL AllowEscape() { return FALSE; }
     void UpdatePalette();

--- a/jp2_pc/Source/TrespassAdv/DialogName.hpp
+++ b/jp2_pc/Source/TrespassAdv/DialogName.hpp
@@ -21,7 +21,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CDialogName)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -32,7 +32,7 @@ protected:
 	// Generated message map functions
 	//{{AFX_MSG(CDialogName)
 	afx_msg void OnShowWindow(BOOL bShow, UINT nStatus);
-	virtual void OnOK();
+	virtual void OnOK() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/jp2_pc/Source/TrespassAdv/TrespassAdv.h
+++ b/jp2_pc/Source/TrespassAdv/TrespassAdv.h
@@ -21,7 +21,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CTrespassAdvApp)
 	public:
-	virtual BOOL InitInstance();
+	virtual BOOL InitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/TrespassAdv/TrespassAdvDlg.cpp
+++ b/jp2_pc/Source/TrespassAdv/TrespassAdvDlg.cpp
@@ -70,13 +70,13 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
 protected:
 	//{{AFX_MSG(CAboutDlg)
-	virtual void OnOK();
+	virtual void OnOK() override;
 	//}}AFX_MSG
 	DECLARE_MESSAGE_MAP()
 };

--- a/jp2_pc/Source/TrespassAdv/TrespassAdvDlg.h
+++ b/jp2_pc/Source/TrespassAdv/TrespassAdvDlg.h
@@ -34,7 +34,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CTrespassAdvDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -52,12 +52,12 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CTrespassAdvDlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();
 	afx_msg void OnButtonAddCard();
-	virtual void OnOK();
+	virtual void OnOK() override;
 	afx_msg void OnDblclkListCards();
 	afx_msg void OnCheckAlphaColour();
 	afx_msg void OnCheckAlphaTextures();

--- a/jp2_pc/Source/TweakNVidia128/TweakNVidia128.h
+++ b/jp2_pc/Source/TweakNVidia128/TweakNVidia128.h
@@ -28,7 +28,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CTweakNVidia128App)
 	public:
-	virtual BOOL InitInstance();
+	virtual BOOL InitInstance() override;
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/TweakNVidia128/TweakNVidia128Dlg.cpp
+++ b/jp2_pc/Source/TweakNVidia128/TweakNVidia128Dlg.cpp
@@ -49,7 +49,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CAboutDlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);    // DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;    // DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation

--- a/jp2_pc/Source/TweakNVidia128/TweakNVidia128Dlg.h
+++ b/jp2_pc/Source/TweakNVidia128/TweakNVidia128Dlg.h
@@ -26,7 +26,7 @@ public:
 	// ClassWizard generated virtual function overrides
 	//{{AFX_VIRTUAL(CTweakNVidia128Dlg)
 	protected:
-	virtual void DoDataExchange(CDataExchange* pDX);	// DDX/DDV support
+	virtual void DoDataExchange(CDataExchange* pDX) override;	// DDX/DDV support
 	//}}AFX_VIRTUAL
 
 // Implementation
@@ -35,7 +35,7 @@ protected:
 
 	// Generated message map functions
 	//{{AFX_MSG(CTweakNVidia128Dlg)
-	virtual BOOL OnInitDialog();
+	virtual BOOL OnInitDialog() override;
 	afx_msg void OnSysCommand(UINT nID, LPARAM lParam);
 	afx_msg void OnPaint();
 	afx_msg HCURSOR OnQueryDragIcon();


### PR DESCRIPTION
The `override` specifier is added to declarations of virtual functions which override another function in a parent class.
Note that the `virtual` keyword is optional for the overriding function.

The function declarations were selected by Resharper/Clang-Tidy.