### PR TITLE
Undefined behavior with delete operator

### DIFF
--- a/jp2_pc/Source/Lib/EntityDBase/TextOverlay.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/TextOverlay.cpp
@@ -242,7 +242,7 @@ void CTextOverlay::Process
 					(*i).ptelNext->u4Flags &=~TEXT_FORMAT_IGNORE;		// make visible
 					(*i).ptelNext->sRemove+=CMessageStep::sElapsedRealTime;	// set the remove time
 				}
-				delete (void*) ((*i).strString);		// delete the memory as a naked pointer
+				delete ((*i).strString);		// delete the memory as a naked pointer
 				ttlTextItems.erase(i);
 				break;
 			}
@@ -346,7 +346,7 @@ void CTextOverlay::RemoveAll
 	for (TTextList::iterator i = ttlTextItems.begin(); i != ttlTextItems.end(); ++i)
 	{
 		// delete the memory as a naked pointer
-		delete (void*) ((*i).strString);
+		delete ((*i).strString);
 	}
 
 	// erase the actual items items in the list

--- a/jp2_pc/Source/Lib/EntityDBase/TextOverlay.cpp
+++ b/jp2_pc/Source/Lib/EntityDBase/TextOverlay.cpp
@@ -242,7 +242,7 @@ void CTextOverlay::Process
 					(*i).ptelNext->u4Flags &=~TEXT_FORMAT_IGNORE;		// make visible
 					(*i).ptelNext->sRemove+=CMessageStep::sElapsedRealTime;	// set the remove time
 				}
-				delete ((*i).strString);		// delete the memory as a naked pointer
+				delete [] ((*i).strString);		// delete the memory as a naked pointer
 				ttlTextItems.erase(i);
 				break;
 			}
@@ -346,7 +346,7 @@ void CTextOverlay::RemoveAll
 	for (TTextList::iterator i = ttlTextItems.begin(); i != ttlTextItems.end(); ++i)
 	{
 		// delete the memory as a naked pointer
-		delete ((*i).strString);
+		delete [] ((*i).strString);
 	}
 
 	// erase the actual items items in the list

--- a/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeBase.hpp
+++ b/jp2_pc/Source/Lib/GeomDBase/WaveletQuadTreeBase.hpp
@@ -721,24 +721,6 @@ namespace NMultiResolution
 		//		This function does not clear the console before printing.
 		//
 		//**************************************
-
-
-		//******************************************************************************************
-		//
-		// Overloaded operators.
-		//
-
-		//******************************************************************************************
-		void* operator new(size_t i_size)
-		{
-			return ::operator new(i_size);
-		}
-
-		//******************************************************************************************
-		void operator delete(void* pv)
-		{
-			::delete pv;
-		}
 	};
 };
 

--- a/jp2_pc/Source/Lib/Groff/EasyString.cpp
+++ b/jp2_pc/Source/Lib/Groff/EasyString.cpp
@@ -115,7 +115,7 @@ inline void CEasyString::SetupStorage
 	const char* str_string2
 )
 {
-	void* heap_storage;
+	char* heap_storage;
 
 	//
 	// Start out by determining how much memory the user requires.

--- a/jp2_pc/Source/Lib/Sys/Symtab.cpp
+++ b/jp2_pc/Source/Lib/Sys/Symtab.cpp
@@ -525,7 +525,7 @@ bool CSymTab::bData(void** symtab, uint* u_size)
 	if (pstHead == 0)
 	{
 		// No! Allocate a small node with a zero in it, to represent 0 symbols.
-		SymtabImage = (void *) new char[4];
+		SymtabImage = new char[4];
 
 		// Were we successful?
 		if (SymtabImage == 0)
@@ -587,7 +587,7 @@ bool CSymTab::bData(void** symtab, uint* u_size)
 
 		// Attempt to allocate the memory for the symbol table image.
 		uSymtabImageSize = u_symtab_image_size;
-		SymtabImage = (void *) new char[uSymtabImageSize];
+		SymtabImage = new char[uSymtabImageSize];
 
 		// Were we successful?
 		if (SymtabImage == 0)

--- a/jp2_pc/Source/Lib/Sys/Symtab.hpp
+++ b/jp2_pc/Source/Lib/Sys/Symtab.hpp
@@ -63,7 +63,7 @@ class CSymTab
 {
 private:
 	uint			uSymtabImageSize;						// Size of the internal table image.
-	void*			SymtabImage;							// Internal representation of the symbol table.
+	char*			SymtabImage;							// Internal representation of the symbol table.
 
 	SSymtab*		pstHead;								// Pointer to the front of the list.
 

--- a/jp2_pc/Source/Lib/View/Raster.cpp
+++ b/jp2_pc/Source/Lib/View/Raster.cpp
@@ -772,7 +772,7 @@
 			switch (emtHeapType)
 			{
 			case emtNormal:
-				delete[] pSurface;
+				delete[] static_cast<uint8*>(pSurface);
 				break;
 
 			case emtFixed:


### PR DESCRIPTION
Some undefined behavior surrounding the usage of the ``delete`` operator is resolved. That includes using ``delete`` on a ``void`` pointer and using ``delete`` where ``delete[]`` should be used.

There are more problematic spots, but those are not as easy and straightforward to fix, especially because they involve custom overloads of the ``new`` and ``delete`` operators.