### PR TITLE
Preselect active driver in driver menu

### DIFF
--- a/jp2_pc/Source/Trespass/DDDevice.cpp
+++ b/jp2_pc/Source/Trespass/DDDevice.cpp
@@ -771,6 +771,14 @@ void CEnumerateDevices::WriteSelectedDeviceToRegistry()
 	SetZBufferBitdepth(dev.d3dDevice.iZBufferBitDepth);
 }
 
+void CEnumerateDevices::LoadSelectedDeviceFromRegistry()
+{
+	char str_title[2048] = { '\0' };
+	GetRegString(strD3D_TITLE, str_title, sizeof(str_title), "");
+
+	SelectDevice(str_title);
+}
+
 
 //
 // Global variables.

--- a/jp2_pc/Source/Trespass/DDDevice.hpp
+++ b/jp2_pc/Source/Trespass/DDDevice.hpp
@@ -150,8 +150,10 @@ public:
 		return Devices[iSelectedDevice];
 	}
 
+	void LoadSelectedDeviceFromRegistry();
 	void WriteSelectedDeviceToRegistry();
 
+	int GetSelectedDeviceIndex() const { return iSelectedDevice; }
 	void SelectDevice(char* str);
 
 	void GetTitle(int i, char* str) const;

--- a/jp2_pc/Source/Trespass/dlgrender.cpp
+++ b/jp2_pc/Source/Trespass/dlgrender.cpp
@@ -273,6 +273,11 @@ void CConfigureWnd::InitializeCardSelection()
 		penumdevDevices->GetTitle(i, str);
 		ListBox_AddString(m_hwndList, str);
 	}
+	
+	penumdevDevices->LoadSelectedDeviceFromRegistry();
+	int selectedDevice = penumdevDevices->GetSelectedDeviceIndex();
+	if (selectedDevice >= 0 && selectedDevice < iMaxDevices)
+	    penumdevDevices->GetTitle(penumdevDevices->GetSelectedDeviceIndex(), str);
 
 	// Attempt to select a string.
 	ListBox_SelectString(m_hwndList, 0, str);


### PR DESCRIPTION
This change preselects the currently configured driver when opening the video driver menu. Previously the preselection was always the last list entry, i.e. the software renderer.